### PR TITLE
2 column support with toggle

### DIFF
--- a/lib/community/bloc/community_bloc.dart
+++ b/lib/community/bloc/community_bloc.dart
@@ -175,13 +175,16 @@ class CommunityBloc extends Bloc<CommunityEvent, CommunityState> {
 
     PostListingType defaultListingType;
     SortType defaultSortType;
+    bool tabletMode;
 
     try {
       defaultListingType = PostListingType.values.byName(prefs.getString("setting_general_default_listing_type") ?? DEFAULT_LISTING_TYPE.name);
       defaultSortType = SortType.values.byName(prefs.getString("setting_general_default_sort_type") ?? DEFAULT_SORT_TYPE.name);
+      tabletMode = prefs.getBool('setting_post_tablet_mode') ?? false;
     } catch (e) {
       defaultListingType = PostListingType.values.byName(DEFAULT_LISTING_TYPE.name);
       defaultSortType = SortType.values.byName(DEFAULT_SORT_TYPE.name);
+      tabletMode = false;
     }
 
     try {
@@ -225,6 +228,18 @@ class CommunityBloc extends Bloc<CommunityEvent, CommunityState> {
               communityId: communityId ?? getCommunityResponse?.communityView.community.id,
               communityName: event.communityName,
             ));
+            if (tabletMode) {
+              List<PostView> posts2 = await lemmy.run(GetPosts(
+                auth: account?.jwt,
+                page: 2,
+                limit: limit,
+                sort: sortType,
+                type: listingType,
+                communityId: communityId ?? getCommunityResponse?.communityView.community.id,
+                communityName: event.communityName,
+              ));
+              posts.addAll(posts2);
+            }
 
             // Parse the posts and add in media information which is used elsewhere in the app
             List<PostViewMedia> formattedPosts = await parsePostViews(posts);
@@ -237,7 +252,7 @@ class CommunityBloc extends Bloc<CommunityEvent, CommunityState> {
             return emit(
               state.copyWith(
                 status: CommunityStatus.success,
-                page: 2,
+                page: tabletMode ? 2 : 3,
                 postViews: formattedPosts,
                 postIds: postIds,
                 listingType: listingType,
@@ -271,6 +286,18 @@ class CommunityBloc extends Bloc<CommunityEvent, CommunityState> {
               communityId: state.communityId,
               communityName: state.communityName,
             ));
+            if (tabletMode) {
+              List<PostView> posts2 = await lemmy.run(GetPosts(
+                auth: account?.jwt,
+                page: state.page + 1,
+                limit: limit,
+                sort: sortType,
+                type: state.listingType,
+                communityId: state.communityId,
+                communityName: state.communityName,
+              ));
+              posts.addAll(posts2);
+            }
 
             // Parse the posts, and append them to the existing list
             List<PostViewMedia> postMedias = await parsePostViews(posts);
@@ -291,7 +318,7 @@ class CommunityBloc extends Bloc<CommunityEvent, CommunityState> {
             return emit(
               state.copyWith(
                 status: CommunityStatus.success,
-                page: state.page + 1,
+                page: tabletMode ? state.page + 2 : state.page + 1,
                 postViews: postViews,
                 postIds: postIds,
                 communityId: communityId,

--- a/lib/community/widgets/post_card_list.dart
+++ b/lib/community/widgets/post_card_list.dart
@@ -97,7 +97,7 @@ class _PostCardListState extends State<PostCardList> {
         },
         child: MasonryGridView.builder(
           gridDelegate: tabletMode ? tabletGridDelegate : phoneGridDelegate,
-          crossAxisSpacing: 20,
+          crossAxisSpacing: 40,
           mainAxisSpacing: 0,
           cacheExtent: 500,
           controller: _scrollController,

--- a/lib/community/widgets/post_card_list.dart
+++ b/lib/community/widgets/post_card_list.dart
@@ -11,6 +11,8 @@ import 'package:thunder/core/models/post_view_media.dart';
 import 'package:thunder/thunder/bloc/thunder_bloc.dart';
 import 'package:thunder/user/bloc/user_bloc.dart';
 
+import 'package:flutter_staggered_grid_view/flutter_staggered_grid_view.dart';
+
 class PostCardList extends StatefulWidget {
   final List<PostViewMedia>? postViews;
   final int? communityId;
@@ -66,6 +68,16 @@ class _PostCardListState extends State<PostCardList> {
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
+    final ThunderState state = context.watch<ThunderBloc>().state;
+
+    bool tabletMode = state.tabletMode;
+
+    const tabletGridDelegate = const SliverSimpleGridDelegateWithFixedCrossAxisCount(
+      crossAxisCount: 2,
+    );
+    const phoneGridDelegate = const SliverSimpleGridDelegateWithFixedCrossAxisCount(
+      crossAxisCount: 1,
+    );
 
     return BlocListener<ThunderBloc, ThunderState>(
       listenWhen: (previous, current) => (previous.status == ThunderStatus.refreshing && current.status == ThunderStatus.success),
@@ -83,7 +95,10 @@ class _PostCardListState extends State<PostCardList> {
                 ));
           }
         },
-        child: ListView.builder(
+        child: MasonryGridView.builder(
+          gridDelegate: tabletMode ? tabletGridDelegate : phoneGridDelegate,
+          crossAxisSpacing: 20,
+          mainAxisSpacing: 0,
           cacheExtent: 500,
           controller: _scrollController,
           itemCount: widget.postViews?.length != null ? ((widget.communityId != null || widget.communityName != null) ? widget.postViews!.length + 1 : widget.postViews!.length + 1) : 1,

--- a/lib/core/models/media_extension.dart
+++ b/lib/core/models/media_extension.dart
@@ -5,10 +5,12 @@ import 'package:flutter/material.dart';
 
 abstract class MediaExtension {
   /// Given a width and height, determine the appropriate re-sized dimensions based on the device screen size.
-  static Size getScaledMediaSize({width, height, offset = 24.0}) {
+  static Size getScaledMediaSize({width, height, offset = 24.0, tabletMode = false}) {
     double mediaRatio = width / height;
 
-    double widthScale = ((PlatformDispatcher.instance.views.first.physicalSize / PlatformDispatcher.instance.views.first.devicePixelRatio).width - offset) / width;
+    double screenWidth = (PlatformDispatcher.instance.views.first.physicalSize / PlatformDispatcher.instance.views.first.devicePixelRatio).width;
+    double usableScreenWidth = tabletMode ? screenWidth / 2 - 20 : screenWidth;
+    double widthScale = (usableScreenWidth - offset) / width;
     double mediaMaxWidth = widthScale * width;
     double mediaMaxHeight = mediaMaxWidth / mediaRatio;
 

--- a/lib/settings/pages/general_settings_page.dart
+++ b/lib/settings/pages/general_settings_page.dart
@@ -37,6 +37,7 @@ class _GeneralSettingsPageState extends State<GeneralSettingsPage> {
   bool showSaveAction = true;
   bool showFullHeightImages = false;
   bool showEdgeToEdgeImages = false;
+  bool tabletMode = false;
   bool showTextContent = false;
   bool hideNsfwPreviews = true;
   bool bottomNavBarSwipeGestures = true;
@@ -133,6 +134,10 @@ class _GeneralSettingsPageState extends State<GeneralSettingsPage> {
         await prefs.setString('setting_post_default_comment_sort_type', value);
         setState(() => defaultCommentSortType = CommentSortType.values.byName(value ?? DEFAULT_COMMENT_SORT_TYPE.name));
         break;
+      case 'setting_post_tablet_mode':
+        await prefs.setBool('setting_post_tablet_mode', value);
+        setState(() => tabletMode = value);
+        break;
 
       // Link Settings
       case 'setting_general_show_link_previews':
@@ -201,6 +206,7 @@ class _GeneralSettingsPageState extends State<GeneralSettingsPage> {
       bottomNavBarSwipeGestures = prefs.getBool('setting_general_enable_swipe_gestures') ?? true;
       bottomNavBarDoubleTapGestures = prefs.getBool('setting_general_enable_doubletap_gestures') ?? false;
       defaultCommentSortType = CommentSortType.values.byName(prefs.getString("setting_post_default_comment_sort_type") ?? DEFAULT_COMMENT_SORT_TYPE.name);
+      tabletMode = prefs.getBool('setting_post_tablet_mode') ?? false;
 
       // Links
       openInExternalBrowser = prefs.getBool('setting_links_open_in_external_browser') ?? false;
@@ -370,6 +376,13 @@ class _GeneralSettingsPageState extends State<GeneralSettingsPage> {
                           iconEnabled: Icons.no_adult_content,
                           iconDisabled: Icons.no_adult_content,
                           onToggle: (bool value) => setPreferences('setting_general_hide_nsfw_previews', value),
+                        ),
+                        ToggleOption(
+                          description: '2-column Tablet Mode',
+                          value: tabletMode,
+                          iconEnabled: Icons.view_comfortable_rounded,
+                          iconDisabled: Icons.view_agenda,
+                          onToggle: (bool value) => setPreferences('setting_post_tablet_mode', value),
                         ),
                         ListOption(
                           description: 'Default Comment Sort Type',

--- a/lib/thunder/bloc/thunder_bloc.dart
+++ b/lib/thunder/bloc/thunder_bloc.dart
@@ -87,6 +87,7 @@ class ThunderBloc extends Bloc<ThunderEvent, ThunderState> {
       bool hideNsfwPreviews = prefs.getBool('setting_general_hide_nsfw_previews') ?? true;
       bool bottomNavBarSwipeGestures = prefs.getBool('setting_general_enable_swipe_gestures') ?? true;
       bool bottomNavBarDoubleTapGestures = prefs.getBool('setting_general_enable_doubletap_gestures') ?? false;
+      bool tabletMode = prefs.getBool('setting_post_tablet_mode') ?? false;
       CommentSortType defaultCommentSortType = CommentSortType.values.byName(prefs.getString("setting_post_default_comment_sort_type") ?? DEFAULT_COMMENT_SORT_TYPE.name);
 
       // Links
@@ -137,6 +138,7 @@ class ThunderBloc extends Bloc<ThunderEvent, ThunderState> {
         showSaveAction: showSaveAction,
         showFullHeightImages: showFullHeightImages,
         showEdgeToEdgeImages: showEdgeToEdgeImages,
+        tabletMode: tabletMode,
         showTextContent: showTextContent,
         hideNsfwPreviews: hideNsfwPreviews,
         bottomNavBarSwipeGestures: bottomNavBarSwipeGestures,

--- a/lib/thunder/bloc/thunder_state.dart
+++ b/lib/thunder/bloc/thunder_state.dart
@@ -31,6 +31,7 @@ class ThunderState extends Equatable {
     this.hideNsfwPreviews = true,
     this.bottomNavBarSwipeGestures = true,
     this.bottomNavBarDoubleTapGestures = false,
+    this.tabletMode = false,
 
     // Link Settings
     this.openInExternalBrowser = false,
@@ -94,6 +95,7 @@ class ThunderState extends Equatable {
   final bool hideNsfwPreviews;
   final bool bottomNavBarSwipeGestures;
   final bool bottomNavBarDoubleTapGestures;
+  final bool tabletMode;
 
   // Link Settings
   final bool openInExternalBrowser;
@@ -150,6 +152,7 @@ class ThunderState extends Equatable {
     bool? showEdgeToEdgeImages,
     bool? showTextContent,
     bool? hideNsfwPreviews,
+    bool? tabletMode,
     bool? bottomNavBarSwipeGestures,
     bool? bottomNavBarDoubleTapGestures,
     // Link Settings
@@ -201,6 +204,7 @@ class ThunderState extends Equatable {
       showEdgeToEdgeImages: showEdgeToEdgeImages ?? this.showEdgeToEdgeImages,
       showTextContent: showTextContent ?? this.showTextContent,
       hideNsfwPreviews: hideNsfwPreviews ?? this.hideNsfwPreviews,
+      tabletMode: tabletMode ?? this.tabletMode,
       bottomNavBarSwipeGestures: bottomNavBarSwipeGestures ?? this.bottomNavBarSwipeGestures,
       bottomNavBarDoubleTapGestures: bottomNavBarDoubleTapGestures ?? this.bottomNavBarDoubleTapGestures,
       // Link Settings
@@ -254,6 +258,7 @@ class ThunderState extends Equatable {
         showEdgeToEdgeImages,
         showTextContent,
         hideNsfwPreviews,
+        tabletMode,
         bottomNavBarSwipeGestures,
         bottomNavBarDoubleTapGestures,
         openInExternalBrowser,

--- a/lib/utils/post.dart
+++ b/lib/utils/post.dart
@@ -97,14 +97,15 @@ Future<List<PostViewMedia>> parsePostViews(List<PostView> postViews) async {
   SharedPreferences prefs = UserPreferences.instance.sharedPreferences;
 
   bool fetchImageDimensions = prefs.getBool('setting_general_show_full_height_images') ?? false;
+  bool tabletMode = prefs.getBool('setting_post_tablet_mode') ?? false;
 
-  Iterable<Future<PostViewMedia>> postFutures = postViews.map<Future<PostViewMedia>>((post) => parsePostView(post, fetchImageDimensions));
+  Iterable<Future<PostViewMedia>> postFutures = postViews.map<Future<PostViewMedia>>((post) => parsePostView(post, fetchImageDimensions, tabletMode));
   List<PostViewMedia> posts = await Future.wait(postFutures);
 
   return posts;
 }
 
-Future<PostViewMedia> parsePostView(PostView postView, bool fetchImageDimensions) async {
+Future<PostViewMedia> parsePostView(PostView postView, bool fetchImageDimensions, bool tabletMode) async {
   List<Media> media = [];
   String? url = postView.post.url;
 
@@ -114,8 +115,7 @@ Future<PostViewMedia> parsePostView(PostView postView, bool fetchImageDimensions
 
       if (fetchImageDimensions) {
         Size result = await retrieveImageDimensions(url);
-
-        Size size = MediaExtension.getScaledMediaSize(width: result.width, height: result.height);
+        Size size = MediaExtension.getScaledMediaSize(width: result.width, height: result.height, tabletMode: tabletMode);
         media.add(Media(mediaUrl: url, originalUrl: url, width: size.width, height: size.height, mediaType: mediaType));
       } else {
         media.add(Media(mediaUrl: url, originalUrl: url, mediaType: mediaType));
@@ -135,8 +135,7 @@ Future<PostViewMedia> parsePostView(PostView postView, bool fetchImageDimensions
 
           int mediaHeight = result.height.toInt();
           int mediaWidth = result.width.toInt();
-          Size size = MediaExtension.getScaledMediaSize(width: mediaWidth, height: mediaHeight);
-
+          Size size = MediaExtension.getScaledMediaSize(width: mediaWidth, height: mediaHeight, tabletMode: tabletMode);
           media.add(Media(mediaUrl: linkInfo.imageURL!, mediaType: MediaType.link, originalUrl: url, height: size.height, width: size.width));
         } else {
           media.add(Media(mediaUrl: linkInfo.imageURL!, mediaType: MediaType.link, originalUrl: url));

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -72,6 +72,7 @@ dependencies:
   path_provider: ^2.0.15
   intl: ^0.18.1
   device_info_plus: ^9.0.2
+  flutter_staggered_grid_view: ^0.6.2
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
Fist major steps to: https://github.com/hjiangsu/thunder/issues/138

Uses a `MasonryGridView`, which is based on `GridView`, which has the same caching features as `ListView`, but allows for multi-column display. There is a toggle in settings for it.

Once this makes it's way to release, I'll try it out on a few tablets I have access to to confirm cell-spacing looks good in 2-column mode across the board.

![Screenshot_1688680782](https://github.com/hjiangsu/thunder/assets/971474/b6f910a5-4250-48f0-adb1-461f9c740d8e)
