### PR TITLE
Show instance icons

### DIFF
--- a/lib/account/pages/login_page.dart
+++ b/lib/account/pages/login_page.dart
@@ -107,9 +107,14 @@ class _LoginPageState extends State<LoginPage> {
             mainAxisAlignment: MainAxisAlignment.start,
             crossAxisAlignment: CrossAxisAlignment.center,
             children: [
-              Container(
-                child: instanceIcon == null 
-                  ? Image.asset('assets/logo.png', width: 80.0, height: 80.0)
+              AnimatedCrossFade(
+                duration: const Duration(milliseconds: 500),
+                crossFadeState: instanceIcon == null
+                  ? CrossFadeState.showFirst
+                  : CrossFadeState.showSecond,
+                firstChild: Image.asset('assets/logo.png', width: 80.0, height: 80.0),
+                secondChild: instanceIcon == null
+                  ? Container()
                   : CircleAvatar(
                       foregroundImage: CachedNetworkImageProvider(instanceIcon!),
                       backgroundColor: Colors.transparent,

--- a/lib/utils/instance.dart
+++ b/lib/utils/instance.dart
@@ -1,3 +1,5 @@
+import 'package:lemmy_api_client/v3.dart';
+
 String? fetchInstanceNameFromUrl(String? url) {
   if (url == null) {
     return null;
@@ -21,4 +23,18 @@ String? checkLemmyInstanceUrl(String text) {
   if (text.contains('@')) return text;
   if (text.contains('/c/')) return generateCommunityInstanceUrl(text);
   return null;
+}
+
+Future<String?> getInstanceIcon(String? url) async {
+  if (url?.isEmpty ?? true) {
+    return null;
+  }
+
+  try {
+    final site = await LemmyApiV3(url!).run(const GetSite());
+    return site.siteView?.site.icon;
+  } catch (e) {
+    // Bad instances will throw an exception, so no icon
+    return null;
+  }
 }


### PR DESCRIPTION
This PR adds the following items related to instance icons.

- Decreased size of icon above login fields.
- Show instance icon after entering instance URL.
- Add more suggestions to instance hint (so not everyone uses lemmy.ml).
- Moved instance field to top of login page (this may be controversial, but it makes sense to me; username/password is meaningless without the instance, plus you see the icon sooner).
- Show instance icons in profile switcher (we may prefer profile icons, not sure).

#### Notes
- We lose the yellow person indicator for the active account, but we already have an active text field to indicate that.
- I didn't put a solid color behind the instance icons because they generally include transparency and I'm assuming they're generally designed for white/black backgrounds.
- I'm not sure if `AccountExtended` is a good pattern and/or if it should go in a separate file.

### Demo

#### Account Switcher

![image](https://github.com/hjiangsu/thunder/assets/7417301/3705624b-11ae-4152-87c7-c67b5a3e3bf4)

#### Add Account

https://github.com/hjiangsu/thunder/assets/7417301/f798ccb0-8279-47d0-9406-702cb98cd7b0