### PR TITLE
Changed default sort of search page

### DIFF
--- a/lib/search/bloc/search_bloc.dart
+++ b/lib/search/bloc/search_bloc.dart
@@ -58,6 +58,7 @@ class SearchBloc extends Bloc<SearchEvent, SearchState> {
           q: event.query,
           page: 1,
           limit: 15,
+          sort: SortType.Active,
         ),
       );
 
@@ -96,6 +97,7 @@ class SearchBloc extends Bloc<SearchEvent, SearchState> {
               q: event.query,
               page: state.page,
               limit: 15,
+              sort: SortType.Active,
             ),
           );
 


### PR DESCRIPTION
Related issue: https://github.com/hjiangsu/thunder/issues/63

The default sort for the communities in the "Search" page looks to be "Hot", which didn't seem to give very relevant issue and often required me to scroll quite a bit to find the community I was looking for.

I chose `SortType.Active` as the new default sort over others like `SortType.TopAll` to avoid suggesting inactive communities, but that's pretty subjective 🤷.

Here's a comparison of the different sorts when searching "technologies":
<table>
<tr>
 <th width="33%">Default (current)
 <th width="33%">`SortType.Active`
 <th width="33%">`SortType.TopAll`
<tr>
 <td>

![image](https://github.com/hjiangsu/thunder/assets/6548393/cebe2aa2-79a3-4ed8-a3a8-edb2a795fb91)
 <td>

![image](https://github.com/hjiangsu/thunder/assets/6548393/d8d6643d-323a-4d21-b7e5-3f2cc0fe1cea)

 <td>

![image](https://github.com/hjiangsu/thunder/assets/6548393/72261836-c3f0-434d-8049-356076a21c55)
</table>