### PR TITLE
Fixed password issue with spaces in front/back

### DIFF
--- a/lib/account/pages/login_page.dart
+++ b/lib/account/pages/login_page.dart
@@ -145,8 +145,8 @@ class _LoginPageState extends State<LoginPage> {
                         // Perform login authentication
                         context.read<AuthBloc>().add(
                               LoginAttempt(
-                                username: _usernameTextEditingController.text.trim(),
-                                password: _passwordTextEditingController.text.trim(),
+                                username: _usernameTextEditingController.text,
+                                password: _passwordTextEditingController.text,
                                 instance: _instanceTextEditingController.text.trim(),
                               ),
                             );


### PR DESCRIPTION
Might be related #52 to instances accept passwords with leading spaces, so there can be an issue at one point. Other than that no real changes .