### PR TITLE
Fix profile modal staying open after logging into new account

### DIFF
--- a/lib/account/pages/login_page.dart
+++ b/lib/account/pages/login_page.dart
@@ -22,9 +22,10 @@ import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 
 class LoginPage extends StatefulWidget {
   final VoidCallback popRegister;
+  final VoidCallback popModal;
   final bool anonymous;
 
-  const LoginPage({super.key, required this.popRegister, this.anonymous = false});
+  const LoginPage({super.key, required this.popRegister, required this.popModal, this.anonymous = false});
 
   @override
   State<LoginPage> createState() => _LoginPageState();
@@ -149,7 +150,7 @@ class _LoginPageState extends State<LoginPage> with SingleTickerProviderStateMix
 
               showSnackbar(AppLocalizations.of(context)!.loginFailed(state.errorMessage ?? AppLocalizations.of(context)!.missingErrorMessage));
             } else if (state.status == AuthStatus.success && context.read<AuthBloc>().state.isLoggedIn) {
-              Navigator.of(context).pop();
+              widget.popModal();
               showSnackbar(AppLocalizations.of(context)!.loginSucceeded);
             } else if (state.status == AuthStatus.contentWarning) {
               bool acceptedContentWarning = false;

--- a/lib/account/widgets/profile_modal_body.dart
+++ b/lib/account/widgets/profile_modal_body.dart
@@ -52,6 +52,10 @@ class _ProfileModalBodyState extends State<ProfileModalBody> {
     ProfileModalBody.shellNavigatorKey.currentState!.pop();
   }
 
+  void popModal() {
+    Navigator.of(context).pop();
+  }
+
   @override
   Widget build(BuildContext context) {
     return Navigator(
@@ -86,7 +90,7 @@ class _ProfileModalBodyState extends State<ProfileModalBody> {
         break;
 
       case '/login':
-        page = LoginPage(popRegister: popRegister, anonymous: (settings.arguments as Map<String, bool>)['anonymous']!);
+        page = LoginPage(popRegister: popRegister, popModal: popModal, anonymous: (settings.arguments as Map<String, bool>)['anonymous']!);
         break;
     }
     return SwipeablePageRoute<dynamic>(


### PR DESCRIPTION
## Pull Request Description

<!--- Please describe what was changed -->

This is a quick PR which steals a fix that I put into @gwbischof's PR #1642. The problem that I fixed was not introduced in his PR, and it's been bothering my in daily usage lol! So if his PR isn't going to be merged soon, I'd like to get this particular fix in sooner. It just ensures that the profile modal closes itself after you switch accounts.

## Issue Being Fixed

<!-- Please describe the problem that is being fixed and, if applicable, reference a GitHub issue -->

Issue Number: Cherry-picked d8720e41512654ec23ff1934dc03be361cd8c735

## Screenshots / Recordings

<!-- This section is optional but highly recommended to show off your changes! -->

## Checklist

- [ ] If a new package was added, did you ensure it uses an appropriate license and is actively maintained?
- [ ] Did you use localized strings (and added appropriate descriptions) where applicable?
- [ ] Did you add `semanticLabel`s where applicable for accessibility?
