### PR TITLE
Refactor community avatar

### DIFF
--- a/lib/community/pages/create_post_page.dart
+++ b/lib/community/pages/create_post_page.dart
@@ -20,6 +20,7 @@ import 'package:thunder/account/models/draft.dart';
 import 'package:thunder/community/bloc/image_bloc.dart';
 import 'package:thunder/core/enums/media_type.dart';
 import 'package:thunder/core/models/media.dart';
+import 'package:thunder/core/models/models.dart';
 import 'package:thunder/post/widgets/post_action_bottom_sheet.dart';
 import 'package:thunder/core/auth/bloc/auth_bloc.dart';
 import 'package:thunder/core/auth/helpers/fetch_account.dart';
@@ -847,7 +848,10 @@ class _CommunitySelectorState extends State<CommunitySelector> {
             children: [
               Row(
                 children: [
-                  CommunityAvatar(community: widget.communityView?.community, radius: 16),
+                  CommunityAvatar(
+                    community: ThunderCommunity(widget.communityView?.community),
+                    radius: 16,
+                  ),
                   const SizedBox(width: 12),
                   widget.communityId != null
                       ? Column(

--- a/lib/community/widgets/community_drawer.dart
+++ b/lib/community/widgets/community_drawer.dart
@@ -12,7 +12,7 @@ import 'package:thunder/account/bloc/account_bloc.dart';
 import 'package:thunder/account/utils/profiles.dart';
 import 'package:thunder/community/bloc/anonymous_subscriptions_bloc.dart';
 import 'package:thunder/core/auth/bloc/auth_bloc.dart';
-import 'package:thunder/core/models/thunder_community.dart';
+import 'package:thunder/core/models/models.dart';
 import 'package:thunder/feed/feed.dart';
 import 'package:thunder/shared/avatars/community_avatar.dart';
 import 'package:thunder/shared/avatars/user_avatar.dart';

--- a/lib/community/widgets/community_drawer.dart
+++ b/lib/community/widgets/community_drawer.dart
@@ -12,6 +12,7 @@ import 'package:thunder/account/bloc/account_bloc.dart';
 import 'package:thunder/account/utils/profiles.dart';
 import 'package:thunder/community/bloc/anonymous_subscriptions_bloc.dart';
 import 'package:thunder/core/auth/bloc/auth_bloc.dart';
+import 'package:thunder/core/models/thunder_community.dart';
 import 'package:thunder/feed/feed.dart';
 import 'package:thunder/shared/avatars/community_avatar.dart';
 import 'package:thunder/shared/avatars/user_avatar.dart';
@@ -481,7 +482,12 @@ class CommunityItem extends StatelessWidget {
 
     return Row(
       children: [
-        CommunityAvatar(community: community, radius: 16, thumbnailSize: 100, format: 'png'),
+        CommunityAvatar(
+          community: ThunderCommunity(community),
+          radius: 16,
+          thumbnailSize: 100,
+          format: 'png',
+        ),
         const SizedBox(width: 16.0),
         Expanded(
           child: Tooltip(

--- a/lib/community/widgets/community_header.dart
+++ b/lib/community/widgets/community_header.dart
@@ -3,6 +3,7 @@ import 'package:flutter/material.dart';
 import 'package:cached_network_image/cached_network_image.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:lemmy_api_client/v3.dart';
+import 'package:thunder/core/models/thunder_community.dart';
 import 'package:thunder/feed/bloc/feed_bloc.dart';
 import 'package:thunder/feed/utils/utils.dart';
 
@@ -96,7 +97,7 @@ class _CommunityHeaderState extends State<CommunityHeader> {
                       Row(
                         children: [
                           CommunityAvatar(
-                            community: widget.getCommunityResponse.communityView.community,
+                            community: ThunderCommunity(widget.getCommunityResponse.communityView.community),
                             radius: 45.0,
                             showCommunityStatus: true,
                           ),

--- a/lib/community/widgets/community_header.dart
+++ b/lib/community/widgets/community_header.dart
@@ -3,10 +3,10 @@ import 'package:flutter/material.dart';
 import 'package:cached_network_image/cached_network_image.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:lemmy_api_client/v3.dart';
-import 'package:thunder/core/models/thunder_community.dart';
+
+import 'package:thunder/core/models/models.dart';
 import 'package:thunder/feed/bloc/feed_bloc.dart';
 import 'package:thunder/feed/utils/utils.dart';
-
 import 'package:thunder/shared/avatars/community_avatar.dart';
 import 'package:thunder/shared/full_name_widgets.dart';
 import 'package:thunder/shared/icon_text.dart';

--- a/lib/community/widgets/community_list_entry.dart
+++ b/lib/community/widgets/community_list_entry.dart
@@ -4,6 +4,7 @@ import 'package:lemmy_api_client/v3.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:thunder/account/bloc/account_bloc.dart';
 import 'package:thunder/core/enums/full_name.dart';
+import 'package:thunder/core/models/thunder_community.dart';
 import 'package:thunder/core/singletons/lemmy_client.dart';
 import 'package:thunder/feed/view/feed_page.dart';
 import 'package:thunder/shared/avatars/community_avatar.dart';
@@ -51,7 +52,10 @@ class CommunityListEntry extends StatelessWidget {
       )}',
       preferBelow: false,
       child: ListTile(
-        leading: CommunityAvatar(community: communityView.community, radius: 25),
+        leading: CommunityAvatar(
+          community: ThunderCommunity(communityView.community),
+          radius: 25,
+        ),
         title: Text(
           communityView.community.title,
           overflow: TextOverflow.ellipsis,

--- a/lib/community/widgets/community_list_entry.dart
+++ b/lib/community/widgets/community_list_entry.dart
@@ -1,10 +1,12 @@
 import 'package:flutter/material.dart';
+
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:lemmy_api_client/v3.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+
 import 'package:thunder/account/bloc/account_bloc.dart';
 import 'package:thunder/core/enums/full_name.dart';
-import 'package:thunder/core/models/thunder_community.dart';
+import 'package:thunder/core/models/models.dart';
 import 'package:thunder/core/singletons/lemmy_client.dart';
 import 'package:thunder/feed/view/feed_page.dart';
 import 'package:thunder/shared/avatars/community_avatar.dart';

--- a/lib/community/widgets/post_card_metadata.dart
+++ b/lib/community/widgets/post_card_metadata.dart
@@ -7,6 +7,7 @@ import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 
 import 'package:thunder/core/auth/bloc/auth_bloc.dart';
 import 'package:thunder/core/enums/view_mode.dart';
+import 'package:thunder/core/models/thunder_community.dart';
 import 'package:thunder/feed/feed.dart';
 import 'package:thunder/post/enums/post_card_metadata_item.dart';
 import 'package:thunder/shared/avatars/community_avatar.dart';
@@ -572,7 +573,7 @@ class PostCommunityAndAuthor extends StatelessWidget {
       children: [
         if (showCommunityIcons && feedType != FeedType.community)
           GestureDetector(
-            child: CommunityAvatar(community: postView.community, radius: showUsername && showCommunityName ? 14 : 7),
+            child: CommunityAvatar(community: ThunderCommunity(postView.community), radius: showUsername && showCommunityName ? 14 : 7),
             onTap: () => navigateToFeedPage(context, communityId: postView.community.id, feedType: FeedType.community),
           ),
         if (showCommunityName && showUsername)

--- a/lib/community/widgets/post_card_metadata.dart
+++ b/lib/community/widgets/post_card_metadata.dart
@@ -7,7 +7,7 @@ import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 
 import 'package:thunder/core/auth/bloc/auth_bloc.dart';
 import 'package:thunder/core/enums/view_mode.dart';
-import 'package:thunder/core/models/thunder_community.dart';
+import 'package:thunder/core/models/models.dart';
 import 'package:thunder/feed/feed.dart';
 import 'package:thunder/post/enums/post_card_metadata_item.dart';
 import 'package:thunder/shared/avatars/community_avatar.dart';

--- a/lib/core/models/models.dart
+++ b/lib/core/models/models.dart
@@ -1,0 +1,1 @@
+export 'thunder_community.dart';

--- a/lib/core/models/thunder_community.dart
+++ b/lib/core/models/thunder_community.dart
@@ -1,0 +1,13 @@
+import 'package:lemmy_api_client/v3.dart';
+
+class ThunderCommunity {
+  Community? community;
+
+  ThunderCommunity(this.community);
+
+  String get name => (community?.title.isNotEmpty == true ? community?.title : community?.name) ?? '';
+
+  bool get locked => community?.postingRestrictedToMods ?? false;
+
+  String? get icon => community?.icon;
+}

--- a/lib/modlog/widgets/modlog_item_context_card.dart
+++ b/lib/modlog/widgets/modlog_item_context_card.dart
@@ -6,6 +6,7 @@ import 'package:html_unescape/html_unescape_small.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 
 import 'package:thunder/core/enums/font_scale.dart';
+import 'package:thunder/core/models/models.dart';
 import 'package:thunder/feed/view/feed_page.dart';
 import 'package:thunder/utils/navigation.dart';
 import 'package:thunder/shared/avatars/community_avatar.dart';
@@ -385,7 +386,7 @@ class ModlogCommunityItemContextCard extends StatelessWidget {
               spacing: 8.0,
               crossAxisAlignment: WrapCrossAlignment.center,
               children: [
-                CommunityAvatar(community: community),
+                CommunityAvatar(community: ThunderCommunity(community)),
                 Column(
                   crossAxisAlignment: CrossAxisAlignment.start,
                   children: [

--- a/lib/post/widgets/post_view.dart
+++ b/lib/post/widgets/post_view.dart
@@ -14,6 +14,7 @@ import 'package:lemmy_api_client/v3.dart';
 
 // Project imports
 import 'package:thunder/account/models/account.dart';
+import 'package:thunder/core/models/thunder_community.dart';
 import 'package:thunder/utils/navigation.dart';
 import 'package:thunder/community/enums/community_action.dart';
 import 'package:thunder/feed/bloc/feed_bloc.dart';
@@ -261,7 +262,12 @@ class _PostSubviewState extends State<PostSubview> with SingleTickerProviderStat
                       ),
                       CommunityChip(
                         communityId: postView.community.id,
-                        communityAvatar: CommunityAvatar(community: postView.community, radius: 10, thumbnailSize: 20, format: 'png'),
+                        communityAvatar: CommunityAvatar(
+                          community: ThunderCommunity(postView.community),
+                          radius: 10,
+                          thumbnailSize: 20,
+                          format: 'png',
+                        ),
                         communityName: postView.community.name,
                         communityTitle: postView.community.title,
                         communityUrl: postView.community.actorId,

--- a/lib/post/widgets/post_view.dart
+++ b/lib/post/widgets/post_view.dart
@@ -14,7 +14,7 @@ import 'package:lemmy_api_client/v3.dart';
 
 // Project imports
 import 'package:thunder/account/models/account.dart';
-import 'package:thunder/core/models/thunder_community.dart';
+import 'package:thunder/core/models/models.dart';
 import 'package:thunder/utils/navigation.dart';
 import 'package:thunder/community/enums/community_action.dart';
 import 'package:thunder/feed/bloc/feed_bloc.dart';

--- a/lib/shared/avatars/community_avatar.dart
+++ b/lib/shared/avatars/community_avatar.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:cached_network_image/cached_network_image.dart';
+
 import 'package:thunder/core/models/models.dart';
 
 /// A community avatar. Displays the associated community icon if available.
@@ -9,6 +10,7 @@ import 'package:thunder/core/models/models.dart';
 /// Otherwise, displays the first letter of the community title (display name).
 /// If no title is available, displays the first letter of the community name.
 class CommunityAvatar extends StatelessWidget {
+  /// The community information to display
   final ThunderCommunity community;
 
   /// The radius of the avatar. Defaults to 12

--- a/lib/shared/avatars/community_avatar.dart
+++ b/lib/shared/avatars/community_avatar.dart
@@ -1,16 +1,15 @@
 import 'package:flutter/material.dart';
 
-import 'package:lemmy_api_client/v3.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:cached_network_image/cached_network_image.dart';
+import 'package:thunder/core/models/models.dart';
 
 /// A community avatar. Displays the associated community icon if available.
 ///
 /// Otherwise, displays the first letter of the community title (display name).
 /// If no title is available, displays the first letter of the community name.
 class CommunityAvatar extends StatelessWidget {
-  /// The community information to display
-  final Community? community;
+  final ThunderCommunity community;
 
   /// The radius of the avatar. Defaults to 12
   final double radius;
@@ -24,7 +23,14 @@ class CommunityAvatar extends StatelessWidget {
   /// The image format to request from the instance
   final String? format;
 
-  const CommunityAvatar({super.key, this.community, this.radius = 12.0, this.showCommunityStatus = false, this.thumbnailSize, this.format});
+  const CommunityAvatar({
+    super.key,
+    required this.community,
+    this.radius = 12.0,
+    this.showCommunityStatus = false,
+    this.thumbnailSize,
+    this.format,
+  });
 
   @override
   Widget build(BuildContext context) {
@@ -35,23 +41,21 @@ class CommunityAvatar extends StatelessWidget {
       backgroundColor: theme.colorScheme.secondaryContainer,
       maxRadius: radius,
       child: Text(
-        community?.title.isNotEmpty == true
-            ? community!.title[0].toUpperCase()
-            : community?.name.isNotEmpty == true
-                ? community!.name[0].toUpperCase()
-                : '',
+        community.name[0].toUpperCase(),
         semanticsLabel: '',
         style: TextStyle(fontWeight: FontWeight.bold, fontSize: radius),
       ),
     );
 
-    if (community?.icon?.isNotEmpty != true) return placeholderIcon;
+    if (community.icon?.isNotEmpty != true) return placeholderIcon;
 
-    Uri imageUri = Uri.parse(community!.icon!);
+    Uri imageUri = Uri.parse(community.icon!);
     bool isPictrsImageEndpoint = imageUri.toString().contains('/pictrs/image/');
+
     Map<String, dynamic> queryParameters = {};
     if (isPictrsImageEndpoint && thumbnailSize != null) queryParameters['thumbnail'] = thumbnailSize.toString();
     if (isPictrsImageEndpoint && format != null) queryParameters['format'] = format;
+
     Uri thumbnailUri = Uri.https(imageUri.host, imageUri.path, queryParameters);
 
     return CachedNetworkImage(
@@ -59,12 +63,8 @@ class CommunityAvatar extends StatelessWidget {
       imageBuilder: (context, imageProvider) {
         return Stack(
           children: [
-            CircleAvatar(
-              backgroundColor: Colors.transparent,
-              foregroundImage: imageProvider,
-              maxRadius: radius,
-            ),
-            if (community?.postingRestrictedToMods == true && showCommunityStatus)
+            CircleAvatar(backgroundColor: Colors.transparent, foregroundImage: imageProvider, maxRadius: radius),
+            if (community.locked && showCommunityStatus)
               Positioned(
                 bottom: -2.0,
                 right: -2.0,

--- a/lib/shared/input_dialogs.dart
+++ b/lib/shared/input_dialogs.dart
@@ -7,13 +7,13 @@ import 'package:flutter_typeahead/flutter_typeahead.dart';
 import 'package:lemmy_api_client/v3.dart';
 import 'package:collection/collection.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
-import 'package:thunder/account/bloc/account_bloc.dart';
 
+import 'package:thunder/account/bloc/account_bloc.dart';
 import 'package:thunder/account/models/account.dart';
 import 'package:thunder/core/auth/bloc/auth_bloc.dart';
 import 'package:thunder/core/auth/helpers/fetch_account.dart';
 import 'package:thunder/core/enums/full_name.dart';
-import 'package:thunder/core/models/thunder_community.dart';
+import 'package:thunder/core/models/models.dart';
 import 'package:thunder/core/singletons/lemmy_client.dart';
 import 'package:thunder/feed/utils/community.dart';
 import 'package:thunder/shared/avatars/community_avatar.dart';

--- a/lib/shared/input_dialogs.dart
+++ b/lib/shared/input_dialogs.dart
@@ -13,6 +13,7 @@ import 'package:thunder/account/models/account.dart';
 import 'package:thunder/core/auth/bloc/auth_bloc.dart';
 import 'package:thunder/core/auth/helpers/fetch_account.dart';
 import 'package:thunder/core/enums/full_name.dart';
+import 'package:thunder/core/models/thunder_community.dart';
 import 'package:thunder/core/singletons/lemmy_client.dart';
 import 'package:thunder/feed/utils/community.dart';
 import 'package:thunder/shared/avatars/community_avatar.dart';
@@ -204,7 +205,7 @@ Widget buildCommunitySuggestionWidget(BuildContext context, CommunityView payloa
     child: InkWell(
       onTap: onSelected == null ? null : () => onSelected(payload),
       child: ListTile(
-        leading: CommunityAvatar(community: payload.community),
+        leading: CommunityAvatar(community: ThunderCommunity(payload.community)),
         title: Text(
           payload.community.title,
           maxLines: 1,

--- a/lib/user/pages/user_settings_block_page.dart
+++ b/lib/user/pages/user_settings_block_page.dart
@@ -5,6 +5,7 @@ import "package:flutter_gen/gen_l10n/app_localizations.dart";
 import 'package:lemmy_api_client/v3.dart';
 
 import 'package:thunder/core/enums/full_name.dart';
+import 'package:thunder/core/models/thunder_community.dart';
 import 'package:thunder/feed/view/feed_page.dart';
 import 'package:thunder/utils/navigation.dart';
 import 'package:thunder/shared/avatars/community_avatar.dart';
@@ -108,7 +109,7 @@ class _UserSettingsBlockPageState extends State<UserSettingsBlockPage> with Sing
             // Override because we're showing display name above
             useDisplayName: false,
           ),
-          leading: CommunityAvatar(community: community, radius: 16.0),
+          leading: CommunityAvatar(community: ThunderCommunity(community), radius: 16.0),
           trailing: state.status == UserSettingsStatus.blocking && state.communityBeingBlocked == community.id
               ? const Padding(
                   padding: EdgeInsets.only(right: 12),

--- a/lib/user/pages/user_settings_block_page.dart
+++ b/lib/user/pages/user_settings_block_page.dart
@@ -5,7 +5,7 @@ import "package:flutter_gen/gen_l10n/app_localizations.dart";
 import 'package:lemmy_api_client/v3.dart';
 
 import 'package:thunder/core/enums/full_name.dart';
-import 'package:thunder/core/models/thunder_community.dart';
+import 'package:thunder/core/models/models.dart';
 import 'package:thunder/feed/view/feed_page.dart';
 import 'package:thunder/utils/navigation.dart';
 import 'package:thunder/shared/avatars/community_avatar.dart';

--- a/lib/user/widgets/user_sidebar.dart
+++ b/lib/user/widgets/user_sidebar.dart
@@ -6,6 +6,7 @@ import 'package:lemmy_api_client/v3.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 
 import 'package:thunder/core/auth/bloc/auth_bloc.dart';
+import 'package:thunder/core/models/thunder_community.dart';
 import 'package:thunder/core/singletons/lemmy_client.dart';
 import 'package:thunder/feed/view/feed_page.dart';
 import 'package:thunder/shared/avatars/community_avatar.dart';
@@ -217,10 +218,7 @@ class UserModeratorList extends StatelessWidget {
                 padding: const EdgeInsets.all(8.0),
                 child: Row(
                   children: [
-                    CommunityAvatar(
-                      community: mods.community,
-                      radius: 20.0,
-                    ),
+                    CommunityAvatar(community: ThunderCommunity(mods.community), radius: 20.0),
                     const SizedBox(width: 16.0),
                     Column(
                       mainAxisAlignment: MainAxisAlignment.start,

--- a/lib/user/widgets/user_sidebar.dart
+++ b/lib/user/widgets/user_sidebar.dart
@@ -6,7 +6,7 @@ import 'package:lemmy_api_client/v3.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 
 import 'package:thunder/core/auth/bloc/auth_bloc.dart';
-import 'package:thunder/core/models/thunder_community.dart';
+import 'package:thunder/core/models/models.dart';
 import 'package:thunder/core/singletons/lemmy_client.dart';
 import 'package:thunder/feed/view/feed_page.dart';
 import 'package:thunder/shared/avatars/community_avatar.dart';


### PR DESCRIPTION
## Pull Request Description

This PR refactors the community avatar by removing its dependence on `Community` and replacing it with primitive types (e.g., String, bool, etc.). This is part of a broader effort to migrate Thunder’s logic away from the Lemmy API models.

**Context**
The Lemmy API models have changed quite a bit from v0.19.x to the upcoming v1.0.0, which is a challenge for us since a lot of Thunder's logic is closely tied to the 0.19.x models. Adapting our existing models to support multiple API versions—0.19.x, 1.0.x, and beyond—would add unnecessary complexity, making it harder to keep track of which fields belong to which version.

To make Thunder more resilient to API changes, I want to decouple it from the Lemmy APIs and introduce our own internal models throughout the app. This will not only shield Thunder from larger API changes but also make it easier to extend support to other platforms, like PieFed.

To start this process, I plan to first replace our reliance on Lemmy API models with primitive types (this PR for example). Once that's done, we can begin building our internal models based on Thunder’s current needs.

@micahmo If you have any feedback or are interested in helping with this process, feel free to let me know!

<!--- Please describe what was changed -->

## Issue Being Fixed

<!-- Please describe the problem that is being fixed and, if applicable, reference a GitHub issue -->

Issue Number: N/A

## Screenshots / Recordings

<!-- This section is optional but highly recommended to show off your changes! -->

## Checklist

- [ ] If a new package was added, did you ensure it uses an appropriate license and is actively maintained?
- [ ] Did you use localized strings (and added appropriate descriptions) where applicable?
- [ ] Did you add `semanticLabel`s where applicable for accessibility?
