### PR TITLE
Fix community icon setting terminology

### DIFF
--- a/lib/core/enums/local_settings.dart
+++ b/lib/core/enums/local_settings.dart
@@ -535,7 +535,7 @@ extension LocalizationExt on AppLocalizations {
       'showCrossPosts': showCrossPosts,
       'postBodyShowUserInstance': postBodyShowUserInstance,
       'postBodyShowCommunityInstance': postBodyShowCommunityInstance,
-      'postBodyShowCommunityAvatar': postBodyShowCommunityAvatar,
+      'postBodyShowCommunityAvatar': showPostCommunityIcons,
       'keywordFilters': keywordFilters,
       'hideTopBarOnScroll': hideTopBarOnScroll,
       'showHiddenPosts': showHiddenPosts,

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -1719,10 +1719,6 @@
   "@postBodySettingsDescription": {
     "description": "Description of post body settings"
   },
-  "postBodyShowCommunityAvatar": "Show Community Avatar",
-  "@postBodyShowCommunityAvatar": {
-    "description": "Whether to show the community avatar for post bodies"
-  },
   "postBodyShowCommunityInstance": "Show Community Instance",
   "@postBodyShowCommunityInstance": {
     "description": "Whether to show the community instance for post bodies"

--- a/lib/settings/pages/post_appearance_settings_page.dart
+++ b/lib/settings/pages/post_appearance_settings_page.dart
@@ -1079,10 +1079,10 @@ class _PostAppearanceSettingsPageState extends State<PostAppearanceSettingsPage>
           ),
           SliverToBoxAdapter(
             child: ToggleOption(
-              description: l10n.postBodyShowCommunityAvatar,
+              description: l10n.showPostCommunityIcons,
               value: postBodyShowCommunityAvatar,
-              iconEnabled: Icons.image,
-              iconDisabled: Icons.image_not_supported,
+              iconEnabled: Icons.groups,
+              iconDisabled: Icons.groups,
               onToggle: (bool value) => setPreferences(LocalSettings.postBodyShowCommunityAvatar, value),
               highlightKey: settingToHighlightKey,
               setting: LocalSettings.postBodyShowCommunityAvatar,


### PR DESCRIPTION
## Pull Request Description

This is a small PR which fixes the terminology for community icons to be more consistent. "Show community avatar" has been changed to "Show community icons" under the Post Body Settings subsection. Additionally, the settings icon has been adjusted to match the other setting.

<!--- Please describe what was changed -->

## Issue Being Fixed

<!-- Please describe the problem that is being fixed and, if applicable, reference a GitHub issue -->

Issue Number: https://github.com/thunder-app/thunder/issues/1719

## Screenshots / Recordings

<!-- This section is optional but highly recommended to show off your changes! -->

## Checklist

- [ ] If a new package was added, did you ensure it uses an appropriate license and is actively maintained?
- [ ] Did you use localized strings (and added appropriate descriptions) where applicable?
- [ ] Did you add `semanticLabel`s where applicable for accessibility?
