### PR TITLE
Fix issue with overlapping icons on compact mode

### DIFF
--- a/lib/shared/image/image_preview.dart
+++ b/lib/shared/image/image_preview.dart
@@ -88,14 +88,7 @@ class _ImagePreviewState extends State<ImagePreview> with SingleTickerProviderSt
 
   @override
   Widget build(BuildContext context) {
-    if (!_isValidImageUrl) {
-      return Center(
-        child: Icon(
-          _getErrorIcon(widget.mediaType),
-          color: Theme.of(context).colorScheme.onSecondaryContainer.withValues(alpha: widget.viewed == true ? 0.55 : 1.0),
-        ),
-      );
-    }
+    if (!_isValidImageUrl) return _fallbackWidget();
 
     return BlocSelector<ThunderBloc, ThunderState, ImageCachingMode>(
       selector: (state) => state.imageCachingMode,
@@ -106,7 +99,6 @@ class _ImagePreviewState extends State<ImagePreview> with SingleTickerProviderSt
   }
 
   Widget _buildImage(BuildContext context, ImageCachingMode imageCachingMode) {
-    final theme = Theme.of(context);
     final devicePixelRatio = MediaQuery.devicePixelRatioOf(context).ceil();
 
     Widget image = ExtendedImage.network(
@@ -134,12 +126,7 @@ class _ImagePreviewState extends State<ImagePreview> with SingleTickerProviderSt
             _controller.reset();
             state.imageProvider.evict();
 
-            return Center(
-              child: Icon(
-                _getErrorIcon(widget.mediaType),
-                color: theme.colorScheme.onSecondaryContainer.withValues(alpha: widget.viewed == true ? 0.55 : 1.0),
-              ),
-            );
+            return _fallbackWidget();
         }
       },
     );
@@ -153,6 +140,20 @@ class _ImagePreviewState extends State<ImagePreview> with SingleTickerProviderSt
     }
 
     return image;
+  }
+
+  Widget _fallbackWidget() {
+    final theme = Theme.of(context);
+
+    // Don't display the associated icon if blur is enabled, otherwise there will be two icons displayed at once.
+    if (widget.blur == true) return SizedBox.shrink();
+
+    return Center(
+      child: Icon(
+        _getErrorIcon(widget.mediaType),
+        color: theme.colorScheme.onSecondaryContainer.withValues(alpha: widget.viewed == true ? 0.55 : 1.0),
+      ),
+    );
   }
 
   IconData _getErrorIcon(MediaType? mediaType) {

--- a/lib/shared/image/image_preview.dart
+++ b/lib/shared/image/image_preview.dart
@@ -88,7 +88,7 @@ class _ImagePreviewState extends State<ImagePreview> with SingleTickerProviderSt
 
   @override
   Widget build(BuildContext context) {
-    if (!_isValidImageUrl) return _fallbackWidget();
+    if (!_isValidImageUrl) return ImagePreviewError(mediaType: widget.mediaType, blur: widget.blur == true, viewed: widget.viewed == true);
 
     return BlocSelector<ThunderBloc, ThunderState, ImageCachingMode>(
       selector: (state) => state.imageCachingMode,
@@ -126,7 +126,7 @@ class _ImagePreviewState extends State<ImagePreview> with SingleTickerProviderSt
             _controller.reset();
             state.imageProvider.evict();
 
-            return _fallbackWidget();
+            return ImagePreviewError(mediaType: widget.mediaType, blur: widget.blur == true, viewed: widget.viewed == true);
         }
       },
     );
@@ -141,17 +141,32 @@ class _ImagePreviewState extends State<ImagePreview> with SingleTickerProviderSt
 
     return image;
   }
+}
 
-  Widget _fallbackWidget() {
+/// Displays the fallback widget when an image fails to load.
+class ImagePreviewError extends StatelessWidget {
+  /// The media type that the underlying image represents.
+  final MediaType? mediaType;
+
+  /// Whether the image should be blurred.
+  final bool blur;
+
+  /// Whether the image has been viewed. This will affect the opacity of the image.
+  final bool viewed;
+
+  const ImagePreviewError({super.key, this.mediaType, this.blur = false, this.viewed = false});
+
+  @override
+  Widget build(BuildContext context) {
     final theme = Theme.of(context);
 
     // Don't display the associated icon if blur is enabled, otherwise there will be two icons displayed at once.
-    if (widget.blur == true) return SizedBox.shrink();
+    if (blur == true) return SizedBox.shrink();
 
     return Center(
       child: Icon(
-        _getErrorIcon(widget.mediaType),
-        color: theme.colorScheme.onSecondaryContainer.withValues(alpha: widget.viewed == true ? 0.55 : 1.0),
+        _getErrorIcon(mediaType),
+        color: theme.colorScheme.onSecondaryContainer.withValues(alpha: viewed == true ? 0.55 : 1.0),
       ),
     );
   }


### PR DESCRIPTION
## Pull Request Description

This PR resolves a regression introduced by the recent `MediaView` PRs, where both the warning icon and media type icon would appear simultaneously when an image fails to load and NSFW preview blur is enabled.

I also moved the image error widget into its own widget to reduce code duplication!

<!--- Please describe what was changed -->

## Issue Being Fixed

<!-- Please describe the problem that is being fixed and, if applicable, reference a GitHub issue -->

Issue Number: N/A

## Screenshots / Recordings

<!-- This section is optional but highly recommended to show off your changes! -->

## Checklist

- [ ] If a new package was added, did you ensure it uses an appropriate license and is actively maintained?
- [ ] Did you use localized strings (and added appropriate descriptions) where applicable?
- [ ] Did you add `semanticLabel`s where applicable for accessibility?
