### PR TITLE
Clean up subscription actions

### DIFF
--- a/lib/community/bloc/community_bloc.dart
+++ b/lib/community/bloc/community_bloc.dart
@@ -336,12 +336,29 @@ class CommunityBloc extends Bloc<CommunityEvent, CommunityState> {
         follow: event.follow,
       ));
 
-      return emit(state.copyWith(
+      emit(state.copyWith(
         status: CommunityStatus.success,
         communityId: state.communityId,
         listingType: state.listingType,
         communityName: state.communityName,
         subscribedType: communityView.subscribed,
+      ));
+
+      await Future.delayed(const Duration(seconds: 1));
+
+      // Update the community details again in case the subscribed type changed
+      final fullCommunityView = await lemmy.run(GetCommunity(
+        auth: account.jwt,
+        id: event.communityId,
+        name: state.communityName,
+      ));
+
+      return emit(state.copyWith(
+        status: CommunityStatus.success,
+        communityId: state.communityId,
+        listingType: state.listingType,
+        communityName: state.communityName,
+        subscribedType: fullCommunityView.communityView.subscribed,
       ));
     } catch (e, s) {
       await Sentry.captureException(e, stackTrace: s);

--- a/lib/community/pages/community_page.dart
+++ b/lib/community/pages/community_page.dart
@@ -106,9 +106,20 @@ class _CommunityPageState extends State<CommunityPage> with AutomaticKeepAliveCl
                     if ((state.communityId != null || state.communityName != null) && isUserLoggedIn)
                       IconButton(
                         icon: Icon(
-                          (state.subscribedType == SubscribedType.notSubscribed || state.subscribedType == null) ? Icons.library_add_check_outlined : Icons.library_add_check_rounded,
+                          switch (state.subscribedType) {
+                            SubscribedType.notSubscribed => Icons.add_circle_outline_rounded,
+                            SubscribedType.pending => Icons.pending_outlined,
+                            SubscribedType.subscribed => Icons.remove_circle_outline_rounded,
+                            _ => Icons.add_circle_outline_rounded,
+                          },
                           semanticLabel: (state.subscribedType == SubscribedType.notSubscribed || state.subscribedType == null) ? 'Subscribe' : 'Unsubscribe',
                         ),
+                        tooltip: switch (state.subscribedType) {
+                          SubscribedType.notSubscribed => 'Subscribe',
+                          SubscribedType.pending => 'Unsubscribe (subscription pending)',
+                          SubscribedType.subscribed => 'Unsubscribe',
+                          _ => null,
+                        },
                         onPressed: () {
                           HapticFeedback.mediumImpact();
                           context.read<CommunityBloc>().add(

--- a/lib/search/pages/search_page.dart
+++ b/lib/search/pages/search_page.dart
@@ -157,31 +157,35 @@ class _SearchPageState extends State<SearchPage> {
                 ]),
                 trailing: isUserLoggedIn
                     ? IconButton(
-                        onPressed: communityView.subscribed == SubscribedType.pending
-                            ? null
-                            : () {
-                                context.read<SearchBloc>().add(
-                                      ChangeCommunitySubsciptionStatusEvent(
-                                        communityId: communityView.community.id,
-                                        follow: communityView.subscribed == SubscribedType.notSubscribed ? true : false,
-                                      ),
-                                    );
-                                SnackBar snackBar = SnackBar(
-                                  content: Text('${communityView.subscribed == SubscribedType.notSubscribed ? 'Added' : 'Removed'} community to subscriptions'),
-                                  behavior: SnackBarBehavior.floating,
-                                );
-                                WidgetsBinding.instance.addPostFrameCallback((timeStamp) {
-                                  ScaffoldMessenger.of(context).clearSnackBars();
-                                  ScaffoldMessenger.of(context).showSnackBar(snackBar);
-                                });
-                              },
+                        onPressed:
+                            () {
+                              context.read<SearchBloc>().add(
+                                    ChangeCommunitySubsciptionStatusEvent(
+                                      communityId: communityView.community.id,
+                                      follow: communityView.subscribed == SubscribedType.notSubscribed ? true : false,
+                                    ),
+                                  );
+                              SnackBar snackBar = SnackBar(
+                                content: Text('${communityView.subscribed == SubscribedType.notSubscribed ? 'Added' : 'Removed'} community ${communityView.subscribed == SubscribedType.notSubscribed ? 'to' : 'from'} subscriptions'),
+                                behavior: SnackBarBehavior.floating,
+                              );
+                              WidgetsBinding.instance.addPostFrameCallback((timeStamp) {
+                                ScaffoldMessenger.of(context).clearSnackBars();
+                                ScaffoldMessenger.of(context).showSnackBar(snackBar);
+                              });
+                            },
                         icon: Icon(
                           switch (communityView.subscribed) {
-                            SubscribedType.notSubscribed => Icons.add,
-                            SubscribedType.pending => Icons.pending_rounded,
-                            SubscribedType.subscribed => Icons.remove,
+                            SubscribedType.notSubscribed => Icons.add_circle_outline_rounded,
+                            SubscribedType.pending => Icons.pending_outlined,
+                            SubscribedType.subscribed => Icons.remove_circle_outline_rounded,
                           },
                         ),
+                        tooltip: switch (communityView.subscribed) {
+                          SubscribedType.notSubscribed => 'Subscribe',
+                          SubscribedType.pending => 'Unsubscribe (subscription pending)',
+                          SubscribedType.subscribed => 'Unsubscribe',
+                        },
                         visualDensity: VisualDensity.compact,
                       )
                     : null,


### PR DESCRIPTION
This PR adds the following:

1. Unify the subscription icons between the search and community pages (and show all three possible states on the community page).
2. Show a tooltip describing the subscription action/state.
3. Allow unsubscribing while pending from the search page.
4. Some subscription requests return pending but go through very quickly. To handle this case, we refresh the subscription status briefly after subscribing. (This seems most common when subscribing cross-instance.)
5. Fix wording of add/remove message.


### Notes
 - For 1: I am totally open to feedback on the icons as long as they can be shared between both views and can indicate all three states.
 - For 2: I debated whether the tooltip should show the status (current subscription) or the action (what will happen when pressed). I went with the latter except in the case of the pending which shows both. Again I'm flexible here.
 - For 4: This is a hacky workaround and maybe we're just accounting for a Lemmy backend bug, in which case I'd be fine with removing this.

---

### Demos

#### Demo 1 -- Search page subscribe (delayed) and unsubscribe

https://github.com/hjiangsu/thunder/assets/7417301/7cf1c482-113f-4deb-b40d-3dfea29218a0

#### Demo 2 -- Community page subscribe (delayed) and unsunscribe

https://github.com/hjiangsu/thunder/assets/7417301/b3bb789b-5fa4-4b17-acd0-2c5d1149ef2e

#### Demo 3 -- Search page subscribe (instant) and unsubscribe

https://github.com/hjiangsu/thunder/assets/7417301/69c05aa0-db4a-430e-89f2-1c941764857a

#### Demo 4 -- Community page subscribe (instant) and unsubscribe

https://github.com/hjiangsu/thunder/assets/7417301/c6010953-5ad8-4a04-8b61-1f919e8c788b

#### Demo 5 -- Community page subscribe (pending) and unsubscribe

https://github.com/hjiangsu/thunder/assets/7417301/e5180836-4ff0-4aaf-b136-41aed18b5275

#### Demo 6 -- Community page subscribe (pending) and unsubscribe

https://github.com/hjiangsu/thunder/assets/7417301/2c441aac-066c-4510-b05c-884683e6ab69