### PR TITLE
Update post_card_view_comfortable.dart to match compact view styling

### DIFF
--- a/lib/community/widgets/post_card_view_comfortable.dart
+++ b/lib/community/widgets/post_card_view_comfortable.dart
@@ -124,7 +124,7 @@ class PostCardViewComfortable extends StatelessWidget {
                           textScaleFactor: state.contentFontSizeScale.textScaleFactor,
                           style: theme.textTheme.titleSmall?.copyWith(
                             fontSize: theme.textTheme.titleSmall!.fontSize! * 1.05,
-                            color: postViewMedia.postView.read ? theme.textTheme.titleSmall?.color?.withOpacity(0.4) : null,
+                            color: postViewMedia.postView.read ? theme.textTheme.titleSmall?.color?.withOpacity(0.4) : theme.textTheme.titleSmall?.color?.withOpacity(0.75),
                           ),
                         ),
                         onTap: () => onTapCommunityName(context, postViewMedia.postView.community.id),


### PR DESCRIPTION
Update post_card_view_comfortable.dart to have the font colors of unread posts more closely match compact mode (see issue #223). If it works, then this:
![image](https://github.com/machinaeZER0/thunder/assets/3624023/d989ead4-8064-4ee9-8a07-59757cb6cb8c)

Should now match this:
![InkedScreenshot_20230704-082754](https://github.com/machinaeZER0/thunder/assets/3624023/3569d568-21c5-4121-9250-29099ca12a02)

The goal being to standardize font color across views, and to help the post titles "pop" more as you scroll.

**IMPORTANT: I am not a coder!** Just a fan :) I don't currently know where to begin in terms of compiling code in order to test this change, so apologies if this either doesn't work or has some unintended consequence.

Looking at post_card_view_compact.dart and post_card_view_comfortable.dart side by side, it looked like this was the value governing the color of at least the community and instance names, so I've updated the line in the latter to more closely match the former. Pretty elegant that this color change seems to be based on opacity levels, as it means it gives the intended effect across light and dark modes. Clever!

Please take a look at your convenience and let me know if this even works, lol. Thank you to @CTalvio for showing me where to start digging (and for everyone's help as I learn how GitHub actually works)!