### PR TITLE
make comment indicators use theme via alpha blending

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@
 - Improvements to text post indicator preview - contribution from @micahmo
 - Show taglines with markdown and cycle through all available taglines - contribution from @micahmo
 - Errors blocking users are now shown as toasts - contribution from @micahmo
+- Make comment indicators use colours blended from the current theme - contribution from @tom-james-watson
+
 
 ### Fixed
 - Handle issue where some deferred comments won't load - contribution from @micahmo

--- a/lib/post/widgets/comment_card.dart
+++ b/lib/post/widgets/comment_card.dart
@@ -124,6 +124,10 @@ class _CommentCardState extends State<CommentCard> with SingleTickerProviderStat
     super.dispose();
   }
 
+  Color getColor(ThemeData theme, int level) {
+    return Color.alphaBlend(theme.colorScheme.primary.withOpacity(0.4), colors[level]);
+  }
+
   @override
   Widget build(BuildContext context) {
     VoteType? myVote = widget.commentViewTree.commentView?.myVote;
@@ -160,7 +164,7 @@ class _CommentCardState extends State<CommentCard> with SingleTickerProviderStat
                     color: widget.level == 0 || widget.level == 1
                         ? theme.colorScheme.background
                         : nestedCommentIndicatorColor == NestedCommentIndicatorColor.colorful
-                            ? colors[((widget.level - 2) % 6).toInt()]
+                            ? getColor(theme, ((widget.level - 2) % 6).toInt())
                             : theme.hintColor.withOpacity(0.25),
                   ),
                 )
@@ -310,7 +314,7 @@ class _CommentCardState extends State<CommentCard> with SingleTickerProviderStat
                                   color: widget.level == 0
                                       ? theme.colorScheme.background
                                       : nestedCommentIndicatorColor == NestedCommentIndicatorColor.colorful
-                                          ? colors[((widget.level - 1) % 6).toInt()]
+                                          ? getColor(theme, ((widget.level - 1) % 6).toInt())
                                           : theme.hintColor.withOpacity(0.25),
                                 ),
                               )
@@ -321,7 +325,7 @@ class _CommentCardState extends State<CommentCard> with SingleTickerProviderStat
                                   color: widget.level == 0
                                       ? theme.colorScheme.background
                                       : nestedCommentIndicatorColor == NestedCommentIndicatorColor.colorful
-                                          ? colors[((widget.level - 1) % 6).toInt()]
+                                          ? getColor(theme, ((widget.level - 1) % 6).toInt())
                                           : theme.hintColor,
                                 ),
                               ),
@@ -441,7 +445,7 @@ class _CommentCardState extends State<CommentCard> with SingleTickerProviderStat
                                             left: BorderSide(
                                               width: nestedCommentIndicatorStyle == NestedCommentIndicatorStyle.thick ? 4.0 : 1,
                                               // This is the color of the nested comment indicator for deferred load
-                                              color: nestedCommentIndicatorColor == NestedCommentIndicatorColor.colorful ? colors[((widget.level) % 6).toInt()] : theme.hintColor,
+                                              color: nestedCommentIndicatorColor == NestedCommentIndicatorColor.colorful ? getColor(theme, (widget.level % 6).toInt()) : theme.hintColor,
                                             ),
                                           ),
                                         ),


### PR DESCRIPTION
## Pull Request Description

Changes the post comment indicators from using a list of static colours to instead use alpha blends of those static colours with the current theme's primary colour. This ensures that the colours are more harmonious and fit better into the selected theme.

This change was suggested as part of the discussion on https://github.com/thunder-app/thunder/pull/603.

The affect is fairly subtle - there's a balance between keeping the colours obviously distinct and having them fit the palette of the theme.

## Issue Being Fixed

The current comment indicator colours don't match the selected theme and so stick out a bit.

Issue Number: N/A

## Screenshots / Recordings

<img width="300" alt="image" src="https://github.com/thunder-app/thunder/assets/3852719/10c67ddd-2d6d-4e15-a8f2-c7bdd1eabd7a">

<img width="300" alt="image" src="https://github.com/thunder-app/thunder/assets/3852719/c9c1e6e7-1269-4d18-a942-ab4f6da52743">

<img width="300" alt="image" src="https://github.com/thunder-app/thunder/assets/3852719/a303de68-f058-4a78-b09f-b9e81f70a2e3">

<img width="300" alt="image" src="https://github.com/thunder-app/thunder/assets/3852719/9e71b53f-472d-4174-87c9-de4685544a76">

## Checklist

- [x] Did you update CHANGELOG.md?
- [x] Did you use localized strings where applicable?
- [x] Did you add `semanticLabel`s where applicable for accessibility?
