### PR TITLE
Fix comment reply/edit action not working on experimental post page

### DIFF
--- a/lib/post/pages/post_page.dart
+++ b/lib/post/pages/post_page.dart
@@ -9,6 +9,7 @@ import 'package:super_sliver_list/super_sliver_list.dart';
 import 'package:thunder/account/models/account.dart';
 import 'package:thunder/comment/enums/comment_action.dart';
 import 'package:thunder/comment/models/comment_node.dart';
+import 'package:thunder/comment/utils/navigate_comment.dart';
 import 'package:thunder/comment/widgets/comment_card.dart';
 import 'package:thunder/core/auth/bloc/auth_bloc.dart';
 import 'package:thunder/core/models/post_view_media.dart';
@@ -232,7 +233,18 @@ class _PostPageState extends State<PostPage> {
                               onVoteAction: (int commentId, int voteType) => context.read<PostBloc>().add(CommentActionEvent(commentId: commentId, action: CommentAction.vote, value: voteType)),
                               onSaveAction: (int commentId, bool saved) => context.read<PostBloc>().add(CommentActionEvent(commentId: commentId, action: CommentAction.save, value: saved)),
                               onDeleteAction: (int commentId, bool deleted) => context.read<PostBloc>().add(CommentActionEvent(commentId: commentId, action: CommentAction.delete, value: deleted)),
-                              onReplyEditAction: (CommentView commentView, bool isEdit) async => context.read<PostBloc>().add(CommentItemUpdatedEvent(commentView: commentView)),
+                              onReplyEditAction: (CommentView commentView, bool isEdit) {
+                                navigateToCreateCommentPage(
+                                  context,
+                                  commentView: isEdit ? commentView : null,
+                                  parentCommentView: isEdit ? null : commentView,
+                                  onCommentSuccess: (commentView, userChanged) {
+                                    if (!userChanged) {
+                                      context.read<PostBloc>().add(CommentItemUpdatedEvent(commentView: commentView));
+                                    }
+                                  },
+                                );
+                              },
                               onCollapseCommentChange: (int commentId, bool collapsed) {
                                 if (collapsed) {
                                   collapsedComments.add(commentId);


### PR DESCRIPTION
## Pull Request Description

This PR fixes an issue where the comment reply/edit bottom sheet action was not triggering properly on the experimental post page.

<!--- Please describe what was changed -->

## Issue Being Fixed

<!-- Please describe the problem that is being fixed and, if applicable, reference a GitHub issue -->

Issue Number: https://lemmy.world/comment/14933382

## Screenshots / Recordings

<!-- This section is optional but highly recommended to show off your changes! -->

## Checklist

- [ ] If a new package was added, did you ensure it uses an appropriate license and is actively maintained?
- [ ] Did you use localized strings (and added appropriate descriptions) where applicable?
- [ ] Did you add `semanticLabel`s where applicable for accessibility?
