### PR TITLE
Fix image download button appearance on light mode

### DIFF
--- a/lib/shared/image_viewer.dart
+++ b/lib/shared/image_viewer.dart
@@ -41,16 +41,12 @@ class _ImageViewerState extends State<ImageViewer> {
 
   @override
   Widget build(BuildContext context) {
-    final theme = Theme.of(context);
     return Scaffold(
-      backgroundColor: Colors.black.withOpacity(0.95),
-      body: Stack(
-        children: [
-          Positioned(
-            top: 50,
-            right: 15,
-            child: IconButton(
-              color: theme.textTheme.titleLarge?.color,
+        appBar: AppBar(
+          backgroundColor: Colors.black,
+          foregroundColor: Colors.white,
+          actions: [
+            IconButton(
               onPressed: () async {
                 File file = await DefaultCacheManager().getSingleFile(widget.url);
 
@@ -70,49 +66,49 @@ class _ImageViewerState extends State<ImageViewer> {
               },
               icon: downloaded ? const Icon(Icons.check_circle, semanticLabel: 'Downloaded') : const Icon(Icons.download, semanticLabel: "Download"),
             ),
-          ),
-          Center(
-            child: ExtendedImageSlidePage(
-              key: slidePagekey,
-              slideAxis: SlideAxis.both,
+          ],
+        ),
+        backgroundColor: Colors.black,
+      body: Center(
+        child: ExtendedImageSlidePage(
+          key: slidePagekey,
+          slideAxis: SlideAxis.both,
+          slideType: SlideType.onlyImage,
+          child: GestureDetector(
+            child: HeroWidget(
+              tag: widget.url,
               slideType: SlideType.onlyImage,
-              child: GestureDetector(
-                child: HeroWidget(
-                  tag: widget.url,
-                  slideType: SlideType.onlyImage,
-                  slidePagekey: slidePagekey,
-                  child: ExtendedImage.network(
-                    widget.url,
-                    enableSlideOutPage: true,
-                    mode: ExtendedImageMode.gesture,
-                    cache: true,
-                    clearMemoryCacheWhenDispose: true,
-                    initGestureConfigHandler: (ExtendedImageState state) {
-                      return GestureConfig(
-                        minScale: 0.9,
-                        animationMinScale: 0.7,
-                        maxScale: 4.0,
-                        animationMaxScale: 4.5,
-                        speed: 1.0,
-                        inertialSpeed: 100.0,
-                        initialScale: 1.0,
-                        inPageView: false,
-                        initialAlignment: InitialAlignment.center,
-                        reverseMousePointerScrollDirection: true,
-                        gestureDetailsIsChanged: (GestureDetails? details) {},
-                      );
-                    },
-                  ),
-                ),
-                onTap: () {
-                  slidePagekey.currentState!.popPage();
-                  Navigator.pop(context);
+              slidePagekey: slidePagekey,
+              child: ExtendedImage.network(
+                widget.url,
+                enableSlideOutPage: true,
+                mode: ExtendedImageMode.gesture,
+                cache: true,
+                clearMemoryCacheWhenDispose: true,
+                initGestureConfigHandler: (ExtendedImageState state) {
+                  return GestureConfig(
+                    minScale: 0.9,
+                    animationMinScale: 0.7,
+                    maxScale: 4.0,
+                    animationMaxScale: 4.5,
+                    speed: 1.0,
+                    inertialSpeed: 100.0,
+                    initialScale: 1.0,
+                    inPageView: false,
+                    initialAlignment: InitialAlignment.center,
+                    reverseMousePointerScrollDirection: true,
+                    gestureDetailsIsChanged: (GestureDetails? details) {},
+                  );
                 },
               ),
             ),
-          )
-        ],
-      ),
+            onTap: () {
+              slidePagekey.currentState!.popPage();
+              Navigator.pop(context);
+            },
+          ),
+        ),
+      )
     );
   }
 }


### PR DESCRIPTION
Fixes the image download button being invisible on light mode. Its color was taken from the theme, which made it a dark color on light themes even though the background was set to black. I put the IconButton inside an AppBar. This also makes the status bar visible on Android, fixes the download button sometimes overlapping with the image, and adds a back button. Here is the before and after:

![Screenshot_20230703_234033](https://github.com/hjiangsu/thunder/assets/66788877/168b082a-0975-42ce-ba68-cb697bbb8f45)  ![Screenshot_20230703_234525](https://github.com/hjiangsu/thunder/assets/66788877/aae5e46d-7331-4359-a4a5-ad856e0e9a51)
