### PR TITLE
Remove scrape missing previews option

### DIFF
--- a/lib/core/enums/local_settings.dart
+++ b/lib/core/enums/local_settings.dart
@@ -153,8 +153,6 @@ enum LocalSettings {
 
   // General Settings
 
-  scrapeMissingPreviews(
-      name: 'setting_general_scrape_missing_previews', key: 'scrapeMissingLinkPreviews', category: LocalSettingsCategories.general, subCategory: LocalSettingsSubCategories.linksBehaviourSettings),
   // Deprecated, use browserMode
   openLinksInExternalBrowser(
       name: 'setting_links_open_in_external_browser',

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -2021,10 +2021,6 @@
   "@scrapeMissingLinkPreviews": {
     "description": "Toggle to scrape missing external link previews."
   },
-  "scrapeMissingPreviews": "Enabling will have a performance hit.",
-  "@scrapeMissingPreviews": {
-    "description": "Notice regarding potential performance impact when enabling link scrapping."
-  },
   "screenReaderProfile": "Screen Reader Profile",
   "@screenReaderProfile": {},
   "screenReaderProfileDescription": "Optimizes Thunder for screen readers by reducing overall elements and removing potentially conflicting gestures.",

--- a/lib/post/utils/post.dart
+++ b/lib/post/utils/post.dart
@@ -15,7 +15,6 @@ import 'package:thunder/core/singletons/lemmy_client.dart';
 import 'package:thunder/core/singletons/preferences.dart';
 import 'package:thunder/utils/global_context.dart';
 import 'package:thunder/utils/media/image.dart';
-import 'package:thunder/utils/links.dart';
 import 'package:thunder/utils/media/video.dart';
 
 extension on MarkPostAsReadResponse {
@@ -302,7 +301,6 @@ Future<List<PostViewMedia>> parsePostViews(List<PostView> postViews, {String? re
   bool edgeToEdgeImages = prefs.getBool(LocalSettings.showPostEdgeToEdgeImages.name) ?? false;
   bool tabletMode = prefs.getBool(LocalSettings.useTabletMode.name) ?? false;
   bool hideNsfwPosts = prefs.getBool(LocalSettings.hideNsfwPosts.name) ?? false;
-  bool scrapeMissingPreviews = prefs.getBool(LocalSettings.scrapeMissingPreviews.name) ?? false;
 
   List<PostView> postViewsFinal = [];
 
@@ -324,7 +322,7 @@ Future<List<PostViewMedia>> parsePostViews(List<PostView> postViews, {String? re
   Iterable<Future<PostViewMedia>> postFutures = postViewsFinal
       .expand(
         (post) => [
-          if (!hideNsfwPosts || (!post.post.nsfw && hideNsfwPosts)) parsePostView(post, fetchImageDimensions, edgeToEdgeImages, tabletMode, scrapeMissingPreviews),
+          if (!hideNsfwPosts || (!post.post.nsfw && hideNsfwPosts)) parsePostView(post, fetchImageDimensions, edgeToEdgeImages, tabletMode),
         ],
       )
       .toList();
@@ -333,7 +331,7 @@ Future<List<PostViewMedia>> parsePostViews(List<PostView> postViews, {String? re
   return posts;
 }
 
-Future<PostViewMedia> parsePostView(PostView postView, bool fetchImageDimensions, bool edgeToEdgeImages, bool tabletMode, bool scrapeMissingPreviews) async {
+Future<PostViewMedia> parsePostView(PostView postView, bool fetchImageDimensions, bool edgeToEdgeImages, bool tabletMode) async {
   List<Media> mediaList = [];
 
   // There are three sources of URLs: the main url attached to the post, the thumbnail url attached to the post, and the video url attached to the post
@@ -372,13 +370,6 @@ Future<PostViewMedia> parsePostView(PostView postView, bool fetchImageDimensions
   } else if (isImage) {
     // If there is no thumbnail image, but the url is an image, we'll use that for the thumbnailUrl
     media.thumbnailUrl = url;
-  } else if (scrapeMissingPreviews) {
-    // If there is no thumbnail image, we'll see if we should try to fetch the link metadata
-    LinkInfo linkInfo = await getLinkInfo(url);
-
-    if (linkInfo.imageURL != null && linkInfo.imageURL!.isNotEmpty) {
-      media.thumbnailUrl = linkInfo.imageURL!;
-    }
   }
 
   // Determine the media url

--- a/lib/post/widgets/post_view.dart
+++ b/lib/post/widgets/post_view.dart
@@ -114,7 +114,6 @@ class _PostSubviewState extends State<PostSubview> with SingleTickerProviderStat
     final ThunderState thunderState = context.read<ThunderBloc>().state;
     final AuthState authState = context.watch<AuthBloc>().state;
 
-    final bool scrapeMissingPreviews = thunderState.scrapeMissingPreviews;
     final bool hideNsfwPreviews = thunderState.hideNsfwPreviews;
     final bool markPostReadOnMediaView = thunderState.markPostReadOnMediaView;
 

--- a/lib/settings/pages/general_settings_page.dart
+++ b/lib/settings/pages/general_settings_page.dart
@@ -71,9 +71,6 @@ class _GeneralSettingsPageState extends State<GeneralSettingsPage> with SingleTi
   /// When enabled, the feed page will display two columns for posts
   bool tabletMode = false;
 
-  /// When enabled, missing link previews will be scraped
-  bool scrapeMissingPreviews = false;
-
   /// Determines how links are handled
   BrowserMode browserMode = BrowserMode.customTabs;
 
@@ -229,10 +226,6 @@ class _GeneralSettingsPageState extends State<GeneralSettingsPage> with SingleTi
         await prefs.setBool(LocalSettings.openLinksInReaderMode.name, value);
         setState(() => openInReaderMode = value);
         break;
-      case LocalSettings.scrapeMissingPreviews:
-        await prefs.setBool(LocalSettings.scrapeMissingPreviews.name, value);
-        setState(() => scrapeMissingPreviews = value);
-        break;
 
       case LocalSettings.showInAppUpdateNotification:
         await prefs.setBool(LocalSettings.showInAppUpdateNotification.name, value);
@@ -302,7 +295,6 @@ class _GeneralSettingsPageState extends State<GeneralSettingsPage> with SingleTi
       browserMode = BrowserMode.values.byName(prefs.getString(LocalSettings.browserMode.name) ?? BrowserMode.customTabs.name);
 
       openInReaderMode = prefs.getBool(LocalSettings.openLinksInReaderMode.name) ?? false;
-      scrapeMissingPreviews = prefs.getBool(LocalSettings.scrapeMissingPreviews.name) ?? false;
 
       imageCachingMode = ImageCachingMode.values.byName(prefs.getString(LocalSettings.imageCachingMode.name) ?? ImageCachingMode.relaxed.name);
       showNavigationLabels = prefs.getBool(LocalSettings.showNavigationLabels.name) ?? true;
@@ -725,19 +717,6 @@ class _GeneralSettingsPageState extends State<GeneralSettingsPage> with SingleTi
                 highlightedSetting: settingToHighlight,
               ),
             ),
-          SliverToBoxAdapter(
-            child: ToggleOption(
-              description: l10n.scrapeMissingLinkPreviews,
-              subtitle: l10n.scrapeMissingPreviews,
-              value: scrapeMissingPreviews,
-              iconEnabled: Icons.image_search_rounded,
-              iconDisabled: Icons.link_off_rounded,
-              onToggle: (bool value) => setPreferences(LocalSettings.scrapeMissingPreviews, value),
-              highlightKey: settingToHighlightKey,
-              setting: LocalSettings.scrapeMissingPreviews,
-              highlightedSetting: settingToHighlight,
-            ),
-          ),
           const SliverToBoxAdapter(child: SizedBox(height: 16.0)),
           SliverToBoxAdapter(
             child: Padding(

--- a/lib/thunder/bloc/thunder_bloc.dart
+++ b/lib/thunder/bloc/thunder_bloc.dart
@@ -108,7 +108,6 @@ class ThunderBloc extends Bloc<ThunderEvent, ThunderState> {
       bool tabletMode = prefs.getBool(LocalSettings.useTabletMode.name) ?? false;
 
       // General Settings
-      bool scrapeMissingPreviews = prefs.getBool(LocalSettings.scrapeMissingPreviews.name) ?? false;
       bool openInReaderMode = prefs.getBool(LocalSettings.openLinksInReaderMode.name) ?? false;
       bool useDisplayNamesForUsers = prefs.getBool(LocalSettings.useDisplayNamesForUsers.name) ?? false;
       bool useDisplayNamesForCommunities = prefs.getBool(LocalSettings.useDisplayNamesForCommunities.name) ?? false;
@@ -283,7 +282,6 @@ class ThunderBloc extends Bloc<ThunderEvent, ThunderState> {
         tabletMode: tabletMode,
 
         // General Settings
-        scrapeMissingPreviews: scrapeMissingPreviews,
         browserMode: browserMode,
         openInReaderMode: openInReaderMode,
         useDisplayNamesForUsers: useDisplayNamesForUsers,

--- a/lib/thunder/bloc/thunder_state.dart
+++ b/lib/thunder/bloc/thunder_state.dart
@@ -24,7 +24,6 @@ class ThunderState extends Equatable {
     this.tabletMode = false,
 
     // General Settings
-    this.scrapeMissingPreviews = false,
     this.browserMode = BrowserMode.customTabs,
     this.openInReaderMode = false,
     this.useDisplayNamesForUsers = false,
@@ -197,7 +196,6 @@ class ThunderState extends Equatable {
   final bool tabletMode;
 
   // General Settings
-  final bool scrapeMissingPreviews;
   final BrowserMode browserMode;
   final bool openInReaderMode;
   final bool useDisplayNamesForUsers;
@@ -378,7 +376,6 @@ class ThunderState extends Equatable {
     bool? tabletMode,
 
     // General Settings
-    bool? scrapeMissingPreviews,
     BrowserMode? browserMode,
     bool? openInReaderMode,
     bool? useDisplayNamesForUsers,
@@ -551,7 +548,6 @@ class ThunderState extends Equatable {
       tabletMode: tabletMode ?? this.tabletMode,
 
       // General Settings
-      scrapeMissingPreviews: scrapeMissingPreviews ?? this.scrapeMissingPreviews,
       browserMode: browserMode ?? this.browserMode,
       openInReaderMode: openInReaderMode ?? this.openInReaderMode,
       useDisplayNamesForUsers: useDisplayNamesForUsers ?? this.useDisplayNamesForUsers,
@@ -734,7 +730,6 @@ class ThunderState extends Equatable {
         tabletMode,
 
         // General Settings
-        scrapeMissingPreviews,
         browserMode,
         useDisplayNamesForUsers,
         useDisplayNamesForCommunities,

--- a/lib/utils/preferences.dart
+++ b/lib/utils/preferences.dart
@@ -137,4 +137,11 @@ Future<void> performSharedPreferencesMigration() async {
     await prefs.setInt(LocalSettings.appTheme.name, ThemeType.dark.index);
     await prefs.setBool(LocalSettings.usePureBlackTheme.name, true);
   }
+
+  // Remove scrapeMissingPreviews setting
+  bool? scrapeMissingPreviews = prefs.getBool('setting_general_scrape_missing_previews');
+  if (scrapeMissingPreviews != null) {
+    await prefs.remove('setting_general_scrape_missing_previews');
+    debugPrint('Removed setting_general_scrape_missing_previews');
+  }
 }


### PR DESCRIPTION
## Pull Request Description

This PR removes the remaining logic for scrape missing previews option mentioned in #1720. I've also added a migration step to remove existing instances of `setting_general_scrape_missing_previews` in `SharedPreferences`.

<!--- Please describe what was changed -->

## Issue Being Fixed

<!-- Please describe the problem that is being fixed and, if applicable, reference a GitHub issue -->

Issue Number: N/A

## Screenshots / Recordings

<!-- This section is optional but highly recommended to show off your changes! -->

## Checklist

- [ ] If a new package was added, did you ensure it uses an appropriate license and is actively maintained?
- [ ] Did you use localized strings (and added appropriate descriptions) where applicable?
- [ ] Did you add `semanticLabel`s where applicable for accessibility?
