### PR TITLE
Improve Material 3 Theme

### DIFF
--- a/lib/account/pages/login_page.dart
+++ b/lib/account/pages/login_page.dart
@@ -158,13 +158,9 @@ class _LoginPageState extends State<LoginPage> {
                 enableSuggestions: false,
               ),
               const SizedBox(height: 32.0),
-              ElevatedButton(
+              FilledButton(
                 style: ElevatedButton.styleFrom(
                   minimumSize: const Size.fromHeight(60),
-                  backgroundColor: theme.colorScheme.primary,
-                  textStyle: theme.textTheme.titleMedium?.copyWith(
-                    color: theme.colorScheme.onPrimary,
-                  ),
                 ),
                 onPressed: (_usernameTextEditingController.text.isNotEmpty && _passwordTextEditingController.text.isNotEmpty && _instanceTextEditingController.text.isNotEmpty)
                     ? () {

--- a/lib/community/widgets/post_card.dart
+++ b/lib/community/widgets/post_card.dart
@@ -192,7 +192,11 @@ class _PostCardState extends State<PostCard> {
             Divider(
               height: 1.0,
               thickness: 4.0,
-              color: useDarkTheme ? theme.colorScheme.background.lighten(7) : theme.colorScheme.background.darken(7),
+              color: ElevationOverlay.applySurfaceTint(
+                Theme.of(context).colorScheme.surface,
+                Theme.of(context).colorScheme.surfaceTint,
+                1,
+              ),
             ),
             InkWell(
               child: useCompactView

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 
 import 'package:dynamic_color/dynamic_color.dart';
+import 'package:flex_color_scheme/flex_color_scheme.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
@@ -79,22 +80,63 @@ class ThunderApp extends StatelessWidget {
             context.read<ThemeBloc>().add(ThemeChangeEvent());
           }
           return DynamicColorBuilder(
-            builder: (dynamicLightColorScheme, dynamicDarkColorScheme) {
-              ColorScheme colorScheme = ColorScheme.fromSeed(
-                seedColor: Colors.blueAccent,
-                brightness: Brightness.light,
+            builder: (lightColorScheme, darkColorScheme) {
+              const FlexSubThemesData subThemeData = FlexSubThemesData(
+                interactionEffects: false,
+                tintedDisabledControls: false,
+                inputDecoratorBorderType: FlexInputBorderType.underline,
+                inputDecoratorUnfocusedBorderIsColored: false,
+                tooltipRadius: 4,
+                tooltipSchemeColor: SchemeColor.inverseSurface,
+                tooltipOpacity: 0.9,
+                snackBarElevation: 6,
+                snackBarBackgroundSchemeColor: SchemeColor.inverseSurface,
+                navigationBarSelectedLabelSchemeColor: SchemeColor.onSurface,
+                navigationBarUnselectedLabelSchemeColor: SchemeColor.onSurface,
+                navigationBarMutedUnselectedLabel: false,
+                navigationBarSelectedIconSchemeColor: SchemeColor.onSurface,
+                navigationBarUnselectedIconSchemeColor: SchemeColor.onSurface,
+                navigationBarMutedUnselectedIcon: false,
+                navigationBarIndicatorSchemeColor: SchemeColor.secondaryContainer,
+                navigationBarIndicatorOpacity: 1.00,
+                navigationRailSelectedLabelSchemeColor: SchemeColor.onSurface,
+                navigationRailUnselectedLabelSchemeColor: SchemeColor.onSurface,
+                navigationRailMutedUnselectedLabel: false,
+                navigationRailSelectedIconSchemeColor: SchemeColor.onSurface,
+                navigationRailUnselectedIconSchemeColor: SchemeColor.onSurface,
+                navigationRailMutedUnselectedIcon: false,
+                navigationRailIndicatorSchemeColor: SchemeColor.secondaryContainer,
+                navigationRailIndicatorOpacity: 1.00,
+                navigationRailBackgroundSchemeColor: SchemeColor.surface,
+                navigationRailLabelType: NavigationRailLabelType.none,
               );
-              ColorScheme darkColorScheme = ColorScheme.fromSeed(
-                seedColor: Colors.lightBlue,
-                background: state.useBlackTheme ? Colors.black : null,
-                surface: state.useBlackTheme ? Colors.black : null,
-                brightness: Brightness.dark,
+
+              ThemeData theme = FlexThemeData.light(
+                scheme: FlexScheme.deepBlue,
+                useMaterial3: true, 
+                subThemesData: subThemeData,
+              );
+              ThemeData darkTheme = FlexThemeData.dark(
+                scheme: FlexScheme.deepBlue,
+                darkIsTrueBlack: state.useBlackTheme,
+                useMaterial3: true,
+                subThemesData: subThemeData,
               );
 
               // Enable Material You theme
               if (state.useMaterialYouTheme == true) {
-                colorScheme = dynamicLightColorScheme?.harmonized() ?? colorScheme;
-                darkColorScheme = dynamicDarkColorScheme?.harmonized() ?? darkColorScheme;
+                theme = FlexThemeData.light(
+                  colorScheme: lightColorScheme,
+                  useMaterial3: true,
+                  subThemesData: subThemeData,
+                );
+
+                darkTheme = FlexThemeData.dark(
+                  colorScheme: darkColorScheme,
+                  darkIsTrueBlack: state.useBlackTheme,
+                  useMaterial3: true,
+                  subThemesData: subThemeData,
+                );
               }
 
               // Set navigation bar color on Android to be transparent
@@ -109,14 +151,8 @@ class ThunderApp extends StatelessWidget {
                   title: 'Thunder',
                   routerConfig: router,
                   themeMode: state.useSystemTheme ? ThemeMode.system : (state.useDarkTheme ? ThemeMode.dark : ThemeMode.light),
-                  theme: ThemeData.from(
-                    colorScheme: colorScheme, 
-                    useMaterial3: true,
-                  ),
-                  darkTheme: ThemeData.from(
-                    colorScheme: darkColorScheme,
-                    useMaterial3: true,
-                  ),
+                  theme: theme,
+                  darkTheme: darkTheme,
                   debugShowCheckedModeBanner: false,
                 ),
               );

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -80,22 +80,22 @@ class ThunderApp extends StatelessWidget {
             context.read<ThemeBloc>().add(ThemeChangeEvent());
           }
           return DynamicColorBuilder(
-            builder: (lightColorScheme, darkColorScheme) {
-              ThemeData theme = FlexThemeData.light(useMaterial3: true, scheme: FlexScheme.deepBlue);
-              ThemeData darkTheme = FlexThemeData.dark(useMaterial3: true, scheme: FlexScheme.deepBlue, darkIsTrueBlack: state.useBlackTheme);
+            builder: (dynamicLightColorScheme, dynamicDarkColorScheme) {
+              ColorScheme colorScheme = ColorScheme.fromSeed(
+                seedColor: Colors.blueAccent,
+                brightness: Brightness.light,
+              );
+              ColorScheme darkColorScheme = ColorScheme.fromSeed(
+                seedColor: Colors.lightBlue,
+                background: state.useBlackTheme ? Colors.black : null,
+                surface: state.useBlackTheme ? Colors.black : null,
+                brightness: Brightness.dark,
+              );
 
               // Enable Material You theme
               if (state.useMaterialYouTheme == true) {
-                theme = ThemeData(
-                  colorScheme: lightColorScheme,
-                  useMaterial3: true,
-                );
-
-                darkTheme = FlexThemeData.dark(
-                  useMaterial3: true,
-                  colorScheme: darkColorScheme,
-                  darkIsTrueBlack: state.useBlackTheme,
-                );
+                colorScheme = dynamicLightColorScheme?.harmonized() ?? colorScheme;
+                darkColorScheme = dynamicDarkColorScheme?.harmonized() ?? darkColorScheme;
               }
 
               // Set navigation bar color on Android to be transparent
@@ -110,8 +110,14 @@ class ThunderApp extends StatelessWidget {
                   title: 'Thunder',
                   routerConfig: router,
                   themeMode: state.useSystemTheme ? ThemeMode.system : (state.useDarkTheme ? ThemeMode.dark : ThemeMode.light),
-                  theme: theme,
-                  darkTheme: darkTheme,
+                  theme: ThemeData.from(
+                    colorScheme: colorScheme, 
+                    useMaterial3: true,
+                  ),
+                  darkTheme: ThemeData.from(
+                    colorScheme: darkColorScheme,
+                    useMaterial3: true,
+                  ),
                   debugShowCheckedModeBanner: false,
                 ),
               );

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,7 +1,6 @@
 import 'dart:async';
 
 import 'package:dynamic_color/dynamic_color.dart';
-import 'package:flex_color_scheme/flex_color_scheme.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';

--- a/lib/shared/link_preview_card.dart
+++ b/lib/shared/link_preview_card.dart
@@ -125,7 +125,11 @@ class LinkPreviewCard extends StatelessWidget {
         clipBehavior: Clip.hardEdge,
         decoration: BoxDecoration(borderRadius: BorderRadius.circular(6)),
         child: Container(
-          color: useDarkTheme ? theme.colorScheme.background.lighten(7) : theme.colorScheme.background.darken(7),
+          color: ElevationOverlay.applySurfaceTint(
+            Theme.of(context).colorScheme.surface,
+            Theme.of(context).colorScheme.surfaceTint,
+            1,
+          ),
           child: SizedBox(
             height: 75.0,
             width: 75.0,
@@ -138,7 +142,11 @@ class LinkPreviewCard extends StatelessWidget {
       );
     } else {
       return Container(
-        color: useDarkTheme ? theme.colorScheme.background.lighten(7) : theme.colorScheme.background.darken(7),
+        color: ElevationOverlay.applySurfaceTint(
+          Theme.of(context).colorScheme.surface,
+          Theme.of(context).colorScheme.surfaceTint,
+          1,
+        ),
         padding: const EdgeInsets.symmetric(horizontal: 8.0, vertical: 12.0),
         child: Row(
           children: [

--- a/lib/thunder/pages/thunder_page.dart
+++ b/lib/thunder/pages/thunder_page.dart
@@ -197,61 +197,47 @@ class _ThunderState extends State<Thunder> {
 
   // Generates the BottomNavigationBar
   Widget _getScaffoldBottomNavigationBar(BuildContext context) {
-    final theme = Theme.of(context);
+    return GestureDetector(
+      onHorizontalDragStart: _handleDragStart,
+      onHorizontalDragUpdate: _handleDragUpdate,
+      onHorizontalDragEnd: _handleDragEnd,
+      // onDoubleTap: _handleDoubleTap,
+      child: NavigationBar(
+        selectedIndex: selectedPageIndex,
+        labelBehavior: NavigationDestinationLabelBehavior.alwaysHide,
+        destinations: const [
+          NavigationDestination(
+            icon: Icon(Icons.dashboard_rounded),
+            label: 'Feed',
+          ),
+          NavigationDestination(
+            icon: Icon(Icons.search_rounded),
+            label: 'Search',
+          ),
+          NavigationDestination(
+            icon: Icon(Icons.person_rounded),
+            label: 'Account',
+          ),
+          NavigationDestination(
+            icon: Icon(Icons.inbox_rounded),
+            label: 'Inbox',
+          ),
+          NavigationDestination(
+            icon: Icon(Icons.settings_rounded),
+            label: 'Settings',
+          ),
+        ],
+        onDestinationSelected: (index) {
+          setState(() {
+            selectedPageIndex = index;
+            pageController.animateToPage(index, duration: const Duration(milliseconds: 500), curve: Curves.ease);
+          });
 
-    return Theme(
-      data: ThemeData.from(colorScheme: theme.colorScheme).copyWith(
-        splashColor: Colors.transparent,
-        highlightColor: Colors.transparent,
-      ),
-      child: GestureDetector(
-        onHorizontalDragStart: _handleDragStart,
-        onHorizontalDragUpdate: _handleDragUpdate,
-        onHorizontalDragEnd: _handleDragEnd,
-        // onDoubleTap: _handleDoubleTap,
-        child: BottomNavigationBar(
-          currentIndex: selectedPageIndex,
-          showSelectedLabels: false,
-          showUnselectedLabels: false,
-          selectedItemColor: theme.colorScheme.primary,
-          type: BottomNavigationBarType.fixed,
-          unselectedFontSize: 20.0,
-          selectedFontSize: 20.0,
-          elevation: 1,
-          items: const [
-            BottomNavigationBarItem(
-              icon: Icon(Icons.dashboard_rounded),
-              label: 'Feed',
-            ),
-            BottomNavigationBarItem(
-              icon: Icon(Icons.search_rounded),
-              label: 'Search',
-            ),
-            BottomNavigationBarItem(
-              icon: Icon(Icons.person_rounded),
-              label: 'Account',
-            ),
-            BottomNavigationBarItem(
-              icon: Icon(Icons.inbox_rounded),
-              label: 'Inbox',
-            ),
-            BottomNavigationBarItem(
-              icon: Icon(Icons.settings_rounded),
-              label: 'Settings',
-            ),
-          ],
-          onTap: (index) {
-            setState(() {
-              selectedPageIndex = index;
-              pageController.animateToPage(index, duration: const Duration(milliseconds: 500), curve: Curves.ease);
-            });
-
-            // @todo Change this from integer to enum or some other type
-            if (index == 3) {
-              context.read<InboxBloc>().add(const GetInboxEvent());
-            }
-          },
-        ),
+          // @todo Change this from integer to enum or some other type
+          if (index == 3) {
+            context.read<InboxBloc>().add(const GetInboxEvent());
+          }
+        },
       ),
     );
   }


### PR DESCRIPTION
This PR improves the material 3 theming of the app. It includes two main changes:
1. Generate the Theme using a `ColorScheme` → I think this is simpler than using a package for it and I prefer the theme generated by it (especially for chips since it only uses one color and not a primary and secondary)
2. Migrate `BottomNavigationBar` to `NavigationBar`

I attached some screenshots. Feel free to just close this PR if you're not happy with it, I know this is purely subjective. 
Thanks for all the work you did!

![image](https://github.com/hjiangsu/thunder/assets/9092682/1cd64e9c-0cda-4924-8a20-f217131bc81d)
![image](https://github.com/hjiangsu/thunder/assets/9092682/5928c7bd-3c6e-47f2-8e43-1ddf47ed0575)
