### PR TITLE
Improve vote indicator apparance in post feed

### DIFF
--- a/lib/community/widgets/post_card_metadata.dart
+++ b/lib/community/widgets/post_card_metadata.dart
@@ -48,13 +48,19 @@ class PostCardMetaData extends StatelessWidget {
                 IconText(
                   textScaleFactor: state.contentFontSizeScale.textScaleFactor,
                   text: formatNumberToK(score),
-                  icon: Icon(Icons.arrow_upward,
+                  textColor: voteType == VoteType.up
+                    ? upVoteColor
+                    : voteType == VoteType.down
+                      ? downVoteColor
+                      : theme.textTheme.titleSmall?.color?.withOpacity(0.9),
+                  icon: Icon( voteType == VoteType.down ? Icons.arrow_downward : Icons.arrow_upward,
                       size: 18.0,
                       color: voteType == VoteType.up
                           ? upVoteColor
                           : voteType == VoteType.down
                               ? downVoteColor
-                              : theme.textTheme.titleSmall?.color?.withOpacity(0.75)),
+                              : theme.textTheme.titleSmall?.color?.withOpacity(0.75)
+                  ),
                   padding: 2.0,
                 ),
                 const SizedBox(width: 12.0),
@@ -66,6 +72,7 @@ class PostCardMetaData extends StatelessWidget {
                     color: theme.textTheme.titleSmall?.color?.withOpacity(0.75),
                   ),
                   text: formatNumberToK(comments),
+                  textColor: theme.textTheme.titleSmall?.color?.withOpacity(0.9),
                   padding: 5.0,
                 ),
                 const SizedBox(width: 10.0),
@@ -77,6 +84,7 @@ class PostCardMetaData extends StatelessWidget {
                     color: theme.textTheme.titleSmall?.color?.withOpacity(0.75),
                   ),
                   text: formatTimeToString(dateTime: published.toIso8601String()),
+                  textColor: theme.textTheme.titleSmall?.color?.withOpacity(0.9),
                 ),
                 const SizedBox(width: 14.0),
                 if (distinguised)

--- a/lib/shared/icon_text.dart
+++ b/lib/shared/icon_text.dart
@@ -19,7 +19,6 @@ class IconText extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final theme = Theme.of(context);
 
     return Row(
       children: [
@@ -28,7 +27,9 @@ class IconText extends StatelessWidget {
         Text(
           text,
           textScaleFactor: textScaleFactor,
-          style: theme.textTheme.bodyMedium?.copyWith(fontSize: theme.textTheme.bodyMedium!.fontSize! * 0.95),
+          style: TextStyle(
+            color: textColor,
+          ),
         ),
       ],
     );


### PR DESCRIPTION
![image](https://github.com/hjiangsu/thunder/assets/4365015/b2bc0aec-b084-4219-af56-589efe3a553b)

This change makes the up/down vote color affect the text of the indicator in post view, as well as the arrow.
The arrow now also flips for posts you've downvoted.

FYI, I removed some code on line 31 in `lib/shared/icon_text.dart` in order to make my changes, I am unsure what it did, but nothing seems to have broken?