### PR TITLE
Limit image height when it exceeds the device height

### DIFF
--- a/lib/shared/media_view.dart
+++ b/lib/shared/media_view.dart
@@ -181,6 +181,30 @@ class _MediaViewState extends State<MediaView> with TickerProviderStateMixin {
     );
   }
 
+  double getMinHeight() {
+    if (!widget.showFullHeightImages) return ViewMode.comfortable.height;
+
+    if (widget.postViewMedia.media.first.height != null) {
+      if (MediaQuery.of(context).size.height < widget.postViewMedia.media.first.height!) return MediaQuery.of(context).size.height;
+      return widget.postViewMedia.media.first.height!;
+    }
+
+    return ViewMode.comfortable.height;
+  }
+
+  double getMaxHeight() {
+    if (!widget.showFullHeightImages) return ViewMode.comfortable.height;
+
+    if (widget.postViewMedia.media.first.height != null) {
+      if (MediaQuery.of(context).size.height < widget.postViewMedia.media.first.height!) return MediaQuery.of(context).size.height;
+      return widget.postViewMedia.media.first.height!;
+    }
+
+    if (widget.allowUnconstrainedImageHeight) return MediaQuery.of(context).size.height;
+
+    return ViewMode.comfortable.height;
+  }
+
   /// Creates an image preview
   Widget buildMediaImage() {
     final theme = Theme.of(context);
@@ -201,13 +225,11 @@ class _MediaViewState extends State<MediaView> with TickerProviderStateMixin {
           constraints: BoxConstraints(
               maxHeight: switch (widget.viewMode) {
                 ViewMode.compact => ViewMode.compact.height,
-                ViewMode.comfortable => widget.showFullHeightImages
-                    ? widget.postViewMedia.media.first.height ?? (widget.allowUnconstrainedImageHeight ? double.infinity : ViewMode.comfortable.height)
-                    : ViewMode.comfortable.height,
+                ViewMode.comfortable => getMaxHeight(),
               },
               minHeight: switch (widget.viewMode) {
                 ViewMode.compact => ViewMode.compact.height,
-                ViewMode.comfortable => widget.showFullHeightImages ? widget.postViewMedia.media.first.height ?? ViewMode.comfortable.height : ViewMode.comfortable.height,
+                ViewMode.comfortable => getMinHeight(),
               },
               maxWidth: switch (widget.viewMode) {
                 ViewMode.compact => ViewMode.compact.height,
@@ -305,13 +327,11 @@ class _MediaViewState extends State<MediaView> with TickerProviderStateMixin {
         constraints: BoxConstraints(
             maxHeight: switch (widget.viewMode) {
               ViewMode.compact => ViewMode.compact.height,
-              ViewMode.comfortable => widget.showFullHeightImages
-                  ? widget.postViewMedia.media.first.height ?? (widget.allowUnconstrainedImageHeight ? double.infinity : ViewMode.comfortable.height)
-                  : ViewMode.comfortable.height,
+              ViewMode.comfortable => getMaxHeight(),
             },
             minHeight: switch (widget.viewMode) {
               ViewMode.compact => ViewMode.compact.height,
-              ViewMode.comfortable => widget.showFullHeightImages ? widget.postViewMedia.media.first.height ?? ViewMode.comfortable.height : ViewMode.comfortable.height,
+              ViewMode.comfortable => getMinHeight(),
             },
             maxWidth: switch (widget.viewMode) {
               ViewMode.compact => ViewMode.compact.height,


### PR DESCRIPTION
## Pull Request Description

This PR adds a constraint to image heights when they exceed the device height. If the image height is larger than the device height, then the image will be constrained to the device's height. This constraint is applied to both the feed page (when full height images are enabled) and the post page.

In these cases, the image's width might be stretched to compensate for the constrained height (which might make the media preview blurry as seen below)

<!--- Please describe what was changed -->

## Issue Being Fixed

<!-- Please describe the problem that is being fixed and, if applicable, reference a GitHub issue -->

Issue Number: Somewhat related to #1417, but addresses this issue https://lemmy.world/post/25819194

## Screenshots / Recordings

https://github.com/user-attachments/assets/82a0d19c-122f-4a8f-b4ab-1926a38470a8

https://github.com/user-attachments/assets/643f3164-ab54-46bd-9eec-44117653968e

<!-- This section is optional but highly recommended to show off your changes! -->

## Checklist

- [ ] If a new package was added, did you ensure it uses an appropriate license and is actively maintained?
- [ ] Did you use localized strings (and added appropriate descriptions) where applicable?
- [ ] Did you add `semanticLabel`s where applicable for accessibility?
