### PR TITLE
Fix color of block icon on block user button

### DIFF
--- a/lib/user/widgets/user_sidebar.dart
+++ b/lib/user/widgets/user_sidebar.dart
@@ -304,7 +304,7 @@ class BlockUserButton extends StatelessWidget {
             child: Row(
               mainAxisAlignment: MainAxisAlignment.center,
               children: [
-                Icon(blocked ? Icons.undo_rounded : Icons.block_rounded),
+                Icon(blocked ? Icons.undo_rounded : Icons.block_rounded, color: Colors.redAccent),
                 const SizedBox(width: 4.0),
                 Text(blocked ? 'Unblock User' : 'Block User'),
               ],


### PR DESCRIPTION
## Pull Request Description

<!--- Please describe what was changed -->

This is a small PR which fixes another color bug that I just discovered. Previously the icon associated with the Block User button was red, but now it's the default theme color. Turns out that this is a known breaking change where the button style no longer applies to icons. (https://github.com/flutter/flutter/issues/154644)

Also note that it looks like the size had also changed; however, I don't hate the new size, so I left that alone.

## Issue Being Fixed

<!-- Please describe the problem that is being fixed and, if applicable, reference a GitHub issue -->

Issue Number: N/A

## Screenshots / Recordings

| Old | New | Fixed |
|--------|--------|--------|
| ![image](https://github.com/user-attachments/assets/cef6c75f-ff69-461b-b61f-c9f4e8636887) | ![image](https://github.com/user-attachments/assets/955c528c-dfa4-4863-b23d-e95f44b5c65f) | ![image](https://github.com/user-attachments/assets/c511be46-04b9-44d9-af58-320f112dd054) | 

<!-- This section is optional but highly recommended to show off your changes! -->

## Checklist

- [ ] If a new package was added, did you ensure it uses an appropriate license and is actively maintained?
- [ ] Did you use localized strings (and added appropriate descriptions) where applicable?
- [ ] Did you add `semanticLabel`s where applicable for accessibility?
