### PR TITLE
Show collapsed comment count

### DIFF
--- a/lib/post/widgets/comment_card.dart
+++ b/lib/post/widgets/comment_card.dart
@@ -233,7 +233,7 @@ class _CommentCardState extends State<CommentCard> with SingleTickerProviderStat
                       crossAxisAlignment: CrossAxisAlignment.start,
                       mainAxisAlignment: MainAxisAlignment.start,
                       children: [
-                        CommentHeader(commentViewTree: widget.commentViewTree, isOwnComment: isOwnComment),
+                        CommentHeader(commentViewTree: widget.commentViewTree, isOwnComment: isOwnComment, isHidden: isHidden),
                         AnimatedSwitcher(
                           duration: const Duration(milliseconds: 130),
                           switchInCurve: Curves.easeInOut,

--- a/lib/post/widgets/comment_header.dart
+++ b/lib/post/widgets/comment_header.dart
@@ -11,17 +11,21 @@ import 'package:thunder/utils/numbers.dart';
 class CommentHeader extends StatelessWidget {
   final CommentViewTree commentViewTree;
   final bool isOwnComment;
+  final bool isHidden;
 
   const CommentHeader({
     super.key,
     required this.commentViewTree,
     this.isOwnComment = false,
+    this.isHidden = false,
   });
 
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
     final ThunderState state = context.read<ThunderBloc>().state;
+
+    bool collapseParentCommentOnGesture = state.collapseParentCommentOnGesture;
 
     VoteType? myVote = commentViewTree.comment?.myVote;
     bool? saved = commentViewTree.comment?.saved;
@@ -61,10 +65,26 @@ class CommentHeader extends StatelessWidget {
           ),
           Row(
             children: [
+              Container(
+                decoration: BoxDecoration(
+                  color: theme.colorScheme.primaryContainer,
+                  borderRadius: const BorderRadius.all(Radius.elliptical(5, 5))
+                ),
+                child: isHidden && (collapseParentCommentOnGesture || commentViewTree.replies.isNotEmpty)
+                  ? Padding(
+                      padding: const EdgeInsets.only(left: 5, right: 5),
+                      child: Text(
+                        '+${commentViewTree.replies.length}',
+                        textScaleFactor: state.contentFontSizeScale.textScaleFactor,
+                      ),
+                    )
+                  : Container(),
+              ),
+              const SizedBox(width: 8.0),
               Icon(
                 saved == true ? Icons.star_rounded : null,
                 color: saved == true ? Colors.purple : null,
-                size: 18.0,
+                size: saved == true ? 18.0 : 0,
               ),
               const SizedBox(width: 8.0),
               Text(


### PR DESCRIPTION
This PR introduces the feature suggested in #190. It accomplishes two goals: (1) to indicate when parents whose contents are hidden have collapsed children, and (2) to show how many child comments there are.

### Notes

- The UI is heavily inspired by Relay.
- I chose to show the count of top-level children only because (a) there was easy access to this value in code without a recursive count and (b) it matches the behavior of Relay.
- Small downside: the width of the publication time may vary, causing the count to have different y-axis placement on different comments. However, this is the same behavior as the star, so maybe not a big deal.
- When we allow the parent comment to be hidden, I show the number (even if it's 0). I'm not sure whether we need this, since there is a clear UI indication that the parent comment is collapsed, but it still may be nice to know that there are no children. In the mode where the parent does not collapsed, I don't show anything on press because nothing else changes.

### Demo

#### Light mode / do not hide parent commend on collapse (video)

https://github.com/hjiangsu/thunder/assets/7417301/2250427c-b21c-4694-8969-0c0be8ddeb5d

#### Dark mode (screenshot)

| ![image](https://github.com/hjiangsu/thunder/assets/7417301/558f6f9b-e037-4f61-88c0-4399aeaccf80) |
| - |

#### Dark mode / hide parent comment on collapse (screenshot)

| ![image](https://github.com/hjiangsu/thunder/assets/7417301/cc896559-8238-43c2-991e-551349595575) |
| - |

---

P.S. There is still a small "issue" where the collapsed state of comments is not remembered. This is not new with my change, and has been logged in #204.