### PR TITLE
Use titles on community pages, add text wrapping on overflow

### DIFF
--- a/lib/community/widgets/community_header.dart
+++ b/lib/community/widgets/community_header.dart
@@ -31,33 +31,35 @@ class CommunityHeader extends StatelessWidget {
                 maxRadius: 45,
               ),
               const SizedBox(width: 20.0),
-              Column(
-                crossAxisAlignment: CrossAxisAlignment.start,
-                mainAxisSize: MainAxisSize.min,
-                children: [
-                  Text(
-                    communityInfo?.communityView.community.name ?? 'N/A',
-                    style: theme.textTheme.headlineSmall?.copyWith(fontWeight: FontWeight.w600),
-                  ),
-                  Text(
-                    fetchInstanceNameFromUrl(communityInfo?.communityView.community.actorId) ?? 'N/A',
-                    style: theme.textTheme.titleSmall,
-                  ),
-                  const SizedBox(height: 8.0),
-                  Row(
-                    children: [
-                      IconText(
-                        icon: const Icon(Icons.people_rounded),
-                        text: formatNumberToK(communityInfo?.communityView.counts.subscribers ?? 0),
-                      ),
-                      const SizedBox(width: 8.0),
-                      IconText(
-                        icon: const Icon(Icons.sensors_rounded),
-                        text: (communityInfo?.online != null) ? '${communityInfo?.online}' : '-',
-                      ),
-                    ],
-                  ),
-                ],
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    Text(
+                      communityInfo?.communityView.community.title ?? communityInfo?.communityView.community.name ?? 'N/A',
+                      style: theme.textTheme.headlineSmall?.copyWith(fontWeight: FontWeight.w600),
+                    ),
+                    Text(
+                      fetchInstanceNameFromUrl(communityInfo?.communityView.community.actorId) ?? 'N/A',
+                      style: theme.textTheme.titleSmall,
+                    ),
+                    const SizedBox(height: 8.0),
+                    Row(
+                      children: [
+                        IconText(
+                          icon: const Icon(Icons.people_rounded),
+                          text: formatNumberToK(communityInfo?.communityView.counts.subscribers ?? 0),
+                        ),
+                        const SizedBox(width: 8.0),
+                        IconText(
+                          icon: const Icon(Icons.sensors_rounded),
+                          text: (communityInfo?.online != null) ? '${communityInfo?.online}' : '-',
+                        ),
+                      ],
+                    ),
+                  ],
+                ),
               ),
             ],
           ),


### PR DESCRIPTION
Changed community header to using community titles, and added wrapping for long ones

![Screenshot_20230706_035007](https://github.com/hjiangsu/thunder/assets/4365015/e487a45e-b060-4bf7-86e7-cd986aded2a4)
