### PR TITLE
Added filtering of posts that already exist in view to prevent duplicates

### DIFF
--- a/lib/community/bloc/community_bloc.dart
+++ b/lib/community/bloc/community_bloc.dart
@@ -229,11 +229,17 @@ class CommunityBloc extends Bloc<CommunityEvent, CommunityState> {
             // Parse the posts and add in media information which is used elsewhere in the app
             List<PostViewMedia> formattedPosts = await parsePostViews(posts);
 
+            var postIds = <int>{};
+            for (var post in formattedPosts) {
+              postIds.add(post.postView.post.id);
+            }
+
             return emit(
               state.copyWith(
                 status: CommunityStatus.success,
                 page: 2,
                 postViews: formattedPosts,
+                postIds: postIds,
                 listingType: listingType,
                 communityId: communityId,
                 communityName: event.communityName,
@@ -269,13 +275,25 @@ class CommunityBloc extends Bloc<CommunityEvent, CommunityState> {
             // Parse the posts, and append them to the existing list
             List<PostViewMedia> postMedias = await parsePostViews(posts);
             List<PostViewMedia> postViews = List.from(state.postViews ?? []);
-            postViews.addAll(postMedias);
+            Set<int> postIds = Set.from(state.postIds ?? {});
+
+            // Insure we don't add existing posts to view
+            for (var postMedia in postMedias) {
+              var id = postMedia.postView.post.id;
+              if (postIds.contains(id)) {
+                continue;
+              }
+
+              postIds.add(id);
+              postViews.add(postMedia);
+            }
 
             return emit(
               state.copyWith(
                 status: CommunityStatus.success,
                 page: state.page + 1,
                 postViews: postViews,
+                postIds: postIds,
                 communityId: communityId,
                 communityName: state.communityName,
                 listingType: listingType,

--- a/lib/community/bloc/community_state.dart
+++ b/lib/community/bloc/community_state.dart
@@ -6,6 +6,7 @@ class CommunityState extends Equatable {
   const CommunityState({
     this.status = CommunityStatus.initial,
     this.postViews = const [],
+    this.postIds = const <int>{},
     this.page = 1,
     this.errorMessage,
     this.listingType = PostListingType.local,
@@ -23,6 +24,7 @@ class CommunityState extends Equatable {
 
   final int page;
   final List<PostViewMedia>? postViews;
+  final Set<int>? postIds;
 
   final String? errorMessage;
 
@@ -38,6 +40,7 @@ class CommunityState extends Equatable {
     CommunityStatus? status,
     int? page,
     List<PostViewMedia>? postViews,
+    Set<int>? postIds,
     String? errorMessage,
     PostListingType? listingType,
     int? communityId,
@@ -51,6 +54,7 @@ class CommunityState extends Equatable {
       status: status ?? this.status,
       page: page ?? this.page,
       postViews: postViews ?? this.postViews,
+      postIds: postIds ?? this.postIds,
       errorMessage: errorMessage ?? this.errorMessage,
       listingType: listingType,
       communityId: communityId,


### PR DESCRIPTION
This is accomplished via a `Set<int> postIds` we now maintain along side the `postView` list in `community_state.dart` that we can check against before adding new posts to `postView`.

I'm still learning my way around Dart, Flutter, and this project. So feel free to let me know if I did something dumb :)