### PR TITLE
Fix issue with media not being marked as read for compact posts

### DIFF
--- a/lib/community/widgets/post_card_view_compact.dart
+++ b/lib/community/widgets/post_card_view_compact.dart
@@ -95,7 +95,7 @@ class PostCardViewCompact extends StatelessWidget {
         crossAxisAlignment: CrossAxisAlignment.center,
         children: [
           !showThumbnailPreviewOnRight && showMedia && (postViewMedia.media.first.mediaType == MediaType.text ? showTextPostIndicator : true)
-              ? CompactThumbnailPreview(media: postViewMedia.media.first, dim: dim, navigateToPost: navigateToPost)
+              ? CompactThumbnailPreview(media: postViewMedia.media.first, dim: dim, postId: postViewMedia.postView.post.id, navigateToPost: navigateToPost)
               : const SizedBox(width: 8.0),
           Expanded(
             child: Column(
@@ -139,7 +139,7 @@ class PostCardViewCompact extends StatelessWidget {
             ),
           ),
           showThumbnailPreviewOnRight && showMedia && (postViewMedia.media.first.mediaType == MediaType.text ? showTextPostIndicator : true)
-              ? CompactThumbnailPreview(media: postViewMedia.media.first, dim: dim, navigateToPost: navigateToPost)
+              ? CompactThumbnailPreview(media: postViewMedia.media.first, dim: dim, postId: postViewMedia.postView.post.id, navigateToPost: navigateToPost)
               : const SizedBox(width: 8.0),
         ],
       ),

--- a/lib/shared/media/compact_thumbnail_preview.dart
+++ b/lib/shared/media/compact_thumbnail_preview.dart
@@ -18,6 +18,9 @@ class CompactThumbnailPreview extends StatelessWidget {
   /// This value can be overridden for special cases (e.g., viewing user account)
   final bool dim;
 
+  /// The post associated with the media
+  final int? postId;
+
   /// The callback function to navigate to the post
   final void Function()? navigateToPost;
 
@@ -25,6 +28,7 @@ class CompactThumbnailPreview extends StatelessWidget {
     super.key,
     required this.media,
     this.dim = false,
+    this.postId,
     this.navigateToPost,
   });
 
@@ -43,6 +47,7 @@ class CompactThumbnailPreview extends StatelessWidget {
             padding: const EdgeInsets.symmetric(horizontal: 10.0, vertical: 4.0),
             child: MediaView(
               media: media,
+              postId: postId,
               showFullHeightImages: false,
               hideNsfwPreviews: hideNsfwPreviews,
               markPostReadOnMediaView: markPostReadOnMediaView,


### PR DESCRIPTION
## Pull Request Description

This PR fixes an issue where tapping on the media thumbnail for compact posts would not mark the post as read. It turns out that `postId` was not properly passed into MediaView, which is needed in order to determine which post to mark as read!

<!--- Please describe what was changed -->

## Issue Being Fixed

<!-- Please describe the problem that is being fixed and, if applicable, reference a GitHub issue -->

Issue Number: N/A

## Screenshots / Recordings

<!-- This section is optional but highly recommended to show off your changes! -->

## Checklist

- [ ] If a new package was added, did you ensure it uses an appropriate license and is actively maintained?
- [ ] Did you use localized strings (and added appropriate descriptions) where applicable?
- [ ] Did you add `semanticLabel`s where applicable for accessibility?
