### PR TITLE
Fix cleartext not permitted error on Android

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -3,6 +3,7 @@
     <application
         android:label="thunder"
         android:name="${applicationName}"
+        android:usesCleartextTraffic="true"
         android:icon="@mipmap/launcher_icon">
         <activity
             android:name=".MainActivity"


### PR DESCRIPTION
I was getting `net::ERR_CLEARTEXT_NOT_PERMITTED` error when opening few links ([example](https://www.businessinsider.in/international/news/ukraine-managed-to-gain-ground-in-ukraine-as-russia-faced-off-against-russia-in-russia/articleshow/101246479.cms)) on the app, This fixes the error on android.