### PR TITLE
Additional info/icons

### DIFF
--- a/lib/post/widgets/comment_card.dart
+++ b/lib/post/widgets/comment_card.dart
@@ -110,9 +110,8 @@ class _CommentCardState extends State<CommentCard> with SingleTickerProviderStat
 
     final theme = Theme.of(context);
 
-    // Checks for either the same creator id to user id, or the same username
-    final bool isOwnComment = widget.commentViewTree.comment?.creator.id == context.read<AuthBloc>().state.account?.userId ||
-        widget.commentViewTree.comment?.creator.name.toLowerCase() == context.read<AuthBloc>().state.account?.username?.toLowerCase();
+    // Checks for the same creator id to user id
+    final bool isOwnComment = widget.commentViewTree.comment?.creator.id == context.read<AuthBloc>().state.account?.userId;
 
     final bool isUserLoggedIn = context.read<AuthBloc>().state.isLoggedIn;
 

--- a/lib/post/widgets/post_view.dart
+++ b/lib/post/widgets/post_view.dart
@@ -17,6 +17,7 @@ import 'package:thunder/core/models/post_view_media.dart';
 import 'package:thunder/post/bloc/post_bloc.dart';
 import 'package:thunder/shared/media_view.dart';
 import 'package:thunder/user/pages/user_page.dart';
+import 'package:thunder/utils/instance.dart';
 import 'package:thunder/utils/numbers.dart';
 import '../../utils/date_time.dart';
 
@@ -91,11 +92,14 @@ class PostSubview extends StatelessWidget {
                       ),
                     );
                   },
-                  child: Text(
-                    postView.creator.displayName != null && useDisplayNames ? postView.creator.displayName! : postView.creator.name,
-                    textScaleFactor: thunderState.contentFontSizeScale.textScaleFactor,
-                    style: theme.textTheme.bodyMedium?.copyWith(
-                      color: theme.textTheme.bodyMedium?.color?.withOpacity(0.75),
+                  child: Tooltip(
+                    message: '${postView.creator.name}@${fetchInstanceNameFromUrl(postView.creator.actorId) ?? '-'}${fetchUsernameDescriptor(context)}',
+                    child: Text(
+                      postView.creator.displayName != null && useDisplayNames ? postView.creator.displayName! : postView.creator.name,
+                      textScaleFactor: thunderState.contentFontSizeScale.textScaleFactor,
+                      style: theme.textTheme.bodyMedium?.copyWith(
+                        color: theme.textTheme.bodyMedium?.color?.withOpacity(0.75),
+                      ),
                     ),
                   ),
                 ),
@@ -125,11 +129,14 @@ class PostSubview extends StatelessWidget {
                       ),
                     );
                   },
-                  child: Text(
-                    postView.community.name,
-                    textScaleFactor: thunderState.contentFontSizeScale.textScaleFactor,
-                    style: theme.textTheme.bodyMedium?.copyWith(
-                      color: theme.textTheme.bodyMedium?.color?.withOpacity(0.75),
+                  child: Tooltip(
+                    message: '${postView.community.name}@${fetchInstanceNameFromUrl(postView.community.actorId) ?? 'N/A'}',
+                    child: Text(
+                      postView.community.name,
+                      textScaleFactor: thunderState.contentFontSizeScale.textScaleFactor,
+                      style: theme.textTheme.bodyMedium?.copyWith(
+                        color: theme.textTheme.bodyMedium?.color?.withOpacity(0.75),
+                      ),
                     ),
                   ),
                 ),
@@ -284,5 +291,19 @@ class PostSubview extends StatelessWidget {
         ],
       ),
     );
+  }
+
+  String fetchUsernameDescriptor(BuildContext context) {
+    PostView postView = postViewMedia.postView;
+    final bool isOwnPost = postView.creator.id == context.read<AuthBloc>().state.account?.userId;
+
+    String descriptor = '';
+
+    if (isOwnPost) descriptor += 'me';
+    if (postView.creator.admin == true) descriptor += '${descriptor.isNotEmpty ? ', ' : ''}admin';
+
+    if (descriptor.isNotEmpty) descriptor = ' ($descriptor)';
+
+    return descriptor;
   }
 }


### PR DESCRIPTION
In the name of minimalism, I agree with the comments on my issue #200 that we don't have to show more than is necessary by default. However, I still like to have the information accessible quickly, which is where tooltips come in handy. This PR does the following via tooltips:

- Show the full user/instance name on posts and comments (this becomes even more important with display names).
- Show the full community/instance name on posts.

I also wanted to tackle special users. For me, (a) the colors are very subtle and (b) I can't remember what they mean. Therefore I added...
 - Icons for OP, self, and admin.
 - Tooltips to describe this.

Finally, I fixed a "bug" where accounts with identical usernames from different instances could both be identified as the current user.

---

### Demos

https://github.com/hjiangsu/thunder/assets/7417301/02e63e5d-d854-4eb1-9a07-0028092c947f

https://github.com/hjiangsu/thunder/assets/7417301/8e35fbf5-ce5f-42ca-b34c-fc0d8ba9fc24

https://github.com/hjiangsu/thunder/assets/7417301/8f355885-f8df-46f9-b0d8-9808bf110ea3

Can't show the "me" icon without leaking my username, but it's the person icon that we used to see in the account switcher.