### PR TITLE
Fix exit confirmation theming

### DIFF
--- a/lib/thunder/pages/thunder_page.dart
+++ b/lib/thunder/pages/thunder_page.dart
@@ -102,7 +102,7 @@ class _ThunderState extends State<Thunder> {
     ScaffoldMessenger.of(context).showSnackBar(
       SnackBar(
         behavior: SnackBarBehavior.floating,
-        backgroundColor: theme.dividerColor,
+        backgroundColor: theme.primaryColorDark,
         width: 190,
         duration: const Duration(milliseconds: 3500),
         content: const Center(child: Text('Press back twice to exit', style: snackBarTextColor)),


### PR DESCRIPTION
This is just a tiny fix on top of #245. In light mode, the snackbar is hard to read.

### Before

| ![image](https://github.com/hjiangsu/thunder/assets/7417301/41856cca-2d21-4096-a61b-6c09aa3ceaed) |
| - |

By changing the background color, the foreground (hard-coded as white) looks fine on both modes.

### After

| ![image](https://github.com/hjiangsu/thunder/assets/7417301/a5d389bc-027a-4751-a738-ff95bc907711) |
| - |

And dark still looks good.

| ![image](https://github.com/hjiangsu/thunder/assets/7417301/4407d543-47db-46a6-abb1-eeebd44ad7b5) |
| - |
