### PR TITLE
Disable Impeller on Android builds

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -16,6 +16,11 @@
         android:requestLegacyExternalStorage="true"
         android:enableOnBackInvokedCallback="false"
         >
+
+        <meta-data
+            android:name="io.flutter.embedding.android.EnableImpeller"
+            android:value="false" />
+      
         <activity
             android:name=".MainActivity"
             android:exported="true"


### PR DESCRIPTION
## Pull Request Description

This PR disables Impeller when building Thunder due to some issues with visual artifacts on certain Android devices. I tested this by building Thunder, but I'm can't verify if it's using Impeller for the built APK.

For reference: https://docs.flutter.dev/perf/impeller#android

<!--- Please describe what was changed -->

## Issue Being Fixed

<!-- Please describe the problem that is being fixed and, if applicable, reference a GitHub issue -->

Issue Number: #1681

## Screenshots / Recordings

<!-- This section is optional but highly recommended to show off your changes! -->

## Checklist

- [ ] If a new package was added, did you ensure it uses an appropriate license and is actively maintained?
- [ ] Did you use localized strings (and added appropriate descriptions) where applicable?
- [ ] Did you add `semanticLabel`s where applicable for accessibility?
