### PR TITLE
Fix search keyboard popping up

### DIFF
--- a/lib/search/pages/search_page.dart
+++ b/lib/search/pages/search_page.dart
@@ -126,11 +126,7 @@ class _SearchPageState extends State<SearchPage> with AutomaticKeepAliveClientMi
   }
 
   FutureOr<bool> _handleBackButtonPress(bool stopDefaultButtonEvent, RouteInfo info) async {
-    if (searchTextFieldFocus.hasFocus) {
-      searchTextFieldFocus.unfocus();
-      return true;
-    }
-
+    if (searchTextFieldFocus.hasFocus) searchTextFieldFocus.unfocus();
     return false;
   }
 

--- a/lib/search/pages/search_page.dart
+++ b/lib/search/pages/search_page.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 import 'dart:io';
 
+import 'package:back_button_interceptor/back_button_interceptor.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
@@ -96,6 +97,7 @@ class _SearchPageState extends State<SearchPage> with AutomaticKeepAliveClientMi
       WidgetsBinding.instance.addPostFrameCallback((_) => searchTextFieldFocus.requestFocus());
     }
 
+    BackButtonInterceptor.add(_handleBackButtonPress);
     super.initState();
   }
 
@@ -121,6 +123,15 @@ class _SearchPageState extends State<SearchPage> with AutomaticKeepAliveClientMi
   void deactivate() {
     _saveToDB();
     super.deactivate();
+  }
+
+  FutureOr<bool> _handleBackButtonPress(bool stopDefaultButtonEvent, RouteInfo info) async {
+    if (searchTextFieldFocus.hasFocus) {
+      searchTextFieldFocus.unfocus();
+      return true;
+    }
+
+    return false;
   }
 
   void _onScroll() {


### PR DESCRIPTION
## Pull Request Description

This PR fixes another instance of https://github.com/thunder-app/thunder/pull/1686 where the keyboard would pop back up in some cases after navigating away from the search page. I've added a back handler to unfocus the search field whenever a back action is detected!

<!--- Please describe what was changed -->

## Issue Being Fixed

<!-- Please describe the problem that is being fixed and, if applicable, reference a GitHub issue -->

Issue Number: https://lemmy.world/comment/15551618

## Screenshots / Recordings

<!-- This section is optional but highly recommended to show off your changes! -->

## Checklist

- [ ] If a new package was added, did you ensure it uses an appropriate license and is actively maintained?
- [ ] Did you use localized strings (and added appropriate descriptions) where applicable?
- [ ] Did you add `semanticLabel`s where applicable for accessibility?
