### PR TITLE
Fade comment count

### DIFF
--- a/lib/post/widgets/comment_header.dart
+++ b/lib/post/widgets/comment_header.dart
@@ -111,20 +111,25 @@ class CommentHeader extends StatelessWidget {
           ),
           Row(
             children: [
-              Container(
-                decoration: BoxDecoration(
-                  color: theme.colorScheme.primaryContainer,
-                  borderRadius: const BorderRadius.all(Radius.elliptical(5, 5))
+              AnimatedOpacity(
+                opacity: (isHidden && (collapseParentCommentOnGesture || commentViewTree.replies.isNotEmpty == true))
+                  ? 1
+                  : 0,
+                // Matches the collapse animation
+                duration: const Duration(milliseconds: 130),
+                child: Container(
+                  decoration: BoxDecoration(
+                    color: theme.colorScheme.primaryContainer,
+                    borderRadius: const BorderRadius.all(Radius.elliptical(5, 5)),
+                  ),
+                  child: Padding(
+                    padding: const EdgeInsets.only(left: 5, right: 5),
+                    child: Text(
+                      '+${commentViewTree.replies.length}',
+                      textScaleFactor: state.contentFontSizeScale.textScaleFactor,
+                    ),
+                  ),
                 ),
-                child: isHidden && (collapseParentCommentOnGesture || commentViewTree.replies.isNotEmpty)
-                  ? Padding(
-                      padding: const EdgeInsets.only(left: 5, right: 5),
-                      child: Text(
-                        '+${commentViewTree.replies.length}',
-                        textScaleFactor: state.contentFontSizeScale.textScaleFactor,
-                      ),
-                    )
-                  : Container(),
               ),
               const SizedBox(width: 8.0),
               Icon(


### PR DESCRIPTION
This is a super small PR which animates the collapsed comment count in and out.

Small downside: this requires that the count widget maintain its size/placement. If we ever put anything to the left of it, there will be a gap.

### Demos

https://github.com/hjiangsu/thunder/assets/7417301/2b994f98-dd93-486e-b2f6-3cb45057b8c4

https://github.com/hjiangsu/thunder/assets/7417301/c62418e3-47c0-4c17-98e6-6a582a70dc13