### PR TITLE
Fix/Workaround + Feature

### DIFF
--- a/lib/account/widgets/account_header.dart
+++ b/lib/account/widgets/account_header.dart
@@ -1,4 +1,7 @@
+import 'dart:ffi';
+
 import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
 
 import 'package:intl/intl.dart';
 import 'package:cached_network_image/cached_network_image.dart';
@@ -8,7 +11,10 @@ import 'package:lemmy_api_client/v3.dart';
 import 'package:thunder/shared/icon_text.dart';
 import 'package:thunder/utils/instance.dart';
 
+import 'package:thunder/thunder/bloc/thunder_bloc.dart';
+
 class AccountHeader extends StatelessWidget {
+
   final PersonViewSafe? accountInfo;
 
   const AccountHeader({super.key, this.accountInfo});
@@ -19,6 +25,9 @@ class AccountHeader extends StatelessWidget {
 
     final DateFormat formatter = DateFormat('yyyy-MM-dd');
     final String formatted = formatter.format(accountInfo!.person.published);
+
+    final bool profileSettings = context.read<ThunderBloc>().state.preferences?.getBool('setting_general_hide_profile_score') ?? true;
+    final totalScore = accountInfo!.counts.commentScore + accountInfo!.counts.postScore;
 
     return Padding(
       padding: const EdgeInsets.only(top: 8.0, left: 24.0, right: 24.0, bottom: 24.0),
@@ -57,6 +66,26 @@ class AccountHeader extends StatelessWidget {
                         text: (accountInfo?.person.published != null) ? '${formatted}' : '-',
                       ),
                     ],
+                  ),
+                  Row(
+                    children: [
+                    if (profileSettings == false)(
+                      IconText(
+                          icon: const Icon(
+                            Icons.arrow_upward_rounded,
+                            size: 16,
+                          ),
+                          text: '${(accountInfo?.counts.postScore).toString()} · ${(accountInfo?.counts.commentScore).toString()} · ${(totalScore).toString()}')
+                  )else if (profileSettings == true)(
+                        IconText(
+                          icon: const Icon(
+                            Icons.note_rounded,
+                            size:16,
+                          ),
+                          text: '${(accountInfo?.counts.postCount).toString()} · ${(accountInfo?.counts.commentCount)}'
+                        )
+                      )
+                    ]
                   ),
                 ],
               ),

--- a/lib/account/widgets/account_header.dart
+++ b/lib/account/widgets/account_header.dart
@@ -11,8 +11,6 @@ import 'package:lemmy_api_client/v3.dart';
 import 'package:thunder/shared/icon_text.dart';
 import 'package:thunder/utils/instance.dart';
 
-import 'package:thunder/thunder/bloc/thunder_bloc.dart';
-
 class AccountHeader extends StatelessWidget {
 
   final PersonViewSafe? accountInfo;
@@ -25,9 +23,6 @@ class AccountHeader extends StatelessWidget {
 
     final DateFormat formatter = DateFormat('yyyy-MM-dd');
     final String formatted = formatter.format(accountInfo!.person.published);
-
-    final bool profileSettings = context.read<ThunderBloc>().state.preferences?.getBool('setting_general_hide_profile_score') ?? true;
-    final totalScore = accountInfo!.counts.commentScore + accountInfo!.counts.postScore;
 
     return Padding(
       padding: const EdgeInsets.only(top: 8.0, left: 24.0, right: 24.0, bottom: 24.0),
@@ -46,7 +41,7 @@ class AccountHeader extends StatelessWidget {
               Column(
                 crossAxisAlignment: CrossAxisAlignment.start,
                 mainAxisSize: MainAxisSize.min,
-                children: [
+                children: <Widget>[
                   Text(
                     accountInfo?.person.displayName ?? accountInfo!.person.name,
                     style: theme.textTheme.headlineSmall?.copyWith(fontWeight: FontWeight.w600),
@@ -66,26 +61,6 @@ class AccountHeader extends StatelessWidget {
                         text: (accountInfo?.person.published != null) ? '${formatted}' : '-',
                       ),
                     ],
-                  ),
-                  Row(
-                    children: [
-                    if (profileSettings == false)(
-                      IconText(
-                          icon: const Icon(
-                            Icons.arrow_upward_rounded,
-                            size: 16,
-                          ),
-                          text: '${(accountInfo?.counts.postScore).toString()} · ${(accountInfo?.counts.commentScore).toString()} · ${(totalScore).toString()}')
-                  )else if (profileSettings == true)(
-                        IconText(
-                          icon: const Icon(
-                            Icons.note_rounded,
-                            size:16,
-                          ),
-                          text: '${(accountInfo?.counts.postCount).toString()} · ${(accountInfo?.counts.commentCount)}'
-                        )
-                      )
-                    ]
                   ),
                 ],
               ),

--- a/lib/account/widgets/account_header.dart
+++ b/lib/account/widgets/account_header.dart
@@ -1,7 +1,4 @@
-import 'dart:ffi';
-
 import 'package:flutter/material.dart';
-import 'package:flutter_bloc/flutter_bloc.dart';
 
 import 'package:intl/intl.dart';
 import 'package:cached_network_image/cached_network_image.dart';
@@ -12,7 +9,6 @@ import 'package:thunder/shared/icon_text.dart';
 import 'package:thunder/utils/instance.dart';
 
 class AccountHeader extends StatelessWidget {
-
   final PersonViewSafe? accountInfo;
 
   const AccountHeader({super.key, this.accountInfo});
@@ -41,7 +37,7 @@ class AccountHeader extends StatelessWidget {
               Column(
                 crossAxisAlignment: CrossAxisAlignment.start,
                 mainAxisSize: MainAxisSize.min,
-                children: <Widget>[
+                children: [
                   Text(
                     accountInfo?.person.displayName ?? accountInfo!.person.name,
                     style: theme.textTheme.headlineSmall?.copyWith(fontWeight: FontWeight.w600),

--- a/lib/settings/pages/general_settings_page.dart
+++ b/lib/settings/pages/general_settings_page.dart
@@ -34,6 +34,9 @@ class _GeneralSettingsPageState extends State<GeneralSettingsPage> {
   bool showSaveAction = true;
   bool showFullHeightImages = false;
   bool hideNsfwPreviews = true;
+  bool hideProfileScore = true;
+  bool swipeGestures = true;
+  bool doubleTapGestures = false;
 
   // Link Settings
   bool openInExternalBrowser = false;
@@ -98,6 +101,18 @@ class _GeneralSettingsPageState extends State<GeneralSettingsPage> {
         await prefs.setBool('setting_general_hide_nsfw_previews', value);
         setState(() => hideNsfwPreviews = value);
         break;
+      case 'setting_general_hide_profile_score':
+        await prefs.setBool('setting_general_hide_profile_score', value);
+        setState(() => hideProfileScore = value);
+        break;
+      case 'setting_general_enable_swipe_gestures':
+        await prefs.setBool('setting_general_enable_swipe_gestures', value);
+        setState(() => swipeGestures = value);
+        break;
+      case 'setting_general_enable_doubletap_gestures':
+        await prefs.setBool('setting_general_enable_doubletap_gestures', value);
+        setState(() => doubleTapGestures = value);
+        break;
       case 'setting_instance_default_instance':
         await prefs.setString('setting_instance_default_instance', value);
         setState(() => defaultInstance = value);
@@ -159,6 +174,8 @@ class _GeneralSettingsPageState extends State<GeneralSettingsPage> {
       showSaveAction = prefs.getBool('setting_general_show_save_action') ?? true;
       showFullHeightImages = prefs.getBool('setting_general_show_full_height_images') ?? false;
       hideNsfwPreviews = prefs.getBool('setting_general_hide_nsfw_previews') ?? true;
+      hideProfileScore = prefs.getBool('setting_general_hide_profile_score') ?? true;
+      doubleTapGestures = prefs.getBool('setting_general_enable_doubletap_gestures') ?? false;
 
       // Links
       openInExternalBrowser = prefs.getBool('setting_links_open_in_external_browser') ?? false;
@@ -301,6 +318,30 @@ class _GeneralSettingsPageState extends State<GeneralSettingsPage> {
                           iconEnabled: Icons.no_adult_content,
                           iconDisabled: Icons.no_adult_content,
                           onToggle: (bool value) => setPreferences('setting_general_hide_nsfw_previews', value),
+                        ),
+                        ToggleOption(
+                          description: 'Hide Profile Scores',
+                          subtitle: 'Only visible to you',
+                          value: hideProfileScore,
+                          iconEnabled: Icons.arrow_upward_rounded,
+                          iconDisabled: Icons.arrow_upward_rounded,
+                          onToggle: (bool value) => setPreferences('setting_general_hide_profile_score', value),
+                        ),
+                        ToggleOption(
+                          description: 'Enable Swipe Gestures',
+                          subtitle: 'Swipe on nav bar',
+                          value: swipeGestures,
+                          iconEnabled: Icons.swipe_right_rounded,
+                          iconDisabled: Icons.swipe_right_rounded,
+                          onToggle: (bool value) => setPreferences('setting_general_enable_swipe_gestures', value),
+                        ),
+                        ToggleOption(
+                          description: 'Enable Double-Tap Gestures',
+                          subtitle: 'Double-tap on nav bar',
+                          value: doubleTapGestures,
+                          iconEnabled: Icons.touch_app_rounded,
+                          iconDisabled: Icons.touch_app_rounded,
+                          onToggle: (bool value) => setPreferences('setting_general_enable_doubletap_gestures', value),
                         ),
                       ],
                     ),

--- a/lib/settings/pages/general_settings_page.dart
+++ b/lib/settings/pages/general_settings_page.dart
@@ -34,7 +34,6 @@ class _GeneralSettingsPageState extends State<GeneralSettingsPage> {
   bool showSaveAction = true;
   bool showFullHeightImages = false;
   bool hideNsfwPreviews = true;
-  bool hideProfileScore = true;
   bool swipeGestures = true;
   bool doubleTapGestures = false;
 
@@ -100,10 +99,6 @@ class _GeneralSettingsPageState extends State<GeneralSettingsPage> {
       case 'setting_general_hide_nsfw_previews':
         await prefs.setBool('setting_general_hide_nsfw_previews', value);
         setState(() => hideNsfwPreviews = value);
-        break;
-      case 'setting_general_hide_profile_score':
-        await prefs.setBool('setting_general_hide_profile_score', value);
-        setState(() => hideProfileScore = value);
         break;
       case 'setting_general_enable_swipe_gestures':
         await prefs.setBool('setting_general_enable_swipe_gestures', value);
@@ -174,7 +169,7 @@ class _GeneralSettingsPageState extends State<GeneralSettingsPage> {
       showSaveAction = prefs.getBool('setting_general_show_save_action') ?? true;
       showFullHeightImages = prefs.getBool('setting_general_show_full_height_images') ?? false;
       hideNsfwPreviews = prefs.getBool('setting_general_hide_nsfw_previews') ?? true;
-      hideProfileScore = prefs.getBool('setting_general_hide_profile_score') ?? true;
+      swipeGestures = prefs.getBool('setting_general_enable_swipe_gestures') ?? true;
       doubleTapGestures = prefs.getBool('setting_general_enable_doubletap_gestures') ?? false;
 
       // Links
@@ -318,14 +313,6 @@ class _GeneralSettingsPageState extends State<GeneralSettingsPage> {
                           iconEnabled: Icons.no_adult_content,
                           iconDisabled: Icons.no_adult_content,
                           onToggle: (bool value) => setPreferences('setting_general_hide_nsfw_previews', value),
-                        ),
-                        ToggleOption(
-                          description: 'Hide Profile Scores',
-                          subtitle: 'Only visible to you',
-                          value: hideProfileScore,
-                          iconEnabled: Icons.arrow_upward_rounded,
-                          iconDisabled: Icons.arrow_upward_rounded,
-                          onToggle: (bool value) => setPreferences('setting_general_hide_profile_score', value),
                         ),
                         ToggleOption(
                           description: 'Enable Swipe Gestures',

--- a/lib/settings/pages/general_settings_page.dart
+++ b/lib/settings/pages/general_settings_page.dart
@@ -34,8 +34,8 @@ class _GeneralSettingsPageState extends State<GeneralSettingsPage> {
   bool showSaveAction = true;
   bool showFullHeightImages = false;
   bool hideNsfwPreviews = true;
-  bool swipeGestures = true;
-  bool doubleTapGestures = false;
+  bool bottomNavBarSwipeGestures = true;
+  bool bottomNavBarDoubleTapGestures = false;
 
   // Link Settings
   bool openInExternalBrowser = false;
@@ -102,11 +102,11 @@ class _GeneralSettingsPageState extends State<GeneralSettingsPage> {
         break;
       case 'setting_general_enable_swipe_gestures':
         await prefs.setBool('setting_general_enable_swipe_gestures', value);
-        setState(() => swipeGestures = value);
+        setState(() => bottomNavBarSwipeGestures = value);
         break;
       case 'setting_general_enable_doubletap_gestures':
         await prefs.setBool('setting_general_enable_doubletap_gestures', value);
-        setState(() => doubleTapGestures = value);
+        setState(() => bottomNavBarDoubleTapGestures = value);
         break;
       case 'setting_instance_default_instance':
         await prefs.setString('setting_instance_default_instance', value);
@@ -169,8 +169,8 @@ class _GeneralSettingsPageState extends State<GeneralSettingsPage> {
       showSaveAction = prefs.getBool('setting_general_show_save_action') ?? true;
       showFullHeightImages = prefs.getBool('setting_general_show_full_height_images') ?? false;
       hideNsfwPreviews = prefs.getBool('setting_general_hide_nsfw_previews') ?? true;
-      swipeGestures = prefs.getBool('setting_general_enable_swipe_gestures') ?? true;
-      doubleTapGestures = prefs.getBool('setting_general_enable_doubletap_gestures') ?? false;
+      bottomNavBarSwipeGestures = prefs.getBool('setting_general_enable_swipe_gestures') ?? true;
+      bottomNavBarDoubleTapGestures = prefs.getBool('setting_general_enable_doubletap_gestures') ?? false;
 
       // Links
       openInExternalBrowser = prefs.getBool('setting_links_open_in_external_browser') ?? false;
@@ -317,7 +317,7 @@ class _GeneralSettingsPageState extends State<GeneralSettingsPage> {
                         ToggleOption(
                           description: 'Enable Swipe Gestures',
                           subtitle: 'Swipe on nav bar',
-                          value: swipeGestures,
+                          value: bottomNavBarSwipeGestures,
                           iconEnabled: Icons.swipe_right_rounded,
                           iconDisabled: Icons.swipe_right_rounded,
                           onToggle: (bool value) => setPreferences('setting_general_enable_swipe_gestures', value),
@@ -325,7 +325,7 @@ class _GeneralSettingsPageState extends State<GeneralSettingsPage> {
                         ToggleOption(
                           description: 'Enable Double-Tap Gestures',
                           subtitle: 'Double-tap on nav bar',
-                          value: doubleTapGestures,
+                          value: bottomNavBarDoubleTapGestures,
                           iconEnabled: Icons.touch_app_rounded,
                           iconDisabled: Icons.touch_app_rounded,
                           onToggle: (bool value) => setPreferences('setting_general_enable_doubletap_gestures', value),

--- a/lib/thunder/pages/thunder_page.dart
+++ b/lib/thunder/pages/thunder_page.dart
@@ -56,9 +56,9 @@ class _ThunderState extends State<Thunder> {
 
   void _handleDragUpdate(DragUpdateDetails details) async {
     final prefs = await SharedPreferences.getInstance();
-    final bool swipeGestures = prefs.getBool('setting_general_enable_swipe_gestures') ?? true;
+    final bool bottomNavBarSwipeGestures = prefs.getBool('setting_general_enable_swipe_gestures') ?? true;
 
-    if(swipeGestures == true){
+    if(bottomNavBarSwipeGestures == true){
       final currentPosition = details.globalPosition.dx;
       final delta = currentPosition - _dragStartX;
       if (delta > 0 && selectedPageIndex == 0) {
@@ -76,11 +76,11 @@ class _ThunderState extends State<Thunder> {
   void _handleDoubleTap() async {
     final bool scaffoldState = _feedScaffoldKey.currentState!.isDrawerOpen;
     final prefs = await SharedPreferences.getInstance();
-    final bool doubleTapGestures = prefs.getBool('setting_general_enable_doubletap_gestures') ?? false;
+    final bool bottomNavBarDoubleTapGestures = prefs.getBool('setting_general_enable_doubletap_gestures') ?? false;
 
-    if (doubleTapGestures == true && scaffoldState == true) {
+    if (bottomNavBarDoubleTapGestures == true && scaffoldState == true) {
       _feedScaffoldKey.currentState?.closeDrawer();
-    } else if (doubleTapGestures == true && scaffoldState == false) {
+    } else if (bottomNavBarDoubleTapGestures == true && scaffoldState == false) {
       _feedScaffoldKey.currentState?.openDrawer();
     }
   }

--- a/lib/thunder/pages/thunder_page.dart
+++ b/lib/thunder/pages/thunder_page.dart
@@ -4,6 +4,8 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_native_splash/flutter_native_splash.dart';
 import 'package:overlay_support/overlay_support.dart';
 
+import 'package:shared_preferences/shared_preferences.dart';
+
 import 'package:thunder/inbox/bloc/inbox_bloc.dart';
 import 'package:thunder/inbox/inbox.dart';
 import 'package:thunder/search/bloc/search_bloc.dart';
@@ -52,18 +54,35 @@ class _ThunderState extends State<Thunder> {
     _dragStartX = details.globalPosition.dx;
   }
 
-  void _handleDragUpdate(DragUpdateDetails details) {
-    final currentPosition = details.globalPosition.dx;
-    final delta = currentPosition - _dragStartX;
-    if (delta > 0 && selectedPageIndex == 0) {
-      _feedScaffoldKey.currentState?.openDrawer();
-    } else if (delta < 0 && selectedPageIndex == 0) {
-      _feedScaffoldKey.currentState?.closeDrawer();
+  void _handleDragUpdate(DragUpdateDetails details) async {
+    final prefs = await SharedPreferences.getInstance();
+    final bool swipeGestures = prefs.getBool('setting_general_enable_swipe_gestures') ?? true;
+
+    if(swipeGestures == true){
+      final currentPosition = details.globalPosition.dx;
+      final delta = currentPosition - _dragStartX;
+      if (delta > 0 && selectedPageIndex == 0) {
+        _feedScaffoldKey.currentState?.openDrawer();
+      } else if (delta < 0 && selectedPageIndex == 0) {
+        _feedScaffoldKey.currentState?.closeDrawer();
+      }
     }
   }
 
   void _handleDragEnd(DragEndDetails details) {
     _dragStartX = 0.0;
+  }
+
+  void _handleDoubleTap() async {
+    final bool scaffoldState = _feedScaffoldKey.currentState!.isDrawerOpen;
+    final prefs = await SharedPreferences.getInstance();
+    final bool doubleTapGestures = prefs.getBool('setting_general_enable_doubletap_gestures') ?? false;
+
+    if (doubleTapGestures == true && scaffoldState == true) {
+      _feedScaffoldKey.currentState?.closeDrawer();
+    } else if (doubleTapGestures == true && scaffoldState == false) {
+      _feedScaffoldKey.currentState?.openDrawer();
+    }
   }
 
   @override
@@ -181,6 +200,7 @@ class _ThunderState extends State<Thunder> {
         onHorizontalDragStart: _handleDragStart,
         onHorizontalDragUpdate: _handleDragUpdate,
         onHorizontalDragEnd: _handleDragEnd,
+        onDoubleTap: _handleDoubleTap,
         child: BottomNavigationBar(
           currentIndex: selectedPageIndex,
           showSelectedLabels: false,

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1016,14 +1016,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.4"
-  web:
-    dependency: transitive
-    description:
-      name: web
-      sha256: dc8ccd225a2005c1be616fe02951e2e342092edf968cf0844220383757ef8f10
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.1.4-beta"
   web_socket_channel:
     dependency: transitive
     description:
@@ -1097,5 +1089,5 @@ packages:
     source: hosted
     version: "3.1.2"
 sdks:
-  dart: ">=3.1.0-185.0.dev <4.0.0"
+  dart: ">=3.1.0-116.0.dev <4.0.0"
   flutter: ">=3.10.0"


### PR DESCRIPTION
Provides workaround for #122 allowing you to toggle the swipe gestures in the general settings page, also adds double tap on nav bar feature to replace it for people like me who still want quick access. In my testing both work seamlessly separate or together.

Additionally, I'm not sure if it was removed on purpose but I really liked the original total post/comments counter from the original alpha. I added that back in to the profile header and added a toggle in the settings to swap post/comments counts to post/comments score. I can remove this if it was removed intentionally.