### PR TITLE
Shorten code for edge-to-edge images and add link padding

### DIFF
--- a/lib/community/widgets/post_card_view_comfortable.dart
+++ b/lib/community/widgets/post_card_view_comfortable.dart
@@ -55,6 +55,13 @@ class PostCardViewComfortable extends StatelessWidget {
 
     final String textContent = postViewMedia.postView.post.body ?? "";
 
+    var mediaView = MediaView(
+      postView: postViewMedia,
+      showFullHeightImages: showFullHeightImages,
+      hideNsfwPreviews: hideNsfwPreviews,
+      edgeToEdgeImages: edgeToEdgeImages,
+    );
+
     return Padding(
       padding: const EdgeInsets.symmetric(vertical: 12.0),
       child: Column(
@@ -72,21 +79,11 @@ class PostCardViewComfortable extends StatelessWidget {
                   softWrap: true),
             ),
           if (edgeToEdgeImages)
-            MediaView(
-              postView: postViewMedia,
-              showFullHeightImages: showFullHeightImages,
-              hideNsfwPreviews: hideNsfwPreviews,
-              edgeToEdgeImages: edgeToEdgeImages,
-            ),
+            mediaView,
           if (!edgeToEdgeImages)
             Padding(
               padding: const EdgeInsets.symmetric(horizontal: 12),
-              child: MediaView(
-                postView: postViewMedia,
-                showFullHeightImages: showFullHeightImages,
-                hideNsfwPreviews: hideNsfwPreviews,
-                edgeToEdgeImages: edgeToEdgeImages,
-              ),
+              child: mediaView,
             ),
           if (!showTitleFirst)
             Padding(

--- a/lib/shared/link_preview_card.dart
+++ b/lib/shared/link_preview_card.dart
@@ -23,6 +23,7 @@ class LinkPreviewCard extends StatelessWidget {
     this.mediaWidth,
     this.showLinkPreviews = true,
     this.showFullHeightImages = false,
+    this.edgeToEdgeImages = false,
     this.viewMode = ViewMode.comfortable,
   });
 
@@ -34,6 +35,8 @@ class LinkPreviewCard extends StatelessWidget {
 
   final bool showLinkPreviews;
   final bool showFullHeightImages;
+
+  final bool edgeToEdgeImages;
 
   final ViewMode viewMode;
 
@@ -66,21 +69,29 @@ class LinkPreviewCard extends StatelessWidget {
         ),
       );
     } else {
-      return Padding(
-        padding: const EdgeInsets.only(top: 4.0, bottom: 8.0),
-        child: InkWell(
-          child: Container(
-            clipBehavior: Clip.hardEdge,
-            decoration: BoxDecoration(borderRadius: BorderRadius.circular(6)),
-            child: Stack(
-              alignment: Alignment.bottomRight,
-              fit: StackFit.passthrough,
-              children: [linkInformation(context)],
-            ),
+      var inkWell = InkWell(
+        child: Container(
+          clipBehavior: Clip.hardEdge,
+          decoration: BoxDecoration(borderRadius: BorderRadius.circular(6)),
+          child: Stack(
+            alignment: Alignment.bottomRight,
+            fit: StackFit.passthrough,
+            children: [linkInformation(context)],
           ),
-          onTap: () => triggerOnTap(context),
         ),
+        onTap: () => triggerOnTap(context),
       );
+      if (edgeToEdgeImages) {
+        return Padding(
+          padding: const EdgeInsets.only(top: 4.0, bottom: 8.0, left: 12.0, right: 12.0),
+          child: inkWell,
+        );
+      } else {
+          return Padding(
+            padding: const EdgeInsets.only(top: 4.0, bottom: 8.0),
+            child: inkWell,
+        );
+      }
     }
   }
 

--- a/lib/shared/media_view.dart
+++ b/lib/shared/media_view.dart
@@ -90,7 +90,7 @@ class _MediaViewState extends State<MediaView> with SingleTickerProviderStateMix
         mediaHeight: widget.postView!.media.first.height,
         mediaWidth: widget.postView!.media.first.width,
         showFullHeightImages: widget.viewMode == ViewMode.comfortable ? widget.showFullHeightImages : false,
-        // edgeToEdgeImages: widget.viewMode == ViewMode.comfortable ? widget.edgeToEdgeImages : false,
+        edgeToEdgeImages: widget.viewMode == ViewMode.comfortable ? widget.edgeToEdgeImages : false,
         viewMode: widget.viewMode,
       );
     }


### PR DESCRIPTION
For some reason I had not considered a variable for this before, so it just shortens the code a bit. Also, edge-to-edge was getting applied to the links pre-preview which looked good at the time, but the more I look at it the more it looks weird, so I solved for that.