### PR TITLE
Refactor user header

### DIFF
--- a/lib/core/models/thunder_user.dart
+++ b/lib/core/models/thunder_user.dart
@@ -4,7 +4,13 @@ class ThunderUser {
   /// The Lemmy API model for the user.
   Person user;
 
-  ThunderUser(this.user);
+  /// The total number of posts that the user has made.
+  final int? totalPosts;
+
+  /// The total number of comments that the user has made.
+  final int? totalComments;
+
+  ThunderUser(this.user, {this.totalPosts, this.totalComments});
 
   /// The ID of the user.
   int get id => user.id;
@@ -20,6 +26,9 @@ class ThunderUser {
 
   /// The avatar of the user.
   String? get icon => user.avatar;
+
+  /// The banner of the user.
+  String? get banner => user.banner;
 
   /// The URL to the user's profile. This is generally associated with the ActivityPub actor URL.
   String get url => user.actorId;

--- a/lib/feed/view/feed_page.dart
+++ b/lib/feed/view/feed_page.dart
@@ -16,6 +16,7 @@ import 'package:thunder/community/widgets/community_header.dart';
 import 'package:thunder/community/widgets/community_sidebar.dart';
 import 'package:thunder/core/auth/bloc/auth_bloc.dart';
 import 'package:thunder/core/enums/local_settings.dart';
+import 'package:thunder/core/models/models.dart';
 import 'package:thunder/core/models/post_view_media.dart';
 import 'package:thunder/core/singletons/lemmy_client.dart';
 import 'package:thunder/feed/bloc/feed_bloc.dart';
@@ -447,7 +448,11 @@ class _FeedViewState extends State<FeedView> {
                                 child: Column(
                                   children: [
                                     UserHeader(
-                                      getPersonDetailsResponse: state.fullPersonView!,
+                                      user: ThunderUser(
+                                        state.fullPersonView!.personView.person,
+                                        totalPosts: state.fullPersonView!.personView.counts.postCount,
+                                        totalComments: state.fullPersonView!.personView.counts.commentCount,
+                                      ),
                                       showUserSidebar: showUserSidebar,
                                       onToggle: (bool toggled) {
                                         // Scroll to top first before showing the sidebar

--- a/lib/user/widgets/user_header.dart
+++ b/lib/user/widgets/user_header.dart
@@ -2,7 +2,6 @@ import 'package:flutter/material.dart';
 
 import 'package:cached_network_image/cached_network_image.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
-import 'package:lemmy_api_client/v3.dart';
 import 'package:auto_size_text/auto_size_text.dart';
 
 import 'package:thunder/core/models/models.dart';
@@ -14,14 +13,19 @@ import 'package:thunder/utils/instance.dart';
 import 'package:thunder/utils/numbers.dart';
 
 class UserHeader extends StatefulWidget {
+  /// User to display in the header
+  final ThunderUser user;
+
+  /// Whether the user sidebar is currently shown
   final bool showUserSidebar;
-  final GetPersonDetailsResponse getPersonDetailsResponse;
+
+  /// Callback function when the user sidebar is toggled
   final Function(bool toggled) onToggle;
 
   const UserHeader({
     super.key,
+    required this.user,
     required this.showUserSidebar,
-    required this.getPersonDetailsResponse,
     required this.onToggle,
   });
 
@@ -48,8 +52,8 @@ class _UserHeaderState extends State<UserHeader> {
         },
         child: Stack(
           children: [
-            if (widget.getPersonDetailsResponse.personView.person.banner == null) Positioned.fill(child: Container(color: theme.colorScheme.surface)),
-            if (widget.getPersonDetailsResponse.personView.person.banner != null)
+            if (widget.user.banner == null) Positioned.fill(child: Container(color: theme.colorScheme.surface)),
+            if (widget.user.banner != null)
               Positioned.fill(
                 child: Row(
                   children: [
@@ -59,7 +63,7 @@ class _UserHeaderState extends State<UserHeader> {
                       child: Container(
                         decoration: BoxDecoration(
                           image: DecorationImage(
-                            image: CachedNetworkImageProvider(widget.getPersonDetailsResponse.personView.person.banner!),
+                            image: CachedNetworkImageProvider(widget.user.banner!),
                             fit: BoxFit.cover,
                           ),
                         ),
@@ -68,7 +72,7 @@ class _UserHeaderState extends State<UserHeader> {
                   ],
                 ),
               ),
-            if (widget.getPersonDetailsResponse.personView.person.banner != null)
+            if (widget.user.banner != null)
               Positioned.fill(
                 child: Container(
                   decoration: BoxDecoration(
@@ -96,7 +100,7 @@ class _UserHeaderState extends State<UserHeader> {
                     children: [
                       Row(
                         children: [
-                          UserAvatar(user: ThunderUser(widget.getPersonDetailsResponse.personView.person), radius: 45.0),
+                          UserAvatar(user: widget.user, radius: 45.0),
                           const SizedBox(width: 20.0),
                           Expanded(
                             child: Column(
@@ -104,38 +108,38 @@ class _UserHeaderState extends State<UserHeader> {
                               mainAxisSize: MainAxisSize.min,
                               children: [
                                 AutoSizeText(
-                                  widget.getPersonDetailsResponse.personView.person.displayName ?? widget.getPersonDetailsResponse.personView.person.name,
+                                  widget.user.name,
                                   style: theme.textTheme.headlineSmall?.copyWith(fontWeight: FontWeight.w600),
                                   maxLines: 1,
                                 ),
                                 UserFullNameWidget(
                                   context,
-                                  widget.getPersonDetailsResponse.personView.person.name,
-                                  widget.getPersonDetailsResponse.personView.person.displayName,
-                                  fetchInstanceNameFromUrl(widget.getPersonDetailsResponse.personView.person.actorId),
+                                  widget.user.username,
+                                  widget.user.displayName,
+                                  fetchInstanceNameFromUrl(widget.user.url),
                                   autoSize: true,
                                   // Override because we're showing display name above
                                   useDisplayName: false,
                                 ),
                                 const SizedBox(height: 8.0),
                                 Wrap(
+                                  spacing: 8.0,
                                   children: [
-                                    IconText(
-                                      icon: const Icon(Icons.wysiwyg_rounded),
-                                      text: formatNumberToK(widget.getPersonDetailsResponse.personView.counts.postCount),
-                                    ),
-                                    const SizedBox(width: 8.0),
-                                    IconText(
-                                      icon: const Icon(Icons.chat_rounded),
-                                      text: formatNumberToK(widget.getPersonDetailsResponse.personView.counts.commentCount),
-                                    ),
-                                    if (feedBloc.state.feedType == FeedType.user) ...[
-                                      const SizedBox(width: 8.0),
+                                    if (widget.user.totalPosts != null)
+                                      IconText(
+                                        icon: const Icon(Icons.wysiwyg_rounded),
+                                        text: formatNumberToK(widget.user.totalPosts!),
+                                      ),
+                                    if (widget.user.totalComments != null)
+                                      IconText(
+                                        icon: const Icon(Icons.chat_rounded),
+                                        text: formatNumberToK(widget.user.totalComments!),
+                                      ),
+                                    if (feedBloc.state.feedType == FeedType.user)
                                       IconText(
                                         icon: Icon(getSortIcon(feedBloc.state)),
                                         text: getSortName(feedBloc.state),
                                       ),
-                                    ],
                                   ],
                                 ),
                               ],


### PR DESCRIPTION
## Pull Request Description

This PR refactors `UserHeader` to use the `ThunderUser` model. A few fields were added into `ThunderUser` to accommodate for this change, including:
- `banner` - the user's banner picture URL
- `totalPosts` - the number of total posts created by the user
- `totalComments` - the number of total comments created by the user

Since the 0.19.x Lemmy API splits up a user's counts (e.g., total posts/comments), I've added some additional fields to the constructor of `ThunderUser` to accept these values rather than creating a new model to hold these counts.

```dart
ThunderUser(this.user, {this.totalPosts, this.totalComments});
```

This change also somewhat matches up with the recent changes to the Lemmy API where aggregate values are combined into their respective parent model. See https://github.com/LemmyNet/lemmy-js-client/pull/492

<!--- Please describe what was changed -->

## Issue Being Fixed

<!-- Please describe the problem that is being fixed and, if applicable, reference a GitHub issue -->

Issue Number: N/A

## Screenshots / Recordings

<!-- This section is optional but highly recommended to show off your changes! -->

## Checklist

- [ ] If a new package was added, did you ensure it uses an appropriate license and is actively maintained?
- [ ] Did you use localized strings (and added appropriate descriptions) where applicable?
- [ ] Did you add `semanticLabel`s where applicable for accessibility?
