### PR TITLE
Enable full-height images by default

### DIFF
--- a/lib/settings/pages/post_appearance_settings_page.dart
+++ b/lib/settings/pages/post_appearance_settings_page.dart
@@ -70,7 +70,7 @@ class _PostAppearanceSettingsPageState extends State<PostAppearanceSettingsPage>
   bool showCommunityIcons = false;
 
   /// When enabled, images and media will display full height. By default, they are displayed with a max height
-  bool showFullHeightImages = false;
+  bool showFullHeightImages = true;
 
   /// When enabled, images and media will extend to the edge of the screen. By default, they are shown as a card
   bool showEdgeToEdgeImages = false;
@@ -157,7 +157,7 @@ class _PostAppearanceSettingsPageState extends State<PostAppearanceSettingsPage>
 
       // Card View Settings
       showTitleFirst = prefs.getBool(LocalSettings.showPostTitleFirst.name) ?? false;
-      showFullHeightImages = prefs.getBool(LocalSettings.showPostFullHeightImages.name) ?? false;
+      showFullHeightImages = prefs.getBool(LocalSettings.showPostFullHeightImages.name) ?? true;
       showEdgeToEdgeImages = prefs.getBool(LocalSettings.showPostEdgeToEdgeImages.name) ?? false;
       showTextContent = prefs.getBool(LocalSettings.showPostTextContentPreview.name) ?? false;
       showVoteActions = prefs.getBool(LocalSettings.showPostVoteActions.name) ?? true;

--- a/lib/thunder/bloc/thunder_bloc.dart
+++ b/lib/thunder/bloc/thunder_bloc.dart
@@ -148,7 +148,7 @@ class ThunderBloc extends Bloc<ThunderEvent, ThunderState> {
       bool showVoteActions = prefs.getBool(LocalSettings.showPostVoteActions.name) ?? true;
       bool showSaveAction = prefs.getBool(LocalSettings.showPostSaveAction.name) ?? true;
       bool showCommunityIcons = prefs.getBool(LocalSettings.showPostCommunityIcons.name) ?? false;
-      bool showFullHeightImages = prefs.getBool(LocalSettings.showPostFullHeightImages.name) ?? false;
+      bool showFullHeightImages = prefs.getBool(LocalSettings.showPostFullHeightImages.name) ?? true;
       bool showEdgeToEdgeImages = prefs.getBool(LocalSettings.showPostEdgeToEdgeImages.name) ?? false;
       bool showTextContent = prefs.getBool(LocalSettings.showPostTextContentPreview.name) ?? false;
       bool showPostAuthor = prefs.getBool(LocalSettings.showPostAuthor.name) ?? false;

--- a/lib/thunder/bloc/thunder_state.dart
+++ b/lib/thunder/bloc/thunder_state.dart
@@ -64,7 +64,7 @@ class ThunderState extends Equatable {
     this.showVoteActions = true,
     this.showSaveAction = true,
     this.showCommunityIcons = false,
-    this.showFullHeightImages = false,
+    this.showFullHeightImages = true,
     this.showEdgeToEdgeImages = false,
     this.showTextContent = false,
     this.showPostAuthor = false,


### PR DESCRIPTION
## Pull Request Description

This PR changes the default setting for "Show Full Height Images" from `false` to `true`. Following the release of v0.19.9 on `lemmy.world`, the majority of users are now at a version that supports image dimensions from the API. This means that our (semi-expensive) workaround for fetching image dimensions no longer applies to a majority of users!

From a UX perspective, making images full-height by default in card view makes more sense than constraining their height. However, users will still have the option to limit the height if they prefer. Additionally, I _believe_ that Thunder is the only app that sets a standard height for images in card view by default.

Note: this change will only affect users who have not previously changed the setting (e.g., no value set in the user's shared preferences).

> Looking at https://fedidb.org/software/lemmy, there are still a few larger instances that are running v0.19.5 and below (image dimensions was introduced in 0.19.6). I don't expect Thunder to have a general release any time soon, so this does give additional buffer time for the remaining instances to update their versions!

<!--- Please describe what was changed -->

## Issue Being Fixed

<!-- Please describe the problem that is being fixed and, if applicable, reference a GitHub issue -->

Issue Number: N/A

## Screenshots / Recordings

<!-- This section is optional but highly recommended to show off your changes! -->

## Checklist

- [ ] If a new package was added, did you ensure it uses an appropriate license and is actively maintained?
- [ ] Did you use localized strings (and added appropriate descriptions) where applicable?
- [ ] Did you add `semanticLabel`s where applicable for accessibility?
