### PR TITLE
Feature/instance name

### DIFF
--- a/lib/community/widgets/community_drawer.dart
+++ b/lib/community/widgets/community_drawer.dart
@@ -127,8 +127,14 @@ class _CommunityDrawerState extends State<CommunityDrawer> {
               }).toList(),
             ),
             Padding(
-              padding: const EdgeInsets.fromLTRB(28, 16, 16, 10),
+              padding: const EdgeInsets.fromLTRB(28, 16, 16, 0),
               child: Text('Subscriptions', style: Theme.of(context).textTheme.titleSmall),
+            ),
+            Padding(
+              padding: const EdgeInsets.fromLTRB(28, 0, 16, 10),
+              child: context.read<AuthBloc>().state.account != null
+                ? Text(context.read<AuthBloc>().state.account!.username ?? "-", style: Theme.of(context).textTheme.bodyMedium)
+                : Container(),
             ),
             (status != AccountStatus.success && status != AccountStatus.failure)
                 ? const Padding(

--- a/lib/community/widgets/community_drawer.dart
+++ b/lib/community/widgets/community_drawer.dart
@@ -5,6 +5,7 @@ import 'package:lemmy_api_client/v3.dart';
 import 'package:thunder/account/bloc/account_bloc.dart';
 import 'package:thunder/community/bloc/community_bloc.dart';
 import 'package:thunder/core/auth/bloc/auth_bloc.dart';
+import 'package:thunder/core/singletons/lemmy_client.dart';
 import 'package:thunder/utils/instance.dart';
 
 class Destination {
@@ -101,8 +102,12 @@ class _CommunityDrawerState extends State<CommunityDrawer> {
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
             Padding(
-              padding: const EdgeInsets.fromLTRB(28, 16, 16, 10),
+              padding: const EdgeInsets.fromLTRB(28, 16, 16, 0),
               child: Text('Feeds', style: Theme.of(context).textTheme.titleSmall),
+            ),
+            Padding(
+              padding: const EdgeInsets.fromLTRB(28, 0, 16, 10),
+              child: Text(LemmyClient.instance.lemmyApiV3.host, style: Theme.of(context).textTheme.bodyMedium),
             ),
             Column(
               children: destinations.map((Destination destination) {


### PR DESCRIPTION
This is just a tiny fix which adds the current instance name and username in the hamburger menu. It's nice to know the default instance that Thunder chooses for you out of the box, and then once you're logged in, it's nice to remember which account/instance you're on.

#### Logged Out

| ![image](https://github.com/hjiangsu/thunder/assets/7417301/da536d0f-acbb-4139-a565-37c95e282e23) |
| - |

#### Logged In

| ![image](https://github.com/hjiangsu/thunder/assets/7417301/36c58f54-1deb-4fc6-ad65-377adcd92865) |
| - |
