### PR TITLE
Do not show display name in tooltip

### DIFF
--- a/lib/shared/chips/community_chip.dart
+++ b/lib/shared/chips/community_chip.dart
@@ -52,6 +52,7 @@ class CommunityChip extends StatelessWidget {
           communityName,
           communityTitle,
           fetchInstanceNameFromUrl(communityUrl) ?? '-',
+          useDisplayName: false,
         ),
         preferBelow: false,
         child: Row(

--- a/lib/shared/chips/user_chip.dart
+++ b/lib/shared/chips/user_chip.dart
@@ -62,6 +62,7 @@ class UserChip extends StatelessWidget {
           person.name,
           person.displayName,
           fetchInstanceNameFromUrl(person.actorId),
+          useDisplayName: false,
         )}${fetchUserGroupDescriptor(userGroups, person)}',
         preferBelow: false,
         child: Material(


### PR DESCRIPTION
## Pull Request Description

<!--- Please describe what was changed -->

This PR fixes an issue where we were showing display names in tooltips. I think it makes sense for the tooltip to display the raw/full name.

## Issue Being Fixed

<!-- Please describe the problem that is being fixed and, if applicable, reference a GitHub issue -->

Issue Number: https://lemmy.world/comment/14940449

## Screenshots / Recordings

<!-- This section is optional but highly recommended to show off your changes! -->

https://github.com/user-attachments/assets/46055092-94ed-4279-aa0c-ce720310ad2b

## Checklist

- [ ] If a new package was added, did you ensure it uses an appropriate license and is actively maintained?
- [ ] Did you use localized strings (and added appropriate descriptions) where applicable?
- [ ] Did you add `semanticLabel`s where applicable for accessibility?
