### PR TITLE
Fix video player back button on landscape mode

### DIFF
--- a/lib/utils/video_player/src/thunder_youtube_player.dart
+++ b/lib/utils/video_player/src/thunder_youtube_player.dart
@@ -101,57 +101,53 @@ class _ThunderYoutubePlayerState extends State<ThunderYoutubePlayer> with Single
           right: false,
           child: Stack(
             children: [
-              Row(
-                mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                children: [
-                  Padding(
-                    padding: const EdgeInsets.all(4.0),
-                    child: IconButton(
-                      onPressed: () => Navigator.pop(context),
-                      icon: Icon(
-                        Icons.arrow_back,
-                        semanticLabel: MaterialLocalizations.of(context).backButtonTooltip,
-                        color: Colors.white.withValues(alpha: 0.90),
-                      ),
-                    ),
-                  ),
-                  Padding(
-                    padding: const EdgeInsets.all(4.0),
-                    child: IconButton(
-                      onPressed: () => handleLink(context, url: widget.videoUrl, forceOpenInBrowser: true),
-                      icon: Icon(
-                        Icons.open_in_browser_rounded,
-                        semanticLabel: GlobalContext.l10n.openInBrowser,
-                        color: Colors.white.withValues(alpha: 0.90),
-                      ),
-                    ),
-                  ),
-                ],
-              ),
               Center(
                 child: ypf.YoutubePlayerBuilder(
                   player: ypf.YoutubePlayer(
                     aspectRatio: 16 / 10,
                     controller: _ypfController,
                     actionsPadding: const EdgeInsets.only(bottom: 8),
-                    topActions: [
-                      IconButton(
-                        onPressed: () {
-                          muted ? _ypfController.unMute() : _ypfController.mute();
-                          setState(() => muted = !muted);
-                        },
-                        icon: Icon(
-                          muted ? Icons.volume_off : Icons.volume_up,
-                          color: Colors.white,
-                        ),
-                      )
-                    ],
+                    topActions: [],
                   ),
                   builder: (context, player) => player,
                   onExitFullScreen: () {
                     SystemChrome.setEnabledSystemUIMode(SystemUiMode.edgeToEdge);
                   },
                 ),
+              ),
+              Row(
+                mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                children: [
+                  SizedBox(width: 16.0),
+                  IconButton(
+                    onPressed: () => Navigator.pop(context),
+                    icon: Icon(
+                      Icons.arrow_back,
+                      semanticLabel: MaterialLocalizations.of(context).backButtonTooltip,
+                      color: Colors.white.withValues(alpha: 0.90),
+                    ),
+                  ),
+                  Spacer(),
+                  IconButton(
+                    onPressed: () {
+                      muted ? _ypfController.unMute() : _ypfController.mute();
+                      setState(() => muted = !muted);
+                    },
+                    icon: Icon(
+                      muted ? Icons.volume_off : Icons.volume_up,
+                      color: Colors.white,
+                    ),
+                  ),
+                  IconButton(
+                    onPressed: () => handleLink(context, url: widget.videoUrl, forceOpenInBrowser: true),
+                    icon: Icon(
+                      Icons.open_in_browser_rounded,
+                      semanticLabel: GlobalContext.l10n.openInBrowser,
+                      color: Colors.white.withValues(alpha: 0.90),
+                    ),
+                  ),
+                  SizedBox(width: 16.0),
+                ],
               ),
             ],
           ),


### PR DESCRIPTION
## Pull Request Description

This PR resolves an issue where the back button was not visible in landscape mode. The problem occurred because the back button (and other actions) were being obscured by the video player.

To fix this, the row that contains the back button and external browser icon have been moved to the top of the stack to keep them above the video player. Additionally, the mute/unmute button has been moved from the video player controls to the top right (where the external browser icon is located). The reason for this was to fix a subsequent issue with overlapping icons while in landscape mode.

<!--- Please describe what was changed -->

## Issue Being Fixed

<!-- Please describe the problem that is being fixed and, if applicable, reference a GitHub issue -->

Issue Number: https://github.com/thunder-app/thunder/issues/1741

## Screenshots / Recordings
Here are some screenshots of both phones/tablets before and after the changes!

| Portrait | Landscape |
|-|-|
|![simulator_screenshot_D10B63C8-8A4E-4DCB-8347-0E24C7CD513B](https://github.com/user-attachments/assets/537b2b54-f6af-4135-8704-086b0c1b9158)|![simulator_screenshot_4E216496-B0A7-4A01-882D-6BD67A8B74B8](https://github.com/user-attachments/assets/9eab03d7-e978-4a43-ab6e-3d54b0744312)|
|![simulator_screenshot_B7B8C511-99C6-4794-AB19-79F3C7DB3B07](https://github.com/user-attachments/assets/98bcaaa2-052f-4f9e-aecc-e4427596ae47)|![simulator_screenshot_9103ED6C-417B-41AB-9DC2-417EF9667E9E](https://github.com/user-attachments/assets/297cb8eb-c2df-4f07-8007-42f85a1942c5)|
|![Screenshot_1742076859](https://github.com/user-attachments/assets/fda9db00-2217-439d-933c-4e064061f989)|![Screenshot_1742076888](https://github.com/user-attachments/assets/44da6889-0e31-4398-9a1a-668cab56a455)|
|![Screenshot_1742076970](https://github.com/user-attachments/assets/7d7346bd-a8db-4977-a0b5-a1ab8f679bc6)|![Screenshot_1742076988](https://github.com/user-attachments/assets/dda47475-ddaa-47b1-87d5-74d709c04f1e)|

<!-- This section is optional but highly recommended to show off your changes! -->

## Checklist

- [ ] If a new package was added, did you ensure it uses an appropriate license and is actively maintained?
- [ ] Did you use localized strings (and added appropriate descriptions) where applicable?
- [ ] Did you add `semanticLabel`s where applicable for accessibility?
