### PR TITLE
Fix inconsistency with comment navigator

### DIFF
--- a/lib/post/pages/post_page.dart
+++ b/lib/post/pages/post_page.dart
@@ -92,6 +92,9 @@ class _PostPageState extends State<PostPage> {
   /// The ID of the comment that should be highlighted
   int? highlightedCommentId;
 
+  /// The timer for calculating the bottom spacer height
+  Timer? _calculateBottomSpacerTimer;
+
   @override
   void initState() {
     super.initState();
@@ -104,31 +107,14 @@ class _PostPageState extends State<PostPage> {
         context.read<PostBloc>().add(const GetPostCommentsEvent());
       }
     });
+  }
 
-    // The following logic helps us to set the size of the bottom spacer so that the user can scroll the last comment to the top of the viewport but no further.
-    // This must be run some time after the layout has been rendered so we can measure everything.
-    // It also must be run after there is something to scroll, and the easiest way to do this is to do it in a scroll listener.
-    WidgetsBinding.instance.addPostFrameCallback((_) {
-      scrollController.addListener(() {
-        if (bottomSpacerHeight == null) {
-          final deviceHeight = MediaQuery.sizeOf(context).height;
-
-          // Get the height of the "reached end" indicator widget
-          final reachedEndHeight = (reachedEndKey.currentContext?.findRenderObject() as RenderBox?)?.size.height;
-
-          // Get the height of the app bar
-          final renderObject = appBarKey.currentContext?.findRenderObject() as RenderSliverFloatingPersistentHeader?;
-          final appBarHeight = renderObject?.geometry!.maxPaintExtent;
-
-          if (appBarHeight != null && reachedEndHeight != null) {
-            // We will make the bottom spacer the size of the device height, minus the size of the app bar and the size of the "reached bottom" indicator.
-            // This will allow the last comment to be scrolled to the top, with the "reached bottom" indicator and the spacer taking up the rest of the space.
-            bottomSpacerHeight = deviceHeight - appBarHeight - reachedEndHeight;
-            setState(() {});
-          }
-        }
-      });
-    });
+  @override
+  void dispose() {
+    scrollController.dispose();
+    listController.dispose();
+    _calculateBottomSpacerTimer?.cancel();
+    super.dispose();
   }
 
   void showSortBottomSheet(BuildContext context, PostState state) {
@@ -216,6 +202,26 @@ class _PostPageState extends State<PostPage> {
     );
   }
 
+  // The following logic helps us to set the size of the bottom spacer so that the user can scroll the last comment to the top of the viewport but no further.
+  // This must be run some time after the layout has been rendered so we can measure everything.
+  Future<void> _getBottomSpacerHeight() async {
+    final deviceHeight = MediaQuery.sizeOf(context).height;
+
+    // Get the height of the "reached end" indicator widget
+    final reachedEndHeight = (reachedEndKey.currentContext?.findRenderObject() as RenderBox?)?.size.height;
+
+    // Get the height of the app bar
+    final renderObject = appBarKey.currentContext?.findRenderObject() as RenderSliverFloatingPersistentHeader?;
+    final appBarHeight = renderObject?.geometry!.maxPaintExtent;
+
+    if (appBarHeight != null && reachedEndHeight != null) {
+      // We will make the bottom spacer the size of the device height, minus the size of the app bar and the size of the "reached bottom" indicator.
+      // This will allow the last comment to be scrolled to the top, with the "reached bottom" indicator and the spacer taking up the rest of the space.
+      bottomSpacerHeight = deviceHeight - appBarHeight - reachedEndHeight;
+      setState(() {});
+    }
+  }
+
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
@@ -224,6 +230,11 @@ class _PostPageState extends State<PostPage> {
     final double statusBarHeight = MediaQuery.of(context).padding.top;
 
     originalUser ??= context.read<AuthBloc>().state.account;
+
+    if (bottomSpacerHeight == null) {
+      if (_calculateBottomSpacerTimer != null) _calculateBottomSpacerTimer!.cancel();
+      _calculateBottomSpacerTimer = Timer(Duration(milliseconds: 250), _getBottomSpacerHeight);
+    }
 
     return PopScope(
       onPopInvokedWithResult: (didPop, result) {


### PR DESCRIPTION
## Pull Request Description

This PR fixes a consistency issue with the comment navigator. More specifically, it fixes an issue where the comment navigator does not work on posts that are not scrollable.

The reason for this is likely due to the fact that the bottom spacer height is determined within the scroll controller's listener event, which only gets triggered when the user attempts to scroll the page. However, if the page is not scrollable (e.g., posts with very few comments), then that logic never gets triggered and the bottom spacer height is never calculated.

To resolve this, I've moved the logic for calculating the bottom spacer height into its own function, and added a `Timer` that gets triggered on build only if the bottom spacer height is not yet determined. In my testing, the bottom spacer height is determined within the first few build phases so this _should not_ have any major performance impacts!

> I've also added some cleanup with the `dispose` override for the controllers and timers.

<!--- Please describe what was changed -->

## Issue Being Fixed

<!-- Please describe the problem that is being fixed and, if applicable, reference a GitHub issue -->

Issue Number: N/A

## Screenshots / Recordings

[issue.webm](https://github.com/user-attachments/assets/70607c0e-bd27-4f1b-b36c-0a268ea8bad6)

[fixed.webm](https://github.com/user-attachments/assets/934892a9-197d-499a-bec9-1b3b97b2baa6)

<!-- This section is optional but highly recommended to show off your changes! -->

## Checklist

- [ ] If a new package was added, did you ensure it uses an appropriate license and is actively maintained?
- [ ] Did you use localized strings (and added appropriate descriptions) where applicable?
- [ ] Did you add `semanticLabel`s where applicable for accessibility?
