### PR TITLE
Refactor post card and removing unnecessary prop-drilling

### DIFF
--- a/lib/comment/widgets/comment_card.dart
+++ b/lib/comment/widgets/comment_card.dart
@@ -170,18 +170,18 @@ class _CommentCardState extends State<CommentCard> with SingleTickerProviderStat
               // We are checking to see if there is a left to right swipe here. If there is a left to right swipe, and LTR swipe actions are disabled, then we disable the DismissDirection temporarily
               // to allow for the full screen swipe to go back. Otherwise, we retain the default behaviour
               if (horizontalDragDistance > 0) {
-                if (determineCommentSwipeDirection(isUserLoggedIn, state) == DismissDirection.endToStart && isOverridingSwipeGestureAction == false && dismissThreshold == 0.0) {
+                if (determineCommentSwipeDirection(context) == DismissDirection.endToStart && isOverridingSwipeGestureAction == false && dismissThreshold == 0.0) {
                   setState(() => isOverridingSwipeGestureAction = true);
                 }
               } else {
-                if (determineCommentSwipeDirection(isUserLoggedIn, state) == DismissDirection.endToStart && isOverridingSwipeGestureAction == true) {
+                if (determineCommentSwipeDirection(context) == DismissDirection.endToStart && isOverridingSwipeGestureAction == true) {
                   setState(() => isOverridingSwipeGestureAction = false);
                 }
               }
             },
             child: Dismissible(
               key: ObjectKey(widget.commentView.comment.id),
-              direction: isOverridingSwipeGestureAction == true ? DismissDirection.none : determineCommentSwipeDirection(isUserLoggedIn, state),
+              direction: isOverridingSwipeGestureAction == true ? DismissDirection.none : determineCommentSwipeDirection(context),
               resizeDuration: Duration.zero,
               dismissThresholds: const {DismissDirection.endToStart: 1, DismissDirection.startToEnd: 1},
               confirmDismiss: (DismissDirection direction) async => false,

--- a/lib/community/pages/create_post_page.dart
+++ b/lib/community/pages/create_post_page.dart
@@ -545,7 +545,6 @@ class _CreatePostPageState extends State<CreatePostPage> {
                                 edgeToEdgeImages: false,
                                 viewMode: ViewMode.comfortable,
                                 markPostReadOnMediaView: false,
-                                isUserLoggedIn: true,
                                 media: Media(
                                   originalUrl: url,
                                   mediaUrl: isImageUrl(url)

--- a/lib/community/utils/post_actions.dart
+++ b/lib/community/utils/post_actions.dart
@@ -54,7 +54,11 @@ void triggerPostAction({
   }
 }
 
-DismissDirection determinePostSwipeDirection(bool isUserLoggedIn, ThunderState state, {bool disableSwiping = false}) {
+/// Determine the direction of the swipe based on the current state
+DismissDirection determinePostSwipeDirection(BuildContext context, {bool disableSwiping = false}) {
+  final state = context.read<ThunderBloc>().state;
+  final isUserLoggedIn = context.read<AuthBloc>().state.isLoggedIn;
+
   if (!isUserLoggedIn) return DismissDirection.none;
 
   if (state.enablePostGestures == false) return DismissDirection.none;

--- a/lib/community/widgets/post_card.dart
+++ b/lib/community/widgets/post_card.dart
@@ -61,7 +61,7 @@ class PostCard extends StatefulWidget {
 }
 
 class _PostCardState extends State<PostCard> {
-  /// The current point at which the user drags the comment
+  /// The current point at which the user drags the post card
   double dismissThreshold = 0;
 
   /// The current swipe action that would be performed if the user let go off the screen
@@ -76,9 +76,6 @@ class _PostCardState extends State<PostCard> {
   /// The second action threshold to trigger the left or right actions (downvote/save)
   double secondActionThreshold = 0.35;
 
-  /// User Settings
-  bool isUserLoggedIn = false;
-
   /// This is used to temporarily disable the swipe action to allow for detection of full screen swipe to go back
   bool isOverridingSwipeGestureAction = false;
 
@@ -86,28 +83,24 @@ class _PostCardState extends State<PostCard> {
   double verticalDragDistance = 0;
 
   @override
-  void initState() {
-    super.initState();
-
-    isUserLoggedIn = context.read<AuthBloc>().state.isLoggedIn;
-  }
-
-  @override
   Widget build(BuildContext context) {
-    final ThunderState state = context.read<ThunderBloc>().state;
+    final state = context.read<ThunderBloc>().state;
 
-    int? myVote = widget.postViewMedia.postView.myVote;
-    bool saved = widget.postViewMedia.postView.saved;
-    bool read = widget.postViewMedia.postView.read;
-    bool? hidden = widget.postViewMedia.postView.hidden;
+    final postView = widget.postViewMedia.postView;
+
+    int? myVote = postView.myVote;
+    bool saved = postView.saved;
+    bool read = postView.read;
+    bool? hidden = postView.hidden;
+
+    // Determine the post swipe direction
+    final postSwipeDirection = determinePostSwipeDirection(context, disableSwiping: widget.disableSwiping);
 
     return Listener(
       behavior: HitTestBehavior.opaque,
-      onPointerDown: (PointerDownEvent event) {
-        widget.onDownAction();
-      },
-      onPointerUp: (event) {
-        setState(() => isOverridingSwipeGestureAction = false);
+      onPointerDown: (_) => widget.onDownAction(),
+      onPointerUp: (_) {
+        if (isOverridingSwipeGestureAction == true) setState(() => isOverridingSwipeGestureAction = false);
 
         if (swipeAction != null && swipeAction != SwipeAction.none) {
           triggerPostAction(
@@ -127,38 +120,31 @@ class _PostCardState extends State<PostCard> {
 
         widget.onUpAction(verticalDragDistance);
       },
-      onPointerCancel: (event) => {},
+      onPointerCancel: (_) => {},
       onPointerMove: (PointerMoveEvent event) {
-        // Get the horizontal drag distance
-        double horizontalDragDistance = event.delta.dx;
-
-        // Set the vertical drag distance
+        // Update the vertical drag distance
         verticalDragDistance = event.delta.dy;
 
-        // We are checking to see if there is a left to right swipe here. If there is a left to right swipe, and LTR swipe actions are disabled, then we disable the DismissDirection temporarily
-        // to allow for the full screen swipe to go back. Otherwise, we retain the default behaviour
-        if (horizontalDragDistance > 0) {
-          if (determinePostSwipeDirection(isUserLoggedIn, state, disableSwiping: widget.disableSwiping) == DismissDirection.endToStart &&
-              isOverridingSwipeGestureAction == false &&
-              dismissThreshold == 0.0) {
-            setState(() => isOverridingSwipeGestureAction = true);
-          }
-        } else {
-          if (determinePostSwipeDirection(isUserLoggedIn, state, disableSwiping: widget.disableSwiping) == DismissDirection.endToStart && isOverridingSwipeGestureAction == true) {
-            setState(() => isOverridingSwipeGestureAction = false);
-          }
+        // Get the horizontal drag distance
+        final horizontalDragDistance = event.delta.dx;
+
+        // We are checking to see if there is a left to right swipe here.
+        // If there is a LTR swipe and LTR swipe actions are disabled, then we disable the DismissDirection temporarily to allow for the full screen swipe to go back.
+        // Otherwise, we retain the default behaviour
+        if (horizontalDragDistance > 0 && postSwipeDirection == DismissDirection.endToStart && isOverridingSwipeGestureAction == false && dismissThreshold == 0.0) {
+          setState(() => isOverridingSwipeGestureAction = true);
+        } else if (postSwipeDirection == DismissDirection.endToStart && isOverridingSwipeGestureAction == true) {
+          setState(() => isOverridingSwipeGestureAction = false);
         }
       },
       child: Column(
         children: [
           Dismissible(
-            direction: isOverridingSwipeGestureAction == true ? DismissDirection.none : determinePostSwipeDirection(isUserLoggedIn, state, disableSwiping: widget.disableSwiping),
-            key: ObjectKey(widget.postViewMedia.postView.post.id),
+            direction: isOverridingSwipeGestureAction == true ? DismissDirection.none : postSwipeDirection,
+            key: ObjectKey(postView.post.id),
             resizeDuration: Duration.zero,
             dismissThresholds: const {DismissDirection.endToStart: 1, DismissDirection.startToEnd: 1},
-            confirmDismiss: (DismissDirection direction) async {
-              return false;
-            },
+            confirmDismiss: (_) async => false,
             onUpdate: (DismissUpdateDetails details) {
               SwipeAction? updatedSwipeAction;
 
@@ -244,7 +230,6 @@ class _PostCardState extends State<PostCard> {
                   ? PostCardViewCompact(
                       postViewMedia: widget.postViewMedia,
                       feedType: widget.feedType,
-                      isUserLoggedIn: isUserLoggedIn,
                       listingType: widget.listingType,
                       navigateToPost: ({PostViewMedia? postViewMedia}) async {
                         widget.onTap.call();
@@ -268,7 +253,6 @@ class _PostCardState extends State<PostCard> {
                       showSaveAction: state.showSaveAction,
                       showCommunityIcons: state.showCommunityIcons,
                       showTextContent: state.showTextContent,
-                      isUserLoggedIn: isUserLoggedIn,
                       onVoteAction: widget.onVoteAction,
                       onSaveAction: widget.onSaveAction,
                       listingType: widget.listingType,
@@ -287,7 +271,7 @@ class _PostCardState extends State<PostCard> {
 
                   switch (postAction) {
                     case PostAction.hide:
-                      context.read<FeedBloc>().add(FeedDismissHiddenPostEvent(postId: postViewMedia.postView.post.id));
+                      context.read<FeedBloc>().add(FeedDismissHiddenPostEvent(postId: postView.post.id));
                       break;
                     default:
                       break;
@@ -295,7 +279,7 @@ class _PostCardState extends State<PostCard> {
 
                   switch (userAction) {
                     case UserAction.block:
-                      context.read<FeedBloc>().add(FeedDismissBlockedEvent(userId: postViewMedia.postView.creator.id));
+                      context.read<FeedBloc>().add(FeedDismissBlockedEvent(userId: postView.creator.id));
                       break;
                     default:
                       break;
@@ -303,7 +287,7 @@ class _PostCardState extends State<PostCard> {
 
                   switch (communityAction) {
                     case CommunityAction.block:
-                      context.read<FeedBloc>().add(FeedDismissBlockedEvent(communityId: postViewMedia.postView.community.id));
+                      context.read<FeedBloc>().add(FeedDismissBlockedEvent(communityId: postView.community.id));
                       break;
                     default:
                       break;
@@ -311,8 +295,9 @@ class _PostCardState extends State<PostCard> {
                 },
               ),
               onTap: () async {
+                final isUserLoggedIn = context.read<AuthBloc>().state.isLoggedIn;
+
                 widget.onTap.call();
-                PostView postView = widget.postViewMedia.postView;
                 if (postView.read == false && isUserLoggedIn) context.read<FeedBloc>().add(FeedItemActionedEvent(postId: postView.post.id, postAction: PostAction.read, value: true));
                 return await navigateToPost(context, postViewMedia: widget.postViewMedia);
               },

--- a/lib/community/widgets/post_card_actions.dart
+++ b/lib/community/widgets/post_card_actions.dart
@@ -33,6 +33,9 @@ class PostCardActions extends StatelessWidget {
   Widget build(BuildContext context) {
     final l10n = AppLocalizations.of(context)!;
 
+    final isUserLoggedIn = context.select((AuthBloc bloc) => bloc.state.isLoggedIn);
+    if (isUserLoggedIn) return const SizedBox.shrink();
+
     return BlocBuilder<ThunderBloc, ThunderState>(
       buildWhen: (previous, current) {
         return previous.upvoteColor != current.upvoteColor ||

--- a/lib/community/widgets/post_card_view_comfortable.dart
+++ b/lib/community/widgets/post_card_view_comfortable.dart
@@ -38,7 +38,6 @@ class PostCardViewComfortable extends StatelessWidget {
   final bool showSaveAction;
   final bool showCommunityIcons;
   final bool showTextContent;
-  final bool isUserLoggedIn;
   final bool markPostReadOnMediaView;
   final ListingType? listingType;
   final void Function({PostViewMedia? postViewMedia})? navigateToPost;
@@ -59,7 +58,6 @@ class PostCardViewComfortable extends StatelessWidget {
     required this.showSaveAction,
     required this.showCommunityIcons,
     required this.showTextContent,
-    required this.isUserLoggedIn,
     required this.onVoteAction,
     required this.onSaveAction,
     required this.markPostReadOnMediaView,
@@ -95,7 +93,7 @@ class PostCardViewComfortable extends StatelessWidget {
     final counts = postView.counts;
     final media = postViewMedia.media.firstOrNull;
 
-    final showCommunitySubscription = isUserLoggedIn && (listingType == ListingType.all || listingType == ListingType.local) && postView.subscribed != SubscribedType.notSubscribed;
+    final showCommunitySubscription = (listingType == ListingType.all || listingType == ListingType.local) && postView.subscribed != SubscribedType.notSubscribed;
     bool indicateRead = this.indicateRead ?? context.select((ThunderBloc bloc) => bloc.state.dimReadPosts);
     final textContent = post.body ?? "";
     final readColor = indicateRead && postView.read ? theme.textTheme.bodyMedium?.color?.withValues(alpha: 0.45) : theme.textTheme.bodyMedium?.color?.withValues(alpha: 0.90);
@@ -113,7 +111,6 @@ class PostCardViewComfortable extends StatelessWidget {
         hideThumbnails: hideThumbnails,
         edgeToEdgeImages: edgeToEdgeImages,
         markPostReadOnMediaView: markPostReadOnMediaView,
-        isUserLoggedIn: isUserLoggedIn,
         navigateToPost: navigateToPost,
         read: indicateRead && postView.read,
       );
@@ -250,7 +247,7 @@ class PostCardViewComfortable extends StatelessWidget {
 
                       HapticFeedback.mediumImpact();
                     }),
-                if (isUserLoggedIn) PostCardActions(voteType: postView.myVote ?? 0, saved: postView.saved, onVoteAction: onVoteAction, onSaveAction: onSaveAction),
+                PostCardActions(voteType: postView.myVote ?? 0, saved: postView.saved, onVoteAction: onVoteAction, onSaveAction: onSaveAction),
               ],
             ),
           )

--- a/lib/community/widgets/post_card_view_compact.dart
+++ b/lib/community/widgets/post_card_view_compact.dart
@@ -21,9 +21,6 @@ class PostCardViewCompact extends StatelessWidget {
   /// The type of feed that the post is in.
   final FeedType? feedType;
 
-  /// Determines whether the user is logged in or not.
-  final bool isUserLoggedIn;
-
   /// The type of listing that the post is in.
   final ListingType? listingType;
 
@@ -43,7 +40,6 @@ class PostCardViewCompact extends StatelessWidget {
     super.key,
     required this.postViewMedia,
     required this.feedType,
-    required this.isUserLoggedIn,
     required this.listingType,
     this.navigateToPost,
     this.indicateRead,
@@ -71,7 +67,7 @@ class PostCardViewCompact extends StatelessWidget {
   Widget build(BuildContext context) {
     final showThumbnailPreviewOnRight = context.select((ThunderBloc bloc) => bloc.state.showThumbnailPreviewOnRight);
     final showTextPostIndicator = context.select((ThunderBloc bloc) => bloc.state.showTextPostIndicator);
-    final showCommunitySubscription = isUserLoggedIn && (listingType == ListingType.all || listingType == ListingType.local) && postViewMedia.postView.subscribed != SubscribedType.notSubscribed;
+    final showCommunitySubscription = (listingType == ListingType.all || listingType == ListingType.local) && postViewMedia.postView.subscribed != SubscribedType.notSubscribed;
 
     bool indicateRead = this.indicateRead ?? context.select((ThunderBloc bloc) => bloc.state.dimReadPosts);
 

--- a/lib/feed/widgets/feed_card_divider.dart
+++ b/lib/feed/widgets/feed_card_divider.dart
@@ -13,17 +13,23 @@ class FeedCardDivider extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
-    final state = context.watch<ThunderBloc>().state;
 
-    final feedCardDividerThickness = state.feedCardDividerThickness;
-    final feedCardDividerColor = state.feedCardDividerColor;
+    return BlocBuilder<ThunderBloc, ThunderState>(
+      buildWhen: (previous, current) {
+        return previous.feedCardDividerThickness != current.feedCardDividerThickness || previous.feedCardDividerColor != current.feedCardDividerColor;
+      },
+      builder: (context, state) {
+        final feedCardDividerThickness = state.feedCardDividerThickness;
+        final feedCardDividerColor = state.feedCardDividerColor;
 
-    return Divider(
-      height: feedCardDividerThickness.value,
-      thickness: feedCardDividerThickness.value,
-      color: feedCardDividerColor == Colors.transparent
-          ? ElevationOverlay.applySurfaceTint(theme.colorScheme.surface, theme.colorScheme.surfaceTint, 10)
-          : Color.alphaBlend(theme.colorScheme.primaryContainer.withValues(alpha: 0.6), feedCardDividerColor).withValues(alpha: 0.2),
+        return Divider(
+          height: feedCardDividerThickness.value,
+          thickness: feedCardDividerThickness.value,
+          color: feedCardDividerColor == Colors.transparent
+              ? ElevationOverlay.applySurfaceTint(theme.colorScheme.surface, theme.colorScheme.surfaceTint, 10)
+              : Color.alphaBlend(theme.colorScheme.primaryContainer.withValues(alpha: 0.6), feedCardDividerColor).withValues(alpha: 0.2),
+        );
+      },
     );
   }
 }

--- a/lib/moderator/view/report_page.dart
+++ b/lib/moderator/view/report_page.dart
@@ -229,7 +229,6 @@ class _ReportFeedViewState extends State<ReportFeedView> {
                                               showMedia: false,
                                               postViewMedia: PostViewMedia(postView: postView, media: [Media(mediaType: MediaType.text)]),
                                               feedType: FeedType.general,
-                                              isUserLoggedIn: false,
                                               listingType: ListingType.all,
                                               isLastTapped: false,
                                             ),

--- a/lib/post/utils/comment_actions.dart
+++ b/lib/post/utils/comment_actions.dart
@@ -64,7 +64,10 @@ void triggerCommentAction({
   }
 }
 
-DismissDirection determineCommentSwipeDirection(bool isUserLoggedIn, ThunderState state) {
+DismissDirection determineCommentSwipeDirection(BuildContext context) {
+  final state = context.read<ThunderBloc>().state;
+  final isUserLoggedIn = context.read<AuthBloc>().state.isLoggedIn;
+
   if (!isUserLoggedIn) return DismissDirection.none;
 
   if (state.enableCommentGestures == false) return DismissDirection.none;

--- a/lib/post/widgets/post_view.dart
+++ b/lib/post/widgets/post_view.dart
@@ -191,7 +191,6 @@ class _PostSubviewState extends State<PostSubview> with SingleTickerProviderStat
                   allowUnconstrainedImageHeight: true,
                   hideNsfwPreviews: hideNsfwPreviews,
                   markPostReadOnMediaView: markPostReadOnMediaView,
-                  isUserLoggedIn: isUserLoggedIn,
                 ),
               ),
             if (widget.postViewMedia.postView.post.body?.isNotEmpty == true)
@@ -394,7 +393,6 @@ class _PostSubviewState extends State<PostSubview> with SingleTickerProviderStat
             hideNsfwPreviews: hideNsfwPreviews,
             markPostReadOnMediaView: markPostReadOnMediaView,
             viewMode: ViewMode.compact,
-            isUserLoggedIn: isUserLoggedIn,
           ),
         ),
         Padding(

--- a/lib/settings/pages/post_appearance_settings_page.dart
+++ b/lib/settings/pages/post_appearance_settings_page.dart
@@ -510,7 +510,6 @@ class _PostAppearanceSettingsPageState extends State<PostAppearanceSettingsPage>
                                         child: PostCardViewCompact(
                                           postViewMedia: snapshot.data![index]!,
                                           feedType: FeedType.general,
-                                          isUserLoggedIn: true,
                                           listingType: ListingType.all,
                                           indicateRead: dimReadPosts,
                                           isLastTapped: false,
@@ -524,7 +523,6 @@ class _PostAppearanceSettingsPageState extends State<PostAppearanceSettingsPage>
                                           hideNsfwPreviews: hideNsfwPreviews,
                                           feedType: FeedType.general,
                                           markPostReadOnMediaView: false,
-                                          isUserLoggedIn: true,
                                           listingType: ListingType.all,
                                           indicateRead: dimReadPosts,
                                           edgeToEdgeImages: showEdgeToEdgeImages,

--- a/lib/shared/comment_reference.dart
+++ b/lib/shared/comment_reference.dart
@@ -201,17 +201,17 @@ class _CommentReferenceState extends State<CommentReference> {
                       // We are checking to see if there is a left to right swipe here. If there is a left to right swipe, and LTR swipe actions are disabled, then we disable the DismissDirection temporarily
                       // to allow for the full screen swipe to go back. Otherwise, we retain the default behaviour
                       if (horizontalDragDistance > 0) {
-                        if (determineCommentSwipeDirection(isUserLoggedIn, state) == DismissDirection.endToStart && isOverridingSwipeGestureAction == false && dismissThreshold == 0.0) {
+                        if (determineCommentSwipeDirection(context) == DismissDirection.endToStart && isOverridingSwipeGestureAction == false && dismissThreshold == 0.0) {
                           setState(() => isOverridingSwipeGestureAction = true);
                         }
                       } else {
-                        if (determineCommentSwipeDirection(isUserLoggedIn, state) == DismissDirection.endToStart && isOverridingSwipeGestureAction == true) {
+                        if (determineCommentSwipeDirection(context) == DismissDirection.endToStart && isOverridingSwipeGestureAction == true) {
                           setState(() => isOverridingSwipeGestureAction = false);
                         }
                       }
                     },
                     child: Dismissible(
-                      direction: (widget.disableActions || isOverridingSwipeGestureAction == true) ? DismissDirection.none : determineCommentSwipeDirection(isUserLoggedIn, state),
+                      direction: (widget.disableActions || isOverridingSwipeGestureAction == true) ? DismissDirection.none : determineCommentSwipeDirection(context),
                       key: ObjectKey(widget.comment.comment.id),
                       resizeDuration: Duration.zero,
                       dismissThresholds: const {DismissDirection.endToStart: 1, DismissDirection.startToEnd: 1},

--- a/lib/shared/media/compact_thumbnail_preview.dart
+++ b/lib/shared/media/compact_thumbnail_preview.dart
@@ -33,8 +33,6 @@ class CompactThumbnailPreview extends StatelessWidget {
     final hideNsfwPreviews = context.select((ThunderBloc bloc) => bloc.state.hideNsfwPreviews);
     final markPostReadOnMediaView = context.select((ThunderBloc bloc) => bloc.state.markPostReadOnMediaView);
 
-    final isUserLoggedIn = context.select((AuthBloc bloc) => bloc.state.isLoggedIn);
-
     return ExcludeSemantics(
       child: Stack(
         alignment: AlignmentDirectional.bottomEnd,
@@ -47,7 +45,6 @@ class CompactThumbnailPreview extends StatelessWidget {
               hideNsfwPreviews: hideNsfwPreviews,
               markPostReadOnMediaView: markPostReadOnMediaView,
               viewMode: ViewMode.compact,
-              isUserLoggedIn: isUserLoggedIn,
               navigateToPost: navigateToPost,
               read: dim,
             ),

--- a/lib/shared/media/media_view.dart
+++ b/lib/shared/media/media_view.dart
@@ -3,6 +3,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 
+import 'package:thunder/core/auth/bloc/auth_bloc.dart';
 import 'package:thunder/core/models/media.dart';
 import 'package:thunder/shared/image/image_preview.dart';
 import 'package:thunder/shared/link_information.dart';
@@ -42,9 +43,6 @@ class MediaView extends StatefulWidget {
   /// Whether to mark the post as read when the media is viewed
   final bool markPostReadOnMediaView;
 
-  /// Whether the user is logged in
-  final bool isUserLoggedIn;
-
   /// The view mode of the media
   final ViewMode viewMode;
 
@@ -64,7 +62,6 @@ class MediaView extends StatefulWidget {
     this.hideNsfwPreviews = true,
     this.hideThumbnails = false,
     this.markPostReadOnMediaView = false,
-    this.isUserLoggedIn = false,
     this.viewMode = ViewMode.comfortable,
     this.navigateToPost,
     this.read,
@@ -95,14 +92,8 @@ class _MediaViewState extends State<MediaView> with TickerProviderStateMixin {
 
   /// Overlays the image as an ImageViewer
   void showImage() {
-    if (widget.isUserLoggedIn && widget.markPostReadOnMediaView) {
-      try {
-        // Mark post as read when on the feed page
-        context.read<FeedBloc>().add(FeedItemActionedEvent(postAction: PostAction.read, postId: widget.postId, value: true));
-      } catch (e) {
-        // Do nothing otherwise
-      }
-    }
+    handleTap();
+
     Navigator.of(context).push(
       PageRouteBuilder(
         opaque: false,
@@ -147,7 +138,9 @@ class _MediaViewState extends State<MediaView> with TickerProviderStateMixin {
   }
 
   void handleTap() {
-    if (widget.isUserLoggedIn && widget.markPostReadOnMediaView) {
+    final isUserLoggedIn = context.read<AuthBloc>().state.isLoggedIn;
+
+    if (isUserLoggedIn && widget.markPostReadOnMediaView) {
       try {
         final feedBloc = BlocProvider.of<FeedBloc>(context);
         feedBloc.add(FeedItemActionedEvent(postAction: PostAction.read, postId: widget.postId, value: true));

--- a/lib/utils/navigation.dart
+++ b/lib/utils/navigation.dart
@@ -188,7 +188,7 @@ Future<void> navigateToPost(
     backGestureDetectionStartOffset: !kIsWeb && Platform.isAndroid ? 45 : 0,
     backGestureDetectionWidth: 45,
     canSwipe: Platform.isIOS || enableFullScreenSwipeNavigationGesture,
-    canOnlySwipeFromEdge: disableFullPageSwipe(isUserLoggedIn: authBloc.state.isLoggedIn, state: state, isPostPage: true) || !enableFullScreenSwipeNavigationGesture,
+    canOnlySwipeFromEdge: disableFullPageSwipe(context, isPostPage: true) || !enableFullScreenSwipeNavigationGesture,
     builder: (_) {
       return MultiBlocProvider(
         providers: [
@@ -299,7 +299,7 @@ Future<void> navigateToComment(BuildContext context, CommentView commentView) as
     reverseTransitionDuration: reduceAnimations ? const Duration(milliseconds: 100) : const Duration(milliseconds: 500),
     backGestureDetectionWidth: 45,
     canSwipe: Platform.isIOS || state.enableFullScreenSwipeNavigationGesture,
-    canOnlySwipeFromEdge: disableFullPageSwipe(isUserLoggedIn: authBloc.state.isLoggedIn, state: thunderBloc.state, isPostPage: true) || !state.enableFullScreenSwipeNavigationGesture,
+    canOnlySwipeFromEdge: disableFullPageSwipe(context, isPostPage: true) || !state.enableFullScreenSwipeNavigationGesture,
     builder: (context) => MultiBlocProvider(
       providers: [
         BlocProvider.value(value: accountBloc),
@@ -637,7 +637,7 @@ Future<void> navigateToFeedPage(
     reverseTransitionDuration: reduceAnimations ? const Duration(milliseconds: 100) : const Duration(milliseconds: 500),
     backGestureDetectionWidth: 45,
     canSwipe: Platform.isIOS || thunderState.enableFullScreenSwipeNavigationGesture,
-    canOnlySwipeFromEdge: disableFullPageSwipe(isUserLoggedIn: authBloc.state.isLoggedIn, state: thunderBloc.state, isFeedPage: true) || !thunderState.enableFullScreenSwipeNavigationGesture,
+    canOnlySwipeFromEdge: disableFullPageSwipe(context, isFeedPage: true) || !thunderState.enableFullScreenSwipeNavigationGesture,
     builder: (context) => MultiBlocProvider(
       providers: [
         BlocProvider.value(value: accountBloc),

--- a/lib/utils/swipe.dart
+++ b/lib/utils/swipe.dart
@@ -1,9 +1,9 @@
 import 'package:flutter/widgets.dart';
+
 import 'package:thunder/community/utils/post_actions.dart';
 import 'package:thunder/post/utils/comment_actions.dart';
-import 'package:thunder/thunder/bloc/thunder_bloc.dart';
 
-bool disableFullPageSwipe({bool isUserLoggedIn = false, required ThunderState state, bool isPostPage = false, isFeedPage = false}) {
+bool disableFullPageSwipe(BuildContext context, {bool isPostPage = false, isFeedPage = false}) {
   if (isPostPage == false && isFeedPage == false) {
     return false;
   }
@@ -12,12 +12,12 @@ bool disableFullPageSwipe({bool isUserLoggedIn = false, required ThunderState st
 
   if (isPostPage) {
     // If the page we are pushing is a post type page, then we check for swipe actions on comments
-    direction = determineCommentSwipeDirection(isUserLoggedIn, state);
+    direction = determineCommentSwipeDirection(context);
   }
 
   if (isFeedPage) {
     // If the page we are pushing is a feed type page (community/user page), then we check for swipe actions on posts
-    direction = determinePostSwipeDirection(isUserLoggedIn, state);
+    direction = determinePostSwipeDirection(context);
   }
 
   if (direction == DismissDirection.none || direction == DismissDirection.endToStart) {


### PR DESCRIPTION
## Pull Request Description

This PR will place some additional focus on refactoring the general post card (that handles both compact/card views), and removing unnecessary prop-drilling of parameters.

For some context: there are a few places that I am seeing where we are passing down a lot of parameters (prop-drilling) that can instead be derived from their respective blocs. For example, in `PostCardViewComfortable`, we are passing down parameters that come from the `ThunderBloc` (e.g., `showEdgeToEdgeImages`, `showTitleFirst`, etc.)

The goal here is to reduce these and instead rely on reading the parameters from the bloc!

This will stay in draft status as it's still a WIP.

<!--- Please describe what was changed -->

## Issue Being Fixed

<!-- Please describe the problem that is being fixed and, if applicable, reference a GitHub issue -->

Issue Number: N/A

## Screenshots / Recordings

<!-- This section is optional but highly recommended to show off your changes! -->

## Checklist

- [ ] If a new package was added, did you ensure it uses an appropriate license and is actively maintained?
- [ ] Did you use localized strings (and added appropriate descriptions) where applicable?
- [ ] Did you add `semanticLabel`s where applicable for accessibility?
