### PR TITLE
Fix unintended keyboard popup when navigating back to main screen

### DIFF
--- a/lib/thunder/widgets/bottom_nav_bar.dart
+++ b/lib/thunder/widgets/bottom_nav_bar.dart
@@ -141,6 +141,10 @@ class _CustomBottomNavigationBarState extends State<CustomBottomNavigationBar> {
             context.read<ThunderBloc>().add(const OnFabToggle(false));
           }
 
+          if (widget.selectedPageIndex == 1 && index != 1) {
+            FocusManager.instance.primaryFocus?.unfocus();
+          }
+
           if (widget.selectedPageIndex == 0 && index == 0) {
             context.read<FeedBloc>().add(ScrollToTopEvent());
           }

--- a/lib/thunder/widgets/bottom_nav_bar.dart
+++ b/lib/thunder/widgets/bottom_nav_bar.dart
@@ -141,15 +141,13 @@ class _CustomBottomNavigationBarState extends State<CustomBottomNavigationBar> {
             context.read<ThunderBloc>().add(const OnFabToggle(false));
           }
 
-          if (widget.selectedPageIndex == 1 && index != 1) {
-            FocusManager.instance.primaryFocus?.unfocus();
-          }
-
           if (widget.selectedPageIndex == 0 && index == 0) {
             context.read<FeedBloc>().add(ScrollToTopEvent());
           }
 
-          if (widget.selectedPageIndex == 1 && index == 1) {
+          if (widget.selectedPageIndex == 1 && index != 1) {
+            FocusManager.instance.primaryFocus?.unfocus();
+          } else if (widget.selectedPageIndex == 1 && index == 1) {
             context.read<SearchBloc>().add(FocusSearchEvent());
           }
 


### PR DESCRIPTION
## Pull Request Description

This PR fixes an issue described in #1684 and #1110 where the keyboard would show up on the main pages after using search. I mainly tested this on an Android emulator as iOS doesn't seem to exhibit this issue (difficult to reproduce)

Note: this fix still keeps the old behaviour of double-tapping the search icon to open up the keyboard!

<!--- Please describe what was changed -->

## Issue Being Fixed

<!-- Please describe the problem that is being fixed and, if applicable, reference a GitHub issue -->

Issue Number: #1684, #1110

## Screenshots / Recordings

Original Issue

https://github.com/user-attachments/assets/50cf04c2-54f3-4efb-987b-4c1fd4a18497

Fixed Issue

https://github.com/user-attachments/assets/66039da6-0565-47a6-a757-fcf166769f59

<!-- This section is optional but highly recommended to show off your changes! -->

## Checklist

- [ ] If a new package was added, did you ensure it uses an appropriate license and is actively maintained?
- [ ] Did you use localized strings (and added appropriate descriptions) where applicable?
- [ ] Did you add `semanticLabel`s where applicable for accessibility?
