### PR TITLE
Fix null check error when navigating to post from Report page

### DIFF
--- a/lib/shared/comment_navigator_fab.dart
+++ b/lib/shared/comment_navigator_fab.dart
@@ -154,13 +154,6 @@ class _CommentNavigatorFabState extends State<CommentNavigatorFab> {
   }
 
   void navigateToParent() {
-    if (widget.comments == null) {
-      // This is a placeholder to allow the previous post page to function correctly.
-      // TODO: Remove this logic when we deprecate the legacy post page
-      navigateUp();
-      return;
-    }
-
     var unobstructedVisibleRange = widget.listController.unobstructedVisibleRange;
 
     int previousIndex = (unobstructedVisibleRange?.$1 ?? 0) - 1;
@@ -218,13 +211,6 @@ class _CommentNavigatorFabState extends State<CommentNavigatorFab> {
   }
 
   void navigateToNextParent() {
-    if (widget.comments == null) {
-      // This is a placeholder to allow the previous post page to function correctly.
-      // TODO: Remove this logic when we deprecate the legacy post page
-      navigateDown();
-      return;
-    }
-
     var unobstructedVisibleRange = widget.listController.unobstructedVisibleRange;
 
     int nextIndex = (unobstructedVisibleRange?.$1 ?? 0) + 1;

--- a/lib/utils/navigation.dart
+++ b/lib/utils/navigation.dart
@@ -151,9 +151,27 @@ Future<void> navigateToPost(
   final hasFeedBloc = context.findAncestorWidgetOfExactType<BlocProvider<FeedBloc>>();
   final feedBloc = hasFeedBloc != null ? context.read<FeedBloc>() : null;
 
+  PostViewMedia? pvm = postViewMedia;
+
+  if (pvm == null) {
+    final client = LemmyClient.instance.lemmyApiV3;
+    final account = await fetchActiveProfileAccount();
+
+    GetPostResponse getPostResponse = await client.run(
+      GetPost(
+        auth: account?.jwt,
+        id: postId,
+      ),
+    );
+
+    List<PostViewMedia> postViewMedias = await parsePostViews([getPostResponse.postView]);
+
+    pvm = postViewMedias.first;
+  }
+
   // Mark post as read when tapped
   if (authBloc.state.isLoggedIn) {
-    feedBloc?.add(FeedItemActionedEvent(postId: postViewMedia?.postView.post.id ?? postId, postAction: PostAction.read, value: true));
+    feedBloc?.add(FeedItemActionedEvent(postId: pvm.postView.post.id, postAction: PostAction.read, value: true));
   }
 
   final state = thunderBloc.state;
@@ -183,7 +201,7 @@ Future<void> navigateToPost(
           BlocProvider(create: (context) => AnonymousSubscriptionsBloc()),
         ],
         child: PostPage(
-          initialPostViewMedia: postViewMedia!,
+          initialPostViewMedia: pvm!,
           onPostUpdated: (PostViewMedia postViewMedia) {
             // Manually marking the read attribute as true when navigating to post since there is a case where the API call to mark the post as read from the feed page is not completed in time
             feedBloc?.add(FeedItemUpdatedEvent(


### PR DESCRIPTION
## Pull Request Description

This PR fixes an issue where attempting to navigate to a post from the Report page would cause a null check error because `PostViewMedia` was not provided. To fix this, the `navigateToPost` function has been modified to fetch the corresponding post if `postViewMedia` is null.

This is likely a regression from #1713 where the legacy post page was removed.

> Additionally, I've removed the conditionals mentioned in #1713 here too!

<!--- Please describe what was changed -->

## Issue Being Fixed

<!-- Please describe the problem that is being fixed and, if applicable, reference a GitHub issue -->

Issue Number: N/A

## Screenshots / Recordings

<!-- This section is optional but highly recommended to show off your changes! -->

The issue:

[issue.webm](https://github.com/user-attachments/assets/e3a2fad8-595d-4793-9db3-a37ab5065fce)

Fixed:

[fixed.webm](https://github.com/user-attachments/assets/54dc3ad7-fd57-42b2-90e4-41633fb25e66)

## Checklist

- [ ] If a new package was added, did you ensure it uses an appropriate license and is actively maintained?
- [ ] Did you use localized strings (and added appropriate descriptions) where applicable?
- [ ] Did you add `semanticLabel`s where applicable for accessibility?
