### PR TITLE
Show sort type label on tooltip

### DIFF
--- a/lib/community/pages/community_page.dart
+++ b/lib/community/pages/community_page.dart
@@ -30,6 +30,7 @@ class _CommunityPageState extends State<CommunityPage> with AutomaticKeepAliveCl
 
   SortType? sortType;
   IconData? sortTypeIcon;
+  String? sortTypeLabel;
 
   @override
   Widget build(BuildContext context) {
@@ -47,7 +48,9 @@ class _CommunityPageState extends State<CommunityPage> with AutomaticKeepAliveCl
           if (previousState.sortType != currentState.sortType) {
             setState(() {
               sortType = currentState.sortType;
-              sortTypeIcon = allSortTypeItems.firstWhere((sortTypeItem) => sortTypeItem.payload == currentState.sortType).icon;
+              final sortTypeItem = allSortTypeItems.firstWhere((sortTypeItem) => sortTypeItem.payload == currentState.sortType);
+              sortTypeIcon = sortTypeItem.icon;
+              sortTypeLabel = sortTypeItem.label;
             });
           }
           return true;
@@ -96,6 +99,7 @@ class _CommunityPageState extends State<CommunityPage> with AutomaticKeepAliveCl
                         }),
                     IconButton(
                         icon: Icon(sortTypeIcon, semanticLabel: 'Sort By'),
+                        tooltip: sortTypeLabel,
                         onPressed: () {
                           HapticFeedback.mediumImpact();
                           showSortBottomSheet(context, state);

--- a/lib/post/pages/post_page.dart
+++ b/lib/post/pages/post_page.dart
@@ -51,6 +51,7 @@ class _PostPageState extends State<PostPage> {
 
   CommentSortType? sortType;
   IconData? sortTypeIcon;
+  String? sortTypeLabel;
 
   @override
   Widget build(BuildContext context) {
@@ -64,7 +65,9 @@ class _PostPageState extends State<PostPage> {
               if (previousState.sortType != currentState.sortType) {
                 setState(() {
                   sortType = currentState.sortType;
-                  sortTypeIcon = commentSortTypeItems.firstWhere((sortTypeItem) => sortTypeItem.payload == currentState.sortType).icon;
+                  final sortTypeItem = commentSortTypeItems.firstWhere((sortTypeItem) => sortTypeItem.payload == currentState.sortType);
+                  sortTypeIcon = sortTypeItem.icon;
+                  sortTypeLabel = sortTypeItem.label;
                 });
               }
               return true;
@@ -76,6 +79,7 @@ class _PostPageState extends State<PostPage> {
                   actions: [
                     IconButton(
                       icon: Icon(sortTypeIcon, semanticLabel: 'Sort By'),
+                      tooltip: sortTypeLabel,
                       onPressed: () => showSortBottomSheet(context, state),
                     ),
                   ],


### PR DESCRIPTION
I often forget which sort mode is selected, and I have not memorized the icons yet. This change allows me to long-press on the sort icon and see the name.

### Notes
* This is my very first time using Dart/Flutter, so I am making a very small change to get familiar with it.
* Let me know if you want me to do PRs to `develop` or `main`.
* I have only tested on Android.

 ### Screenshots

| ![image](https://github.com/hjiangsu/thunder/assets/7417301/1676af35-b4d8-4ddd-8fc8-a576aa43b15b) |
| - |

| ![image](https://github.com/hjiangsu/thunder/assets/7417301/37c2cf06-3c7d-46f5-8427-56f34a02134f) |
| - |