### PR TITLE
Fix profile modal not closing after switching accounts

### DIFF
--- a/lib/account/widgets/profile_modal_body.dart
+++ b/lib/account/widgets/profile_modal_body.dart
@@ -252,7 +252,7 @@ class _ProfileSelectState extends State<ProfileSelect> {
                               ? null
                               : () {
                                   context.read<AuthBloc>().add(SwitchAccount(accountId: accounts![index].account.id, reload: widget.reloadOnSave));
-                                  Navigator.of(context).pop();
+                                  Navigator.of(context, rootNavigator: true).pop();
                                 },
                           borderRadius: BorderRadius.circular(50),
                           child: AnimatedSize(
@@ -508,7 +508,7 @@ class _ProfileSelectState extends State<ProfileSelect> {
                                     context.read<AuthBloc>().add(const LogOutOfAllAccounts());
                                     context.read<ThunderBloc>().add(OnSetCurrentAnonymousInstance(anonymousInstances![index].anonymousInstance.instance));
                                     context.read<AuthBloc>().add(InstanceChanged(instance: anonymousInstances![index].anonymousInstance.instance));
-                                    Navigator.of(context).pop();
+                                    Navigator.of(context, rootNavigator: true).pop();
                                   },
                             borderRadius: BorderRadius.circular(50),
                             child: AnimatedSize(


### PR DESCRIPTION
## Pull Request Description

<!--- Please describe what was changed -->

This is a quick followup to #1701. For some reason, even though the modal was closing after adding a new account, it wasn't closing after switching accounts. I found that adding `rootNavigator: true` helped. To be honest I'm not sure exactly why (maybe it was a breaking change from a Flutter upgrade, since I only noticed it recently). But this seems to do the trick.