### PR TITLE
Fix uppercase image dimensions

### DIFF
--- a/lib/utils/image.dart
+++ b/lib/utils/image.dart
@@ -30,9 +30,12 @@ Future<Size> retrieveImageDimensions(String imageUrl) async {
     bool isImage = isImageUrl(imageUrl);
     if (!isImage) throw Exception('The URL provided was not an image');
 
+    final uri = Uri.parse(imageUrl);
+    final path = uri.path.toLowerCase();
+
     // We'll just retrieve the first part of the image
     final rangeResponse = await http.get(
-      Uri.parse(imageUrl),
+      uri,
       headers: {'Range': 'bytes=0-1000'},
     );
 
@@ -40,13 +43,13 @@ Future<Size> retrieveImageDimensions(String imageUrl) async {
     final imageData = rangeResponse.bodyBytes;
 
     // Get the image dimensions
-    if (imageUrl.endsWith('jpg') || imageUrl.endsWith('jpeg')) {
+    if (path.endsWith('jpg') || path.endsWith('jpeg')) {
       return getJPEGImageDimensions(imageData);
     }
-    if (imageUrl.endsWith('gif')) {
+    if (path.endsWith('gif')) {
       return getGIFImageDimensions(imageData);
     }
-    if (imageUrl.endsWith('png')) {
+    if (path.endsWith('png')) {
       return getPNGImageDimensions(imageData);
     }
   } catch (e) {

--- a/lib/utils/post.dart
+++ b/lib/utils/post.dart
@@ -97,14 +97,15 @@ Future<List<PostViewMedia>> parsePostViews(List<PostView> postViews) async {
   SharedPreferences prefs = UserPreferences.instance.sharedPreferences;
 
   bool fetchImageDimensions = prefs.getBool('setting_general_show_full_height_images') ?? false;
+  bool edgeToEdgeImages = prefs.getBool('setting_general_show_edge_to_edge_images') ?? false;
 
-  Iterable<Future<PostViewMedia>> postFutures = postViews.map<Future<PostViewMedia>>((post) => parsePostView(post, fetchImageDimensions));
+  Iterable<Future<PostViewMedia>> postFutures = postViews.map<Future<PostViewMedia>>((post) => parsePostView(post, fetchImageDimensions, edgeToEdgeImages));
   List<PostViewMedia> posts = await Future.wait(postFutures);
 
   return posts;
 }
 
-Future<PostViewMedia> parsePostView(PostView postView, bool fetchImageDimensions) async {
+Future<PostViewMedia> parsePostView(PostView postView, bool fetchImageDimensions, bool edgeToEdgeImages) async {
   List<Media> media = [];
   String? url = postView.post.url;
 
@@ -115,7 +116,7 @@ Future<PostViewMedia> parsePostView(PostView postView, bool fetchImageDimensions
       if (fetchImageDimensions) {
         Size result = await retrieveImageDimensions(url);
 
-        Size size = MediaExtension.getScaledMediaSize(width: result.width, height: result.height);
+        Size size = MediaExtension.getScaledMediaSize(width: result.width, height: result.height, offset: edgeToEdgeImages ? 0 : 24);
         media.add(Media(mediaUrl: url, originalUrl: url, width: size.width, height: size.height, mediaType: mediaType));
       } else {
         media.add(Media(mediaUrl: url, originalUrl: url, mediaType: mediaType));
@@ -135,8 +136,7 @@ Future<PostViewMedia> parsePostView(PostView postView, bool fetchImageDimensions
 
           int mediaHeight = result.height.toInt();
           int mediaWidth = result.width.toInt();
-          Size size = MediaExtension.getScaledMediaSize(width: mediaWidth, height: mediaHeight);
-
+          Size size = MediaExtension.getScaledMediaSize(width: mediaWidth, height: mediaHeight, offset: edgeToEdgeImages ? 0 : 24);
           media.add(Media(mediaUrl: linkInfo.imageURL!, mediaType: MediaType.link, originalUrl: url, height: size.height, width: size.width));
         } else {
           media.add(Media(mediaUrl: linkInfo.imageURL!, mediaType: MediaType.link, originalUrl: url));


### PR DESCRIPTION
This fixes a bug where the URI was not parsed to lowercase before checking extensions to parse image dimensions.

Also, the static offset of 24 that allows for the curves on image corners was causing issues with cropping on edge-to-edge images, so I fixed that. For optimization reasons I did not have it clear the cache if someone changes the setting, so if they swap back/forth previously loaded images will continue to have the crop (or no curved corners if they swap back) until an image reloads.