### PR TITLE
Improvements to feed page and app bars

### DIFF
--- a/lib/account/widgets/account_page_app_bar.dart
+++ b/lib/account/widgets/account_page_app_bar.dart
@@ -21,13 +21,17 @@ import 'package:thunder/utils/navigation.dart';
 class AccountPageAppBar extends StatefulWidget {
   const AccountPageAppBar({
     super.key,
-    this.showAppBarTitle = true,
     this.showSaved = false,
     this.onToggleSaved,
+    required this.status,
+    required this.scrollController,
   });
 
-  /// Whether to show the app bar title
-  final bool showAppBarTitle;
+  /// The status of the feed
+  final FeedStatus status;
+
+  /// The scroll controller for the feed. Used to determine when to show/hide the app bar title
+  final ScrollController scrollController;
 
   /// Whether or not to show saved posts/comments
   final bool showSaved;
@@ -43,13 +47,43 @@ class _AccountPageAppBarState extends State<AccountPageAppBar> {
   /// Whether or not to show saved posts. We store a local variable here so that the icon can be optimistically updated
   bool showSaved = false;
 
+  /// Whether to show the app bar title
+  bool showAppBarTitle = false;
+
+  void _onScroll() {
+    // Updates the [showAppBarTitle] value when the user has scrolled past a given threshold
+    if (widget.scrollController.position.pixels > 100.0 && showAppBarTitle == false) {
+      setState(() => showAppBarTitle = true);
+    } else if (widget.scrollController.position.pixels < 100.0 && showAppBarTitle == true) {
+      setState(() => showAppBarTitle = false);
+    }
+  }
+
+  @override
+  void initState() {
+    super.initState();
+    widget.scrollController.addListener(_onScroll);
+  }
+
   @override
   void didUpdateWidget(covariant AccountPageAppBar oldWidget) {
     super.didUpdateWidget(oldWidget);
 
-    if (showSaved != widget.showSaved && context.read<FeedBloc>().state.status == FeedStatus.success) {
+    if (widget.status != FeedStatus.initial) {
+      showAppBarTitle = true;
+    } else {
+      showAppBarTitle = false;
+    }
+
+    if (showSaved != widget.showSaved && widget.status == FeedStatus.success) {
       setState(() => showSaved = widget.showSaved);
     }
+  }
+
+  @override
+  void dispose() {
+    widget.scrollController.removeListener(_onScroll);
+    super.dispose();
   }
 
   @override
@@ -63,7 +97,7 @@ class _AccountPageAppBarState extends State<AccountPageAppBar> {
       titleSpacing: 0.0,
       toolbarHeight: 70.0,
       surfaceTintColor: state.hideTopBarOnScroll ? Colors.transparent : null,
-      title: AccountAppBarTitle(visible: widget.showAppBarTitle),
+      title: AccountAppBarTitle(visible: showAppBarTitle),
       leading: IconButton(
         onPressed: () {
           HapticFeedback.mediumImpact();

--- a/lib/feed/bloc/feed_bloc.dart
+++ b/lib/feed/bloc/feed_bloc.dart
@@ -609,7 +609,7 @@ class FeedBloc extends Bloc<FeedEvent, FeedState> {
     // Handle fetching the next page of the feed
     emit(state.copyWith(status: FeedStatus.fetching));
 
-    List<PostViewMedia> postViewMedias = List.from(state.postViewMedias);
+    List<PostViewMedia> postViewMedias = state.postViewMedias;
     List<CommentView> commentViews = List.from(state.commentViews);
 
     Map<String, dynamic> feedItemResult = await fetchFeedItems(

--- a/lib/feed/view/feed_page.dart
+++ b/lib/feed/view/feed_page.dart
@@ -177,9 +177,6 @@ class FeedView extends StatefulWidget {
 class _FeedViewState extends State<FeedView> {
   final ScrollController _scrollController = ScrollController();
 
-  /// Boolean which indicates whether the title on the app bar should be shown
-  bool showAppBarTitle = false;
-
   /// Boolean which indicates whether the community sidebar should be shown
   bool showCommunitySidebar = false;
 
@@ -205,13 +202,6 @@ class _FeedViewState extends State<FeedView> {
     super.initState();
 
     _scrollController.addListener(() {
-      // Updates the [showAppBarTitle] value when the user has scrolled past a given threshold
-      if (_scrollController.position.pixels > 100.0 && showAppBarTitle == false) {
-        setState(() => showAppBarTitle = true);
-      } else if (_scrollController.position.pixels < 100.0 && showAppBarTitle == true) {
-        setState(() => showAppBarTitle = false);
-      }
-
       // Fetches new posts when the user has scrolled past 70% list
       if (_scrollController.position.pixels > _scrollController.position.maxScrollExtent * 0.7 && context.read<FeedBloc>().state.status != FeedStatus.fetching) {
         context.read<FeedBloc>().add(FeedFetchedEvent(feedTypeSubview: selectedUserOption[0] ? FeedTypeSubview.post : FeedTypeSubview.comment));
@@ -333,7 +323,6 @@ class _FeedViewState extends State<FeedView> {
           top: false,
           child: BlocConsumer<FeedBloc, FeedState>(
             listenWhen: (previous, current) {
-              if (current.status == FeedStatus.initial) setState(() => showAppBarTitle = false);
               if (previous.scrollId != current.scrollId) _scrollController.animateTo(0, duration: const Duration(milliseconds: 300), curve: Curves.easeInOut);
               if (previous.dismissReadId != current.dismissReadId) dismissRead();
               if (current.dismissBlockedUserId != null || current.dismissBlockedCommunityId != null) dismissBlockedUsersAndCommunities(current.dismissBlockedUserId, current.dismissBlockedCommunityId);
@@ -384,7 +373,8 @@ class _FeedViewState extends State<FeedView> {
                       slivers: <Widget>[
                         widget.feedType == FeedType.account
                             ? AccountPageAppBar(
-                                showAppBarTitle: showAppBarTitle,
+                                status: state.status,
+                                scrollController: _scrollController,
                                 showSaved: state.showSaved,
                                 onToggleSaved: (showSaved) {
                                   context.read<FeedBloc>().add(
@@ -404,7 +394,9 @@ class _FeedViewState extends State<FeedView> {
                                 },
                               )
                             : FeedPageAppBar(
-                                showAppBarTitle: (state.feedType == FeedType.general && state.status != FeedStatus.initial) ? true : showAppBarTitle,
+                                status: state.status,
+                                feedType: state.feedType,
+                                scrollController: _scrollController,
                                 scaffoldStateKey: widget.scaffoldStateKey,
                               ),
                         // Display loading indicator until the feed is fetched
@@ -559,17 +551,11 @@ class _FeedViewState extends State<FeedView> {
                             ],
                           ),
                           // Widget representing the bottom of the feed (reached end or loading more posts indicators)
-                          if (state.status != FeedStatus.failureLoadingCommunity && state.status != FeedStatus.failureLoadingUser)
-                            SliverToBoxAdapter(
-                              child: ((selectedUserOption[0] && state.hasReachedPostsEnd) || (selectedUserOption[1] && state.hasReachedCommentsEnd))
-                                  ? const FeedReachedEnd()
-                                  : Container(
-                                      height: state.status == FeedStatus.initial ? MediaQuery.of(context).size.height * 0.5 : null, // Might have to adjust this to be more robust
-                                      alignment: Alignment.center,
-                                      padding: const EdgeInsets.symmetric(vertical: 16.0),
-                                      child: const CircularProgressIndicator(),
-                                    ),
-                            ),
+                          FeedEndIndicator(
+                            status: state.status,
+                            scrollController: _scrollController,
+                            hasReachedEnd: (selectedUserOption[0] && state.hasReachedPostsEnd) || (selectedUserOption[1] && state.hasReachedCommentsEnd),
+                          ),
                         ],
                       ],
                     ),
@@ -862,6 +848,75 @@ class FeedReachedEnd extends StatelessWidget {
         ),
         const SizedBox(height: 160)
       ],
+    );
+  }
+}
+
+/// A widget that displays the appropriate indicator when the user reaches the end of the feed.
+///
+/// If the user has reached the end of the feed, a [FeedReachedEnd] widget is displayed. Otherwise, a loading indicator is displayed.
+class FeedEndIndicator extends StatefulWidget {
+  const FeedEndIndicator({
+    super.key,
+    required this.status,
+    required this.scrollController,
+    this.hasReachedEnd = false,
+  });
+
+  /// The status of the feed
+  final FeedStatus status;
+
+  /// The scroll controller for the feed. Used to determine when to show/hide the app bar title
+  final ScrollController scrollController;
+
+  /// Whether the feed has reached the end
+  final bool hasReachedEnd;
+
+  @override
+  State<FeedEndIndicator> createState() => _FeedEndIndicatorState();
+}
+
+class _FeedEndIndicatorState extends State<FeedEndIndicator> {
+  /// Whether to show the feed end indicator or not
+  bool showFeedEndIndicator = false;
+
+  void _onReachEnd() {
+    if (widget.scrollController.position.pixels > widget.scrollController.position.maxScrollExtent - 100) {
+      setState(() => showFeedEndIndicator = true);
+    } else {
+      setState(() => showFeedEndIndicator = false);
+    }
+  }
+
+  @override
+  void initState() {
+    super.initState();
+    widget.scrollController.addListener(_onReachEnd);
+  }
+
+  @override
+  void dispose() {
+    widget.scrollController.removeListener(_onReachEnd);
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    if (widget.status != FeedStatus.failureLoadingCommunity && widget.status != FeedStatus.failureLoadingUser && showFeedEndIndicator) {
+      return SliverToBoxAdapter(
+        child: widget.hasReachedEnd
+            ? const FeedReachedEnd()
+            : Container(
+                height: widget.status == FeedStatus.initial ? MediaQuery.of(context).size.height * 0.5 : null, // Might have to adjust this to be more robust
+                alignment: Alignment.center,
+                padding: const EdgeInsets.symmetric(vertical: 16.0),
+                child: const CircularProgressIndicator(),
+              ),
+      );
+    }
+
+    return SliverToBoxAdapter(
+      child: Container(),
     );
   }
 }

--- a/lib/feed/widgets/feed_page_app_bar.dart
+++ b/lib/feed/widgets/feed_page_app_bar.dart
@@ -29,10 +29,22 @@ import 'package:thunder/thunder/bloc/thunder_bloc.dart';
 
 /// Holds the app bar for the feed page. The app bar actions changes depending on the type of feed (general, community, user)
 class FeedPageAppBar extends StatefulWidget {
-  const FeedPageAppBar({super.key, this.showAppBarTitle = true, this.scaffoldStateKey});
+  const FeedPageAppBar({
+    super.key,
+    required this.status,
+    this.feedType,
+    required this.scrollController,
+    this.scaffoldStateKey,
+  });
 
-  /// Whether to show the app bar title
-  final bool showAppBarTitle;
+  /// The status of the feed
+  final FeedStatus status;
+
+  /// The type of feed (general, community, user)
+  final FeedType? feedType;
+
+  /// The scroll controller for the feed. Used to determine when to show/hide the app bar title
+  final ScrollController scrollController;
 
   /// The scaffold key of the parent scaffold holding the drawer.
   /// This is used to determine if we are in a pushed navigation stack.
@@ -44,6 +56,41 @@ class FeedPageAppBar extends StatefulWidget {
 
 class _FeedPageAppBarState extends State<FeedPageAppBar> {
   Person? person;
+
+  /// Whether to show the app bar title
+  bool showAppBarTitle = false;
+
+  void _onScroll() {
+    // Updates the [showAppBarTitle] value when the user has scrolled past a given threshold
+    if (widget.scrollController.position.pixels > 100.0 && showAppBarTitle == false) {
+      setState(() => showAppBarTitle = true);
+    } else if (widget.scrollController.position.pixels < 100.0 && showAppBarTitle == true && widget.feedType != FeedType.general) {
+      setState(() => showAppBarTitle = false);
+    }
+  }
+
+  @override
+  void initState() {
+    super.initState();
+    widget.scrollController.addListener(_onScroll);
+  }
+
+  @override
+  void didUpdateWidget(covariant FeedPageAppBar oldWidget) {
+    super.didUpdateWidget(oldWidget);
+
+    if (widget.feedType == FeedType.general && widget.status != FeedStatus.initial) {
+      showAppBarTitle = true;
+    } else if (widget.status == FeedStatus.initial) {
+      showAppBarTitle = false;
+    }
+  }
+
+  @override
+  void dispose() {
+    widget.scrollController.removeListener(_onScroll);
+    super.dispose();
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -60,7 +107,7 @@ class _FeedPageAppBarState extends State<FeedPageAppBar> {
       centerTitle: false,
       toolbarHeight: 70.0,
       surfaceTintColor: thunderBloc.state.hideTopBarOnScroll ? Colors.transparent : null,
-      title: FeedAppBarTitle(visible: widget.showAppBarTitle),
+      title: FeedAppBarTitle(visible: showAppBarTitle),
       leadingWidth: widget.scaffoldStateKey != null && thunderBloc.state.useProfilePictureForDrawer && authState.isLoggedIn ? 50 : null,
       leading: feedBloc.state.status == FeedStatus.initial
           ? null


### PR DESCRIPTION
## Pull Request Description

This PR applies some improvements to the feed page to reduce a few sources of potential jank. In particular:
- The `showAppBarTitle` logic has been moved from `FeedPage` to its respective app bar widgets (`FeedPageAppBar` and `AccountPageAppBar`). This change ensures that `setState` calls are handled within the app bar widgets and prevents unnecessary rebuilds of the entire `FeedPage` when `showAppBarTitle` updates.
- A new widget was created `FeedEndIndicator` to display the appropriate element at the end of the feed (e.g., a loading icon or an "end of feed" message). While this change doesn't directly impact performance, it improves the experience when attempting to perform profiling on Thunder.

For some context on `FeedEndIndicator`:
- Previously, a loading indicator was always displayed at the end of the feed if additional items could be fetched from the API. This made it difficult to profile the app and detect jank frames as the loading animation constantly created new frames, causing any jank frames to disappear from the profiling tools.
- To improve profiling, I've adjusted the logic so that the loading indicator only appears when the user scrolls near the end of the feed. This prevents unnecessary frame generation and makes it easier to analyze and diagnose jank frames.

<!--- Please describe what was changed -->

## Issue Being Fixed

<!-- Please describe the problem that is being fixed and, if applicable, reference a GitHub issue -->

Issue Number: N/A

## Screenshots / Recordings

<!-- This section is optional but highly recommended to show off your changes! -->

## Checklist

- [ ] If a new package was added, did you ensure it uses an appropriate license and is actively maintained?
- [ ] Did you use localized strings (and added appropriate descriptions) where applicable?
- [ ] Did you add `semanticLabel`s where applicable for accessibility?
