### PR TITLE
Preserve post page state

### DIFF
--- a/lib/post/bloc/post_bloc.dart
+++ b/lib/post/bloc/post_bloc.dart
@@ -79,6 +79,12 @@ class PostBloc extends Bloc<PostEvent, PostState> {
       _reportCommentEvent,
       transformer: throttleDroppable(throttleDuration),
     );
+    on<UpdateScrollPosition>(
+      _onUpdateScrollPosition,
+    );
+    on<UpdateCollapsedComment>(
+      _onUpdateCollapsedComment,
+    );
   }
 
   /// Fetches the post, along with the initial set of comments
@@ -639,5 +645,15 @@ class PostBloc extends Bloc<PostEvent, PostState> {
     }
 
     return null;
+  }
+
+  void _onUpdateScrollPosition(UpdateScrollPosition event, Emitter<PostState> emit) {
+    return emit(state.copyWith(status: state.status, scrollPosition: event.scrollPosition, didScrollPositionChange: true));
+  }
+
+  void _onUpdateCollapsedComment(UpdateCollapsedComment event, Emitter<PostState> emit) {
+    List<int> collapsedComments = event.collapsed ? (state.collapsedComments.toList()..add(event.commentId)) : (state.collapsedComments.toList()..remove(event.commentId));
+
+    return emit(state.copyWith(status: state.status, collapsedComments: collapsedComments));
   }
 }

--- a/lib/post/bloc/post_event.dart
+++ b/lib/post/bloc/post_event.dart
@@ -88,3 +88,16 @@ class ReportCommentEvent extends PostEvent {
     required this.message,
   });
 }
+
+class UpdateScrollPosition extends PostEvent {
+  final double scrollPosition;
+
+  const UpdateScrollPosition({required this.scrollPosition});
+}
+
+class UpdateCollapsedComment extends PostEvent {
+  final int commentId;
+  final bool collapsed;
+
+  const UpdateCollapsedComment({required this.commentId, required this.collapsed});
+}

--- a/lib/post/bloc/post_state.dart
+++ b/lib/post/bloc/post_state.dart
@@ -35,6 +35,9 @@ class PostState extends Equatable {
     this.navigateCommentIndex = 0,
     this.navigateCommentId = 0,
     this.commentMatches,
+    this.scrollPosition,
+    this.didScrollPositionChange = false,
+    this.collapsedComments = const [],
   });
 
   final PostStatus status;
@@ -74,6 +77,16 @@ class PostState extends Equatable {
   // even if the comment index doesn't change
   final int navigateCommentId;
 
+  /// Saves the position of the user's scrolling while viewing a post
+  final double? scrollPosition;
+
+  /// Whether the scroll position changed. If it did not, we don't want to rebuild.
+  /// This flag just makes it easier to check without having to access both the old and new [scrollPosition].
+  final bool didScrollPositionChange;
+
+  /// Keeps track of which comments should be collapsed. When a comment is collapsed, its child comments are hidden.
+  final List<int> collapsedComments;
+
   PostState copyWith({
     required PostStatus status,
     int? postId,
@@ -98,6 +111,9 @@ class PostState extends Equatable {
     int? navigateCommentIndex,
     int? navigateCommentId,
     List<Comment>? commentMatches,
+    double? scrollPosition,
+    bool? didScrollPositionChange,
+    List<int>? collapsedComments,
   }) {
     return PostState(
       status: status,
@@ -123,6 +139,9 @@ class PostState extends Equatable {
       navigateCommentIndex: navigateCommentIndex ?? 0,
       navigateCommentId: navigateCommentId ?? 0,
       commentMatches: commentMatches ?? this.commentMatches,
+      scrollPosition: scrollPosition ?? this.scrollPosition,
+      didScrollPositionChange: didScrollPositionChange ?? false,
+      collapsedComments: collapsedComments ?? this.collapsedComments,
     );
   }
 
@@ -150,5 +169,8 @@ class PostState extends Equatable {
         navigateCommentIndex,
         navigateCommentId,
         commentMatches,
+        scrollPosition,
+        didScrollPositionChange,
+        collapsedComments,
       ];
 }

--- a/lib/post/pages/post_page.dart
+++ b/lib/post/pages/post_page.dart
@@ -77,9 +77,6 @@ class _PostPageState extends State<PostPage> {
   /// Whether the post source should be displayed.
   bool viewSource = false;
 
-  /// Keeps track of which comments should be collapsed. When a comment is collapsed, its child comments are hidden.
-  List<int> collapsedComments = [];
-
   /// The active account that was selected when the page was opened
   Account? originalUser;
 
@@ -88,6 +85,10 @@ class _PostPageState extends State<PostPage> {
 
   /// The height of the bottom spacer
   double? bottomSpacerHeight;
+
+  /// Whether we have set the initial scroll offset.
+  /// This needs to be done after building so the controller is attached
+  bool hasSetInitialScroll = false;
 
   /// The ID of the comment that should be highlighted
   int? highlightedCommentId;
@@ -105,6 +106,15 @@ class _PostPageState extends State<PostPage> {
       // Fetches new comments when the user has scrolled past 70% list
       if (scrollController.position.pixels > scrollController.position.maxScrollExtent * 0.7 && context.read<PostBloc>().state.status == PostStatus.success) {
         context.read<PostBloc>().add(const GetPostCommentsEvent());
+      }
+
+      context.read<PostBloc>().add(UpdateScrollPosition(scrollPosition: scrollController.position.pixels));
+    });
+
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!hasSetInitialScroll) {
+        hasSetInitialScroll = true;
+        scrollController.jumpTo(context.read<PostBloc>().state.scrollPosition ?? 0.0);
       }
     });
   }
@@ -244,12 +254,19 @@ class _PostPageState extends State<PostPage> {
       },
       child: BlocConsumer<PostBloc, PostState>(
         listener: (context, state) {
+          if (state.didScrollPositionChange) {
+            return;
+          }
+
           if (state.status == PostStatus.success && state.postView != widget.initialPostViewMedia && state.postView != null) {
             if (!userChanged) {
               widget.onPostUpdated?.call(state.postView!);
             }
             setState(() {});
           }
+        },
+        buildWhen: (previous, current) {
+          return !current.didScrollPositionChange;
         },
         builder: (context, state) {
           if (state.status == PostStatus.initial) {
@@ -532,6 +549,8 @@ class _PostPageState extends State<PostPage> {
                             CommentNode commentNode = flattenedComments[index - 1];
                             CommentView commentView = commentNode.commentView!;
 
+                            final List<int> collapsedComments = context.read<PostBloc>().state.collapsedComments;
+
                             bool isCollapsed = collapsedComments.contains(commentView.comment.id);
                             bool isHidden = collapsedComments.any((int id) => commentView.comment.path.contains('$id') && id != commentView.comment.id);
 
@@ -549,12 +568,7 @@ class _PostPageState extends State<PostPage> {
                                 context.read<PostBloc>().add(CommentItemUpdatedEvent(commentView: commentView));
                               },
                               onCollapseCommentChange: (int commentId, bool collapsed) {
-                                if (collapsed) {
-                                  collapsedComments.add(commentId);
-                                } else {
-                                  collapsedComments.remove(commentId);
-                                }
-
+                                context.read<PostBloc>().add(UpdateCollapsedComment(commentId: commentId, collapsed: collapsed));
                                 setState(() {});
                               },
                             );

--- a/lib/utils/navigation.dart
+++ b/lib/utils/navigation.dart
@@ -62,6 +62,8 @@ import 'package:thunder/utils/links.dart';
 import 'package:thunder/utils/swipe.dart';
 import 'package:thunder/post/bloc/post_bloc.dart' as post_bloc;
 
+({String postApId, post_bloc.PostBloc postBloc})? _cachedPostBloc;
+
 /// Navigates to the instance page for the given [instanceHost].
 ///
 /// When [instanceId] is provided, the instance page will allow the option to block that given instance. This value represents
@@ -178,6 +180,14 @@ Future<void> navigateToPost(
   final reduceAnimations = state.reduceAnimations;
   final enableFullScreenSwipeNavigationGesture = state.enableFullScreenSwipeNavigationGesture;
 
+  final post_bloc.PostBloc postBloc = _cachedPostBloc?.postApId == postViewMedia!.postView.post.apId
+      ? _cachedPostBloc!.postBloc
+      : (_cachedPostBloc = (
+          postApId: postViewMedia.postView.post.apId,
+          postBloc: post_bloc.PostBloc(),
+        ))
+          .postBloc;
+
   final route = SwipeablePageRoute(
     transitionDuration: isLoadingPageShown
         ? Duration.zero
@@ -195,13 +205,13 @@ Future<void> navigateToPost(
           BlocProvider.value(value: accountBloc),
           BlocProvider.value(value: authBloc),
           BlocProvider.value(value: thunderBloc),
-          BlocProvider(create: (context) => post_bloc.PostBloc()),
+          BlocProvider.value(value: postBloc),
           BlocProvider(create: (context) => InstanceBloc(lemmyClient: LemmyClient.instance)),
           BlocProvider(create: (context) => CommunityBloc(lemmyClient: LemmyClient.instance)),
           BlocProvider(create: (context) => AnonymousSubscriptionsBloc()),
         ],
         child: PostPage(
-          initialPostViewMedia: pvm!,
+          initialPostViewMedia: postBloc.state.postView ?? pvm!,
           onPostUpdated: (PostViewMedia postViewMedia) {
             // Manually marking the read attribute as true when navigating to post since there is a case where the API call to mark the post as read from the feed page is not completed in time
             feedBloc?.add(FeedItemUpdatedEvent(


### PR DESCRIPTION
## Pull Request Description

This PR aims to preserve the state of the post page when navigating out and back in. This is something I've been wanting for a long time (missing this feature from Relay) and I finally got it working! It's done by preserving the `PostBloc` that is created when we navigate to a post page, as well as moving everything important to the `PostState` that wasn't already there (such as the list of collapsed comments and scroll position) instead of in the widget state.

Notes
* We will only save the most recently opened post, so you can navigate out and back in while preserving the state, but if you navigate to another post, everything will reset.
* I implemented this for both the new and old post pages.

## Issue Being Fixed

<!-- Please describe the problem that is being fixed and, if applicable, reference a GitHub issue -->

Issue Number: #742, #1113

## Screenshots / Recordings

<!-- This section is optional but highly recommended to show off your changes! -->

(Too big for GitHub)

https://files.catbox.moe/p01rwn.mp4

## Checklist

- [ ] If a new package was added, did you ensure it uses an appropriate license and is actively maintained?
- [ ] Did you use localized strings (and added appropriate descriptions) where applicable?
- [ ] Did you add `semanticLabel`s where applicable for accessibility?
