### PR TITLE
Fix link images not respecting edge-to-edge option

### DIFF
--- a/lib/shared/image_preview.dart
+++ b/lib/shared/image_preview.dart
@@ -22,6 +22,7 @@ class ImagePreview extends StatefulWidget {
   final bool isGallery;
   final bool isExpandable;
   final bool showFullHeightImages;
+  final bool edgeToEdgeImages;
   final int? postId;
   final void Function()? navigateToPost;
   final bool? isComment;
@@ -39,6 +40,7 @@ class ImagePreview extends StatefulWidget {
     this.isGallery = false,
     this.isExpandable = true,
     this.showFullHeightImages = false,
+    this.edgeToEdgeImages = false,
     this.postId,
     this.navigateToPost,
     this.isComment,
@@ -93,7 +95,7 @@ class _ImagePreviewState extends State<ImagePreview> {
 
     return Container(
       clipBehavior: Clip.hardEdge,
-      decoration: BoxDecoration(borderRadius: BorderRadius.circular(12)),
+      decoration: BoxDecoration(borderRadius: BorderRadius.circular(widget.edgeToEdgeImages ? 0 : 12)),
       child: Stack(
         children: [
           // This is used for link posts where the preview comes from Lemmy
@@ -108,7 +110,7 @@ class _ImagePreviewState extends State<ImagePreview> {
                           maxWidth: MediaQuery.of(context).size.width * 0.60,
                         )
                       : BoxConstraints(
-                          maxWidth: widget.maxWidth ?? MediaQuery.of(context).size.width - 24,
+                          maxWidth: widget.maxWidth ?? MediaQuery.of(context).size.width - (widget.edgeToEdgeImages ? 0 : 24),
                         ),
                   alignment: widget.isComment == true ? Alignment.topCenter : Alignment.center,
                   widget.url!,

--- a/lib/shared/link_information.dart
+++ b/lib/shared/link_information.dart
@@ -19,6 +19,8 @@ class LinkInformation extends StatefulWidget {
   /// Type of media (image, link, text, etc.)
   final MediaType? mediaType;
 
+  final bool showEdgeToEdgeImages;
+
   /// Custom callback function for when the link is tapped
   final Function? onTap;
 
@@ -30,6 +32,7 @@ class LinkInformation extends StatefulWidget {
     required this.viewMode,
     this.originURL,
     this.mediaType,
+    this.showEdgeToEdgeImages = false,
     this.onTap,
     this.onLongPress,
   });
@@ -75,7 +78,7 @@ class _LinkInformationState extends State<LinkInformation> {
         },
         child: Container(
           decoration: BoxDecoration(
-            borderRadius: BorderRadius.circular(12),
+            borderRadius: BorderRadius.circular(widget.showEdgeToEdgeImages ? 0 : 12),
             color: ElevationOverlay.applySurfaceTint(theme.colorScheme.surface.withValues(alpha: 0.8), theme.colorScheme.surfaceTint, 10),
           ),
           padding: const EdgeInsets.symmetric(horizontal: 8.0, vertical: 8.0),

--- a/lib/shared/link_preview_card.dart
+++ b/lib/shared/link_preview_card.dart
@@ -78,6 +78,7 @@ class LinkPreviewCard extends StatelessWidget {
                           url: mediaURL ?? originURL!,
                           height: showFullHeightImages ? mediaHeight : ViewMode.comfortable.height,
                           width: mediaWidth ?? MediaQuery.of(context).size.width - (edgeToEdgeImages ? 0 : 24),
+                          edgeToEdgeImages: edgeToEdgeImages,
                           isExpandable: false,
                         ),
                       )
@@ -86,6 +87,7 @@ class LinkPreviewCard extends StatelessWidget {
                         url: mediaURL ?? originURL!,
                         height: showFullHeightImages ? mediaHeight : ViewMode.comfortable.height,
                         width: mediaWidth ?? MediaQuery.of(context).size.width - (edgeToEdgeImages ? 0 : 24),
+                        edgeToEdgeImages: edgeToEdgeImages,
                         isExpandable: false,
                       )
               ] else if (scrapeMissingPreviews)
@@ -129,6 +131,7 @@ class LinkPreviewCard extends StatelessWidget {
               LinkInformation(
                 viewMode: viewMode,
                 originURL: originURL,
+                showEdgeToEdgeImages: edgeToEdgeImages,
               ),
               Positioned.fill(
                 child: Material(

--- a/lib/shared/media_view.dart
+++ b/lib/shared/media_view.dart
@@ -354,6 +354,7 @@ class _MediaViewState extends State<MediaView> with TickerProviderStateMixin {
                     viewMode: widget.viewMode,
                     mediaType: widget.postViewMedia.media.first.mediaType,
                     originURL: widget.postViewMedia.media.first.originalUrl ?? '',
+                    showEdgeToEdgeImages: widget.edgeToEdgeImages,
                   ),
                 ),
               ),
@@ -371,6 +372,7 @@ class _MediaViewState extends State<MediaView> with TickerProviderStateMixin {
         originURL: widget.postViewMedia.media.first.originalUrl,
         mediaType: widget.postViewMedia.media.first.mediaType,
         onTap: widget.postViewMedia.media.first.mediaType == MediaType.image ? showImage : null,
+        showEdgeToEdgeImages: widget.edgeToEdgeImages,
       );
     }
     switch (widget.postViewMedia.media.firstOrNull?.mediaType) {
@@ -382,6 +384,7 @@ class _MediaViewState extends State<MediaView> with TickerProviderStateMixin {
             viewMode: widget.viewMode,
             mediaType: widget.postViewMedia.media.first.mediaType,
             originURL: widget.postViewMedia.media.first.originalUrl ?? '',
+            showEdgeToEdgeImages: widget.edgeToEdgeImages,
           );
         }
 


### PR DESCRIPTION
## Pull Request Description

This PR fixes a visual inconsistency where enabling edge-to-edge images would be correctly applied to image previews but not link previews.

> On a side note, it might be worthwhile to refactor the media preview widgets as the logic is fairly difficult to follow!

<!--- Please describe what was changed -->

## Issue Being Fixed

<!-- Please describe the problem that is being fixed and, if applicable, reference a GitHub issue -->

Issue Number: N/A

## Screenshots / Recordings

| Current | Fixed |
|-|-|
|![simulator_screenshot_807CC749-C341-44CD-A577-5272233BC609](https://github.com/user-attachments/assets/144920ba-5e58-4c78-9983-c117ae6064ee) | ![simulator_screenshot_5B4526CB-052F-43BB-A9DB-EE66BD0F4192](https://github.com/user-attachments/assets/04040ea9-5925-44a4-89f1-0c19911f1b89)|
| ![simulator_screenshot_459F2592-ACA9-4ACA-A347-1F0FDE28A85A](https://github.com/user-attachments/assets/8f87fa9c-30dd-41b0-a604-62384492b816)|![simulator_screenshot_C60E165F-687D-4A4F-A283-185B8A2082E5](https://github.com/user-attachments/assets/0f29e4ba-c1c4-4ef3-b0e5-e72947543ecc)|

<!-- This section is optional but highly recommended to show off your changes! -->

## Checklist

- [ ] If a new package was added, did you ensure it uses an appropriate license and is actively maintained?
- [ ] Did you use localized strings (and added appropriate descriptions) where applicable?
- [ ] Did you add `semanticLabel`s where applicable for accessibility?
