### PR TITLE
Add ability to search for top-level settings pages

### DIFF
--- a/lib/core/enums/local_settings.dart
+++ b/lib/core/enums/local_settings.dart
@@ -13,7 +13,8 @@ enum LocalSettingsCategories {
   about('About'),
   debug('Debug'),
   theming('Theming'),
-  videoPlayer('Video Player');
+  videoPlayer('Video Player'),
+  appearance('Appearance');
 
   final String value;
 
@@ -69,6 +70,25 @@ enum LocalSettingsSubCategories {
 }
 
 enum LocalSettings {
+  /// -------------------------- Setting entries which allow searching for top-level settings pages --------------------------
+  settingsPageGeneral(name: 'settings_page_general', key: 'settingsPageGeneral', category: LocalSettingsCategories.general, subCategory: LocalSettingsSubCategories.general, isPage: true),
+  settingsPageFilters(name: 'settings_page_filters', key: 'settingsPageFilters', category: LocalSettingsCategories.filters, subCategory: LocalSettingsSubCategories.general, isPage: true),
+  settingsPageAppearance(name: 'settings_page_appearance', key: 'settingsPageAppearance', category: LocalSettingsCategories.appearance, subCategory: LocalSettingsSubCategories.general, isPage: true),
+  settingsPageGestures(name: 'settings_page_gestures', key: 'settingsPageGestures', category: LocalSettingsCategories.gestures, subCategory: LocalSettingsSubCategories.general, isPage: true),
+  settingsPageVideo(name: 'settings_page_video', key: 'settingsPageVideo', category: LocalSettingsCategories.videoPlayer, subCategory: LocalSettingsSubCategories.general, isPage: true),
+  settingsPageFloatingActionButton(
+      name: 'settings_page_floating_action_button',
+      key: 'settingsPageFloatingActionButton',
+      category: LocalSettingsCategories.floatingActionButton,
+      subCategory: LocalSettingsSubCategories.general,
+      isPage: true),
+  settingsPageAccessibility(
+      name: 'settings_page_accessibility', key: 'settingsPageAccessibility', category: LocalSettingsCategories.accessibility, subCategory: LocalSettingsSubCategories.general, isPage: true),
+  settingsPageAccount(name: 'settings_page_account', key: 'settingsPageAccount', category: LocalSettingsCategories.account, subCategory: LocalSettingsSubCategories.general, isPage: true),
+  settingsPageUserLabels(name: 'settings_page_user_labels', key: 'settingsPageUserLabels', category: LocalSettingsCategories.userLabels, subCategory: LocalSettingsSubCategories.general, isPage: true),
+  settingsPageAbout(name: 'settings_page_about', key: 'settingsPageAbout', category: LocalSettingsCategories.about, subCategory: LocalSettingsSubCategories.general, isPage: true),
+  settingsPageDebug(name: 'settings_page_debug', key: 'settingsPageDebug', category: LocalSettingsCategories.debug, subCategory: LocalSettingsSubCategories.general, isPage: true),
+
   /// -------------------------- Account Settings --------------------------
   // Discussion Languages
   discussionLanguages(name: 'account_discussion_languages', key: 'discussionLanguages', category: LocalSettingsCategories.account, subCategory: LocalSettingsSubCategories.contentManagement),
@@ -379,6 +399,7 @@ enum LocalSettings {
     required this.subCategory,
     required this.key,
     this.searchable = true,
+    this.isPage = false,
   });
 
   /// The name of the setting as stored in local preferences
@@ -398,6 +419,9 @@ enum LocalSettings {
   /// Whether this setting should appear as a search result
   final bool searchable;
 
+  /// Whether this settings entry represents a whole page of settings
+  final bool isPage;
+
   /// Defines the settings that are excluded from import/export
   static List<LocalSettings> importExportExcludedSettings = [
     LocalSettings.currentAnonymousInstance,
@@ -408,6 +432,17 @@ enum LocalSettings {
 extension LocalizationExt on AppLocalizations {
   String getLocalSettingLocalization(String key) {
     Map<String, String> localizationMap = {
+      'settingsPageDebug': settingsPageDebug,
+      'settingsPageAbout': settingsPageAbout,
+      'settingsPageUserLabels': settingsPageUserLabels,
+      'settingsPageAccount': settingsPageAccount,
+      'settingsPageAccessibility': settingsPageAccessibility,
+      'settingsPageFloatingActionButton': settingsPageFloatingActionButton,
+      'settingsPageVideo': settingsPageVideo,
+      'settingsPageGestures': settingsPageGestures,
+      'settingsPageAppearance': settingsPageAppearance,
+      'settingsPageFilters': settingsPageFilters,
+      'settingsPageGeneral': settingsPageGeneral,
       'defaultFeedType': defaultFeedType,
       'defaultFeedSortType': defaultFeedSortType,
       'hideNsfwPostsFromFeed': hideNsfwPostsFromFeed,

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -2137,6 +2137,54 @@
   "@settingsNotImportedSuccessfully": {
     "description": "Message shown to the user when the settings were imported unsuccessfully"
   },
+  "settingsPage": "Settings Page",
+  "@settingsPage": {
+    "description": "Settings page subtitle for search results"
+  },
+  "settingsPageAbout": "About",
+  "@settingsPageAbout": {
+    "description": "About settings page"
+  },
+  "settingsPageAccessibility": "Accessibility",
+  "@settingsPageAccessibility": {
+    "description": "Accessibility settings page"
+  },
+  "settingsPageAccount": "Account",
+  "@settingsPageAccount": {
+    "description": "Account settings page"
+  },
+  "settingsPageAppearance": "Appearance",
+  "@settingsPageAppearance": {
+    "description": "Appearance settings page"
+  },
+  "settingsPageDebug": "Debug",
+  "@settingsPageDebug": {
+    "description": "Debug settings page"
+  },
+  "settingsPageFilters": "Filters",
+  "@settingsPageFilters": {
+    "description": "Filters settings page"
+  },
+  "settingsPageFloatingActionButton": "Floating Action Button",
+  "@settingsPageFloatingActionButton": {
+    "description": "Floating action button settings page"
+  },
+  "settingsPageGeneral": "General",
+  "@settingsPageGeneral": {
+    "description": "General settings page"
+  },
+  "settingsPageGestures": "Gestures",
+  "@settingsPageGestures": {
+    "description": "Gestures settings page"
+  },
+  "settingsPageUserLabels": "User Labels",
+  "@settingsPageUserLabels": {
+    "description": "User labels settings page"
+  },
+  "settingsPageVideo": "Video",
+  "@settingsPageVideo": {
+    "description": "Video settings page"
+  },
   "share": "Share",
   "@share": {},
   "shareComment": "Share Comment Link",

--- a/lib/settings/pages/settings_page.dart
+++ b/lib/settings/pages/settings_page.dart
@@ -102,8 +102,9 @@ class _SettingsPageState extends State<SettingsPage> {
                     return List<ListTile>.generate(
                       localSettings.length,
                       (index) => ListTile(
-                        subtitle: Text(
-                            "${l10n.getLocalSettingLocalization(localSettings[index].category.toString())}${' > ${l10n.getLocalSettingLocalization(localSettings[index].subCategory.toString())}'}"),
+                        subtitle: Text(localSettings[index].isPage
+                            ? l10n.settingsPage
+                            : "${l10n.getLocalSettingLocalization(localSettings[index].category.toString())}${' > ${l10n.getLocalSettingLocalization(localSettings[index].subCategory.toString())}'}"),
                         onTap: () {
                           controller.closeView(null);
                           controller.clear();

--- a/lib/utils/settings_utils.dart
+++ b/lib/utils/settings_utils.dart
@@ -8,6 +8,8 @@ import 'package:thunder/account/bloc/account_bloc.dart';
 import 'package:thunder/core/auth/bloc/auth_bloc.dart';
 import 'package:thunder/core/enums/local_settings.dart';
 import 'package:thunder/settings/pages/about_settings_page.dart';
+import 'package:thunder/settings/pages/accessibility_settings_page.dart';
+import 'package:thunder/settings/pages/appearance_settings_page.dart';
 import 'package:thunder/settings/pages/comment_appearance_settings_page.dart';
 import 'package:thunder/settings/pages/debug_settings_page.dart';
 import 'package:thunder/settings/pages/filter_settings_page.dart';
@@ -15,6 +17,7 @@ import 'package:thunder/settings/pages/general_settings_page.dart';
 import 'package:thunder/settings/pages/gesture_settings_page.dart';
 import 'package:thunder/settings/pages/post_appearance_settings_page.dart';
 import 'package:thunder/settings/pages/theme_settings_page.dart';
+import 'package:thunder/settings/pages/user_labels_settings_page.dart';
 import 'package:thunder/settings/pages/video_player_settings.dart';
 import 'package:thunder/shared/snackbar.dart';
 import 'package:thunder/thunder/bloc/thunder_bloc.dart';
@@ -38,6 +41,7 @@ void navigateToSetting(BuildContext context, LocalSettings setting) {
         LocalSettingsCategories.debug: SETTINGS_DEBUG_PAGE,
         LocalSettingsCategories.about: SETTINGS_ABOUT_PAGE,
         LocalSettingsCategories.videoPlayer: SETTINGS_VIDEO_PAGE,
+        LocalSettingsCategories.appearance: SETTINGS_APPEARANCE_PAGE,
       }[setting.category] ??
       SETTINGS_GENERAL_PAGE;
 
@@ -86,6 +90,9 @@ void navigateToSetting(BuildContext context, LocalSettings setting) {
             SETTINGS_APPEARANCE_THEMES_PAGE => ThemeSettingsPage(settingToHighlight: setting),
             SETTINGS_DEBUG_PAGE => DebugSettingsPage(settingToHighlight: setting),
             SETTINGS_VIDEO_PAGE => VideoPlayerSettingsPage(settingToHighlight: setting),
+            SETTINGS_USER_LABELS_PAGE => UserLabelSettingsPage(settingToHighlight: setting),
+            SETTINGS_ACCESSIBILITY_PAGE => AccessibilitySettingsPage(settingToHighlight: setting),
+            SETTINGS_APPEARANCE_PAGE => AppearanceSettingsPage(settingToHighlight: setting),
             _ => Container(),
           },
         ),


### PR DESCRIPTION
## Pull Request Description

<!--- Please describe what was changed -->

This PR adds the ability to to search for top-level settings pages.

## Issue Being Fixed

<!-- Please describe the problem that is being fixed and, if applicable, reference a GitHub issue -->

Issue Number: #1662

## Screenshots / Recordings

<!-- This section is optional but highly recommended to show off your changes! -->

https://github.com/user-attachments/assets/acae3871-0f4a-4d34-99f6-0d321982290d

## Checklist

- [ ] If a new package was added, did you ensure it uses an appropriate license and is actively maintained?
- [ ] Did you use localized strings (and added appropriate descriptions) where applicable?
- [ ] Did you add `semanticLabel`s where applicable for accessibility?
