### PR TITLE
gray body text in post view

### DIFF
--- a/lib/community/widgets/post_card_view_comfortable.dart
+++ b/lib/community/widgets/post_card_view_comfortable.dart
@@ -103,7 +103,7 @@ class _PostCardViewComfortableState extends State<PostCardViewComfortable> {
                 overflow: TextOverflow.ellipsis,
                 textScaleFactor: contentFontSizeScaleFactor,
                 style: theme.textTheme.bodyMedium?.copyWith(
-                  color: widget.postViewMedia.postView.read ? theme.textTheme.bodyMedium?.color?.withOpacity(0.4) : null,
+                  color: widget.postViewMedia.postView.read ? theme.textTheme.bodyMedium?.color?.withOpacity(0.4) : theme.textTheme.bodyMedium?.color?.withOpacity(0.6),
                 ),
               ),
             ),


### PR DESCRIPTION
A first-step for https://github.com/hjiangsu/thunder/issues/223 is to blend out the body content in the post view. This seems to be a good balance for light/dark themes.