### PR TITLE
Fix tapping on media not marking post as read

### DIFF
--- a/lib/community/widgets/post_card_view_comfortable.dart
+++ b/lib/community/widgets/post_card_view_comfortable.dart
@@ -91,6 +91,7 @@ class PostCardViewComfortable extends StatelessWidget {
 
     Widget mediaView = MediaView(
       media: postViewMedia.media.first,
+      postId: postViewMedia.postView.post.id,
       showFullHeightImages: showFullHeightImages,
       hideNsfwPreviews: hideNsfwPreviews,
       hideThumbnails: hideThumbnails,

--- a/lib/community/widgets/post_card_view_compact.dart
+++ b/lib/community/widgets/post_card_view_compact.dart
@@ -239,6 +239,7 @@ class ThumbnailPreview extends StatelessWidget {
             padding: const EdgeInsets.symmetric(horizontal: 10.0, vertical: 4),
             child: MediaView(
               media: postViewMedia.media.first,
+              postId: postViewMedia.postView.post.id,
               showFullHeightImages: false,
               hideNsfwPreviews: hideNsfwPreviews,
               markPostReadOnMediaView: markPostReadOnMediaView,

--- a/lib/post/widgets/post_view.dart
+++ b/lib/post/widgets/post_view.dart
@@ -186,6 +186,7 @@ class _PostSubviewState extends State<PostSubview> with SingleTickerProviderStat
                 expanded: MediaView(
                   viewMode: ViewMode.comfortable,
                   media: postViewMedia.media.first,
+                  postId: postViewMedia.postView.post.id,
                   showFullHeightImages: true,
                   allowUnconstrainedImageHeight: true,
                   hideNsfwPreviews: hideNsfwPreviews,
@@ -388,6 +389,7 @@ class _PostSubviewState extends State<PostSubview> with SingleTickerProviderStat
           ),
           child: MediaView(
             media: postViewMedia.media.first,
+            postId: postViewMedia.postView.post.id,
             showFullHeightImages: false,
             hideNsfwPreviews: hideNsfwPreviews,
             markPostReadOnMediaView: markPostReadOnMediaView,

--- a/lib/shared/media/media_view.dart
+++ b/lib/shared/media/media_view.dart
@@ -146,6 +146,17 @@ class _MediaViewState extends State<MediaView> with TickerProviderStateMixin {
     return ViewMode.comfortable.height;
   }
 
+  void handleTap() {
+    if (widget.isUserLoggedIn && widget.markPostReadOnMediaView) {
+      try {
+        final feedBloc = BlocProvider.of<FeedBloc>(context);
+        feedBloc.add(FeedItemActionedEvent(postAction: PostAction.read, postId: widget.postId, value: true));
+      } catch (e) {
+        debugPrint('Error marking post as read: $e');
+      }
+    }
+  }
+
   @override
   Widget build(BuildContext context) {
     // If hiding thumbnails is enabled or if the media has no image URL (e.g., text or links with no images), we should display a link preview instead
@@ -155,7 +166,10 @@ class _MediaViewState extends State<MediaView> with TickerProviderStateMixin {
         viewMode: widget.viewMode,
         originURL: widget.media.originalUrl,
         mediaType: widget.media.mediaType,
-        onTap: widget.media.mediaType == MediaType.image ? showImage : null,
+        onTap: () {
+          handleTap();
+          handleLink(context, url: widget.media.originalUrl!);
+        },
         showEdgeToEdgeImages: widget.edgeToEdgeImages,
       );
     }
@@ -194,7 +208,10 @@ class _MediaViewState extends State<MediaView> with TickerProviderStateMixin {
       child = InkWell(
         splashColor: theme.colorScheme.primary.withValues(alpha: 0.4),
         borderRadius: BorderRadius.circular((widget.edgeToEdgeImages ? 0 : 12)),
-        onTap: () => handleLink(context, url: widget.media.originalUrl!),
+        onTap: () {
+          handleTap();
+          handleLink(context, url: widget.media.originalUrl!);
+        },
         onLongPress: () => handleLinkLongPress(context, widget.media.originalUrl!, widget.media.originalUrl),
         child: widget.viewMode == ViewMode.comfortable
             ? SizedBox(
@@ -218,7 +235,10 @@ class _MediaViewState extends State<MediaView> with TickerProviderStateMixin {
       child = InkWell(
         splashColor: theme.colorScheme.primary.withValues(alpha: 0.4),
         borderRadius: BorderRadius.circular((widget.edgeToEdgeImages ? 0 : 12)),
-        onTap: showImage,
+        onTap: () {
+          handleTap();
+          showImage();
+        },
         child: GestureDetector(
           onLongPressStart: (_) {
             _overlayEntry = OverlayEntry(
@@ -252,11 +272,7 @@ class _MediaViewState extends State<MediaView> with TickerProviderStateMixin {
         splashColor: theme.colorScheme.primary.withValues(alpha: 0.4),
         borderRadius: BorderRadius.circular((widget.edgeToEdgeImages ? 0 : 12)),
         onTap: () {
-          if (widget.isUserLoggedIn && widget.markPostReadOnMediaView) {
-            FeedBloc feedBloc = BlocProvider.of<FeedBloc>(context);
-            feedBloc.add(FeedItemActionedEvent(postAction: PostAction.read, postId: widget.postId, value: true));
-          }
-
+          handleTap();
           showVideoPlayer(context, url: widget.media.mediaUrl ?? widget.media.originalUrl, postId: widget.postId);
         },
         child: widget.viewMode == ViewMode.comfortable


### PR DESCRIPTION
## Pull Request Description

This PR fixes a regression with the recent MediaView refactor where tapping on the MediaView would not mark the post as read if the option was enabled.

<!--- Please describe what was changed -->

## Issue Being Fixed

<!-- Please describe the problem that is being fixed and, if applicable, reference a GitHub issue -->

Issue Number: N/A

## Screenshots / Recordings

<!-- This section is optional but highly recommended to show off your changes! -->

## Checklist

- [ ] If a new package was added, did you ensure it uses an appropriate license and is actively maintained?
- [ ] Did you use localized strings (and added appropriate descriptions) where applicable?
- [ ] Did you add `semanticLabel`s where applicable for accessibility?
