### PR TITLE
Title first and edge-to-edge images

### DIFF
--- a/lib/community/widgets/post_card.dart
+++ b/lib/community/widgets/post_card.dart
@@ -105,6 +105,8 @@ class _PostCardState extends State<PostCard> {
 
     final bool isUserLoggedIn = context.read<AuthBloc>().state.isLoggedIn;
     final bool useCompactView = context.read<ThunderBloc>().state.preferences?.getBool('setting_general_use_compact_view') ?? false;
+    final bool showTitleFirst = context.read<ThunderBloc>().state.preferences?.getBool('setting_general_show_title_first') ?? false;
+    final bool edgeToEdgeImages = context.read<ThunderBloc>().state.preferences?.getBool('setting_general_show_edge_to_edge_images') ?? false;
     final bool disableSwipeActionsOnPost = context.read<ThunderBloc>().state.preferences?.getBool('setting_post_disable_swipe_actions') ?? false;
     final bool useDarkTheme = context.read<ThemeBloc>().state.useDarkTheme;
 
@@ -208,6 +210,8 @@ class _PostCardState extends State<PostCard> {
                       hideNsfwPreviews: hideNsfwPreviews,
                       showInstanceName: widget.showInstanceName,
                       showFullHeightImages: showFullHeightImages,
+                      edgeToEdgeImages: edgeToEdgeImages,
+                      showTitleFirst: showTitleFirst,
                       showVoteActions: showVoteActions,
                       showSaveAction: showSaveAction,
                       showTextContent: showTextContent,

--- a/lib/community/widgets/post_card_view_comfortable.dart
+++ b/lib/community/widgets/post_card_view_comfortable.dart
@@ -20,6 +20,8 @@ class PostCardViewComfortable extends StatefulWidget {
   final PostViewMedia postViewMedia;
   final bool showThumbnailPreviewOnRight;
   final bool hideNsfwPreviews;
+  final bool edgeToEdgeImages;
+  final bool showTitleFirst;
   final bool showInstanceName;
   final bool showFullHeightImages;
   final bool showVoteActions;
@@ -32,6 +34,8 @@ class PostCardViewComfortable extends StatefulWidget {
     required this.postViewMedia,
     required this.showThumbnailPreviewOnRight,
     required this.hideNsfwPreviews,
+    required this.edgeToEdgeImages,
+    required this.showTitleFirst,
     required this.showInstanceName,
     required this.showFullHeightImages,
     required this.showVoteActions,
@@ -77,26 +81,54 @@ class _PostCardViewComfortableState extends State<PostCardViewComfortable> {
     final String textContent = widget.postViewMedia.postView.post.body ?? "";
 
     return Padding(
-      padding: const EdgeInsets.symmetric(vertical: 12.0, horizontal: 12.0),
+      padding: const EdgeInsets.symmetric(vertical: 12.0),
       child: Column(
         mainAxisAlignment: MainAxisAlignment.start,
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
-          MediaView(
-            postView: widget.postViewMedia,
-            showFullHeightImages: widget.showFullHeightImages,
-            hideNsfwPreviews: widget.hideNsfwPreviews,
-          ),
-          Text(widget.postViewMedia.postView.post.name,
+          if (widget.showTitleFirst)
+          Padding(
+            padding: const EdgeInsets.only(left: 12, right: 12, bottom: 4),
+            child: Text(widget.postViewMedia.postView.post.name,
               textScaleFactor: titleFontSizeScaleFactor,
               style: theme.textTheme.titleMedium?.copyWith(
                 color: widget.postViewMedia.postView.read ? theme.textTheme.titleMedium?.color?.withOpacity(0.4) : null,
               ),
-              softWrap: true),
+              softWrap: true
+            ),
+          ),
+          if (widget.edgeToEdgeImages)
+            MediaView(
+              postView: widget.postViewMedia,
+              showFullHeightImages: widget.showFullHeightImages,
+              hideNsfwPreviews: widget.hideNsfwPreviews,
+              edgeToEdgeImages: widget.edgeToEdgeImages,
+            ),
+          if (!widget.edgeToEdgeImages)
+            Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 12),
+              child: MediaView(
+                postView: widget.postViewMedia,
+                showFullHeightImages: widget.showFullHeightImages,
+                hideNsfwPreviews: widget.hideNsfwPreviews,
+                edgeToEdgeImages: widget.edgeToEdgeImages,
+              ),
+            ),
+          if (!widget.showTitleFirst)
+          Padding(
+            padding: const EdgeInsets.only(top: 4.0, bottom: 6.0, left: 12.0, right: 12.0),
+            child: Text(widget.postViewMedia.postView.post.name,
+              textScaleFactor: titleFontSizeScaleFactor,
+              style: theme.textTheme.titleMedium?.copyWith(
+                color: widget.postViewMedia.postView.read ? theme.textTheme.titleMedium?.color?.withOpacity(0.4) : null,
+              ),
+              softWrap: true
+            ),
+          ),
           Visibility(
             visible: widget.showTextContent && textContent.isNotEmpty,
             child: Padding(
-              padding: const EdgeInsets.only(top: 6.0, bottom: 4.0),
+              padding: const EdgeInsets.only(bottom: 6.0, left: 12.0, right: 12.0),
               child: Text(
                 textContent,
                 maxLines: 4,
@@ -109,7 +141,7 @@ class _PostCardViewComfortableState extends State<PostCardViewComfortable> {
             ),
           ),
           Padding(
-            padding: const EdgeInsets.only(top: 6.0, bottom: 4.0),
+            padding: const EdgeInsets.only(bottom: 4.0, left: 12.0, right: 12.0),
             child: Row(
               children: [
                 Expanded(

--- a/lib/settings/pages/general_settings_page.dart
+++ b/lib/settings/pages/general_settings_page.dart
@@ -23,6 +23,7 @@ class GeneralSettingsPage extends StatefulWidget {
 class _GeneralSettingsPageState extends State<GeneralSettingsPage> {
   // Feed Settings
   bool useCompactView = false;
+  bool showTitleFirst = false;
   PostListingType defaultPostListingType = DEFAULT_LISTING_TYPE;
   SortType defaultSortType = DEFAULT_SORT_TYPE;
 
@@ -34,6 +35,7 @@ class _GeneralSettingsPageState extends State<GeneralSettingsPage> {
   bool showVoteActions = true;
   bool showSaveAction = true;
   bool showFullHeightImages = false;
+  bool showEdgeToEdgeImages = false;
   bool showTextContent = false;
   bool hideNsfwPreviews = true;
   bool bottomNavBarSwipeGestures = true;
@@ -63,6 +65,10 @@ class _GeneralSettingsPageState extends State<GeneralSettingsPage> {
       case 'setting_general_use_compact_view':
         await prefs.setBool('setting_general_use_compact_view', value);
         setState(() => useCompactView = value);
+        break;
+      case 'setting_general_show_title_first':
+        await prefs.setBool('setting_general_show_title_first', value);
+        setState(() => showTitleFirst = value);
         break;
       case 'setting_general_default_listing_type':
         await prefs.setString('setting_general_default_listing_type', value);
@@ -97,6 +103,10 @@ class _GeneralSettingsPageState extends State<GeneralSettingsPage> {
       case 'setting_general_show_full_height_images':
         await prefs.setBool('setting_general_show_full_height_images', value);
         setState(() => showFullHeightImages = value);
+        break;
+      case 'setting_general_show_edge_to_edge_images':
+        await prefs.setBool('setting_general_show_edge_to_edge_images', value);
+        setState(() => showEdgeToEdgeImages = value);
         break;
       case 'setting_general_show_text_content':
         await prefs.setBool('setting_general_show_text_content', value);
@@ -163,6 +173,7 @@ class _GeneralSettingsPageState extends State<GeneralSettingsPage> {
     setState(() {
       // Feed Settings
       useCompactView = prefs.getBool('setting_general_use_compact_view') ?? false;
+      showTitleFirst = prefs.getBool('setting_general_show_title_first') ?? false;
 
       try {
         defaultPostListingType = PostListingType.values.byName(prefs.getString("setting_general_default_listing_type") ?? DEFAULT_LISTING_TYPE.name);
@@ -179,6 +190,7 @@ class _GeneralSettingsPageState extends State<GeneralSettingsPage> {
       showVoteActions = prefs.getBool('setting_general_show_vote_actions') ?? true;
       showSaveAction = prefs.getBool('setting_general_show_save_action') ?? true;
       showFullHeightImages = prefs.getBool('setting_general_show_full_height_images') ?? false;
+      showEdgeToEdgeImages = prefs.getBool('setting_general_show_edge_to_edge_images') ?? false;
       showTextContent = prefs.getBool('setting_general_show_text_content') ?? false;
       hideNsfwPreviews = prefs.getBool('setting_general_hide_nsfw_previews') ?? true;
       bottomNavBarSwipeGestures = prefs.getBool('setting_general_enable_swipe_gestures') ?? true;
@@ -323,12 +335,28 @@ class _GeneralSettingsPageState extends State<GeneralSettingsPage> {
                           onToggle: (bool value) => setPreferences('setting_general_show_full_height_images', value),
                         ),
                         ToggleOption(
+                          description: 'Edge-to-edge images',
+                          subtitle: 'Applies to normal view only',
+                          value: showEdgeToEdgeImages,
+                          iconEnabled: Icons.panorama_wide_angle_select,
+                          iconDisabled: Icons.panorama_wide_angle_outlined,
+                          onToggle: (bool value) => setPreferences('setting_general_show_edge_to_edge_images', value),
+                        ),
+                        ToggleOption(
                           description: 'Show text content',
                           subtitle: 'Applies to normal view only',
                           value: showTextContent,
                           iconEnabled: Icons.notes_rounded,
                           iconDisabled: Icons.notes_rounded,
                           onToggle: (bool value) => setPreferences('setting_general_show_text_content', value),
+                        ),
+                        ToggleOption(
+                          description: 'Show title first',
+                          subtitle: 'Applies to normal view only',
+                          value: showTitleFirst,
+                          iconEnabled: Icons.subtitles,
+                          iconDisabled: Icons.subtitles_off,
+                          onToggle: (bool value) => setPreferences('setting_general_show_title_first', value),
                         ),
                         ToggleOption(
                           description: 'Hide NSFW previews',

--- a/lib/shared/media_view.dart
+++ b/lib/shared/media_view.dart
@@ -24,6 +24,7 @@ class MediaView extends StatefulWidget {
   final PostViewMedia? postView;
   final bool showFullHeightImages;
   final bool hideNsfwPreviews;
+  final bool edgeToEdgeImages;
   final ViewMode viewMode;
 
   const MediaView({
@@ -31,6 +32,7 @@ class MediaView extends StatefulWidget {
     this.post,
     this.postView,
     this.showFullHeightImages = true,
+    this.edgeToEdgeImages = false,
     required this.hideNsfwPreviews,
     this.viewMode = ViewMode.comfortable,
   });
@@ -88,6 +90,7 @@ class _MediaViewState extends State<MediaView> with SingleTickerProviderStateMix
         mediaHeight: widget.postView!.media.first.height,
         mediaWidth: widget.postView!.media.first.width,
         showFullHeightImages: widget.viewMode == ViewMode.comfortable ? widget.showFullHeightImages : false,
+        // edgeToEdgeImages: widget.viewMode == ViewMode.comfortable ? widget.edgeToEdgeImages : false,
         viewMode: widget.viewMode,
       );
     }
@@ -118,7 +121,7 @@ class _MediaViewState extends State<MediaView> with SingleTickerProviderStateMix
         ),
         child: Container(
           clipBehavior: Clip.hardEdge,
-          decoration: BoxDecoration(borderRadius: BorderRadius.circular(6)),
+          decoration: BoxDecoration(borderRadius: BorderRadius.circular((widget.edgeToEdgeImages ? 0 : 6))),
           child: Stack(
             alignment: Alignment.center,
             children: [
@@ -147,7 +150,7 @@ class _MediaViewState extends State<MediaView> with SingleTickerProviderStateMix
     final openInExternalBrowser = context.read<ThunderBloc>().state.preferences?.getBool('setting_links_open_in_external_browser') ?? false;
 
     double? height = widget.viewMode == ViewMode.compact ? 75 : (widget.showFullHeightImages ? widget.postView!.media.first.height : 150);
-    double width = widget.viewMode == ViewMode.compact ? 75 : MediaQuery.of(context).size.width - 24;
+    double width = widget.viewMode == ViewMode.compact ? 75 : MediaQuery.of(context).size.width - (widget.edgeToEdgeImages ? 0 : 24);
 
     return Hero(
       tag: widget.postView!.media.first.mediaUrl!,
@@ -159,7 +162,7 @@ class _MediaViewState extends State<MediaView> with SingleTickerProviderStateMix
         cache: true,
         clearMemoryCacheWhenDispose: true,
         cacheWidth:
-            widget.viewMode == ViewMode.compact ? (75 * View.of(context).devicePixelRatio.ceil()) : ((MediaQuery.of(context).size.width - 24) * View.of(context).devicePixelRatio.ceil()).toInt(),
+            widget.viewMode == ViewMode.compact ? (75 * View.of(context).devicePixelRatio.ceil()) : ((MediaQuery.of(context).size.width - (widget.edgeToEdgeImages ? 0 : 24)) * View.of(context).devicePixelRatio.ceil()).toInt(),
         loadStateChanged: (ExtendedImageState state) {
           switch (state.extendedImageLoadState) {
             case LoadState.loading:


### PR DESCRIPTION
Adds two options under Post, one for putting the title above the image/content, and another for edge-to-edge images. I've adjusted padding to look like it was before if those options are turned off, but altered a bit to fit with the changes when they are on.

Updates for: https://github.com/hjiangsu/thunder/issues/136