### PR TITLE
#249 Fixed comments not all showing on User page.

### DIFF
--- a/lib/user/bloc/user_bloc.dart
+++ b/lib/user/bloc/user_bloc.dart
@@ -87,7 +87,7 @@ class UserBloc extends Bloc<UserEvent, UserState> {
             List<PostViewMedia> posts = await parsePostViews(fullPersonView?.posts ?? []);
 
             // Build the tree view from the flattened comments
-            List<CommentViewTree> commentTree = buildCommentViewTree(fullPersonView?.comments ?? []);
+            List<CommentViewTree> commentTree = buildCommentViewTree(fullPersonView?.comments ?? [], flatten: true);
 
             return emit(
               state.copyWith(
@@ -128,7 +128,7 @@ class UserBloc extends Bloc<UserEvent, UserState> {
           postViewMedias.addAll(posts);
 
           // Build the tree view from the flattened comments
-          List<CommentViewTree> commentTree = buildCommentViewTree(fullPersonView.comments ?? []);
+          List<CommentViewTree> commentTree = buildCommentViewTree(fullPersonView.comments ?? [], flatten: true);
 
           // Append the new comments
           List<CommentViewTree> commentViewTree = List.from(state.comments);
@@ -191,7 +191,7 @@ class UserBloc extends Bloc<UserEvent, UserState> {
             List<PostViewMedia> posts = await parsePostViews(fullPersonView?.posts ?? []);
 
             // Build the tree view from the flattened comments
-            List<CommentViewTree> commentTree = buildCommentViewTree(fullPersonView?.comments ?? []);
+            List<CommentViewTree> commentTree = buildCommentViewTree(fullPersonView?.comments ?? [], flatten: true);
 
             return emit(
               state.copyWith(
@@ -231,7 +231,7 @@ class UserBloc extends Bloc<UserEvent, UserState> {
           postViewMedias.addAll(posts);
 
           // Build the tree view from the flattened comments
-          List<CommentViewTree> commentTree = buildCommentViewTree(fullPersonView.comments ?? []);
+          List<CommentViewTree> commentTree = buildCommentViewTree(fullPersonView.comments ?? [], flatten: true);
 
           // Append the new comments
           List<CommentViewTree> commentViewTree = List.from(state.savedComments);

--- a/lib/utils/comment.dart
+++ b/lib/utils/comment.dart
@@ -64,7 +64,7 @@ Future<CommentView> saveComment(int commentId, bool save) async {
   return updatedCommentView;
 }
 
-List<CommentViewTree> buildCommentViewTree(List<CommentView> comments) {
+List<CommentViewTree> buildCommentViewTree(List<CommentView> comments, {bool flatten = false}) {
   Map<String, CommentViewTree> commentMap = {};
 
   // Create a map of CommentView objects using the comment path as the key
@@ -75,6 +75,10 @@ List<CommentViewTree> buildCommentViewTree(List<CommentView> comments) {
       replies: [],
       level: commentView.comment.path.split('.').length - 2,
     );
+  }
+
+  if (flatten) {
+    return commentMap.values.toList();
   }
 
   // Build the tree structure by assigning children to their parent comments


### PR DESCRIPTION
Bug Fix: https://github.com/hjiangsu/thunder/issues/249

`comment.buildCommentViewTree()` can now optionally return comments flattened so that we get a simple list to show on User page.

