### PR TITLE
Show pinned posts in compact mode when in card view

### DIFF
--- a/lib/community/widgets/post_card.dart
+++ b/lib/community/widgets/post_card.dart
@@ -164,7 +164,7 @@ class _PostCardState extends State<PostCard> {
     final currentSwipeDirection = determinePostSwipeDirection(isUserLoggedIn, state, disableSwiping: widget.disableSwiping);
 
     // Determine which post card view to use based on the settings
-    Widget child = state.useCompactView
+    Widget child = state.useCompactView || widget.postViewMedia.postView.post.featuredLocal == true
         ? PostCardViewCompact(
             postViewMedia: widget.postViewMedia,
             isUserLoggedIn: isUserLoggedIn,

--- a/lib/community/widgets/post_card.dart
+++ b/lib/community/widgets/post_card.dart
@@ -166,7 +166,7 @@ class _PostCardState extends State<PostCard> {
     final feedType = context.read<FeedBloc>().state.feedType;
 
     // Determine which post card view to use based on the settings
-    Widget child = state.useCompactView || widget.postViewMedia.postView.post.featuredLocal == true || (feedType == FeedType.community && widget.postViewMedia.postView.post.featuredCommunity)
+    Widget child = state.useCompactView || widget.postViewMedia.postView.post.featuredLocal || (feedType == FeedType.community && widget.postViewMedia.postView.post.featuredCommunity)
         ? PostCardViewCompact(
             postViewMedia: widget.postViewMedia,
             isUserLoggedIn: isUserLoggedIn,

--- a/lib/community/widgets/post_card.dart
+++ b/lib/community/widgets/post_card.dart
@@ -5,6 +5,7 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 
 import 'package:thunder/community/enums/community_action.dart';
 import 'package:thunder/community/utils/post_actions.dart';
+import 'package:thunder/feed/view/feed_page.dart';
 import 'package:thunder/post/widgets/post_action_bottom_sheet.dart';
 import 'package:thunder/community/widgets/post_card_view_comfortable.dart';
 import 'package:thunder/community/widgets/post_card_view_compact.dart';
@@ -162,9 +163,10 @@ class _PostCardState extends State<PostCard> {
   Widget build(BuildContext context) {
     final state = context.read<ThunderBloc>().state;
     final currentSwipeDirection = determinePostSwipeDirection(isUserLoggedIn, state, disableSwiping: widget.disableSwiping);
+    final feedType = context.read<FeedBloc>().state.feedType;
 
     // Determine which post card view to use based on the settings
-    Widget child = state.useCompactView || widget.postViewMedia.postView.post.featuredLocal == true
+    Widget child = state.useCompactView || widget.postViewMedia.postView.post.featuredLocal == true || (feedType == FeedType.community && widget.postViewMedia.postView.post.featuredCommunity)
         ? PostCardViewCompact(
             postViewMedia: widget.postViewMedia,
             isUserLoggedIn: isUserLoggedIn,


### PR DESCRIPTION
## Pull Request Description

This PR applies a small change where pinned posts are shown in compact mode (when in card view). To be more specific:
- When viewing the general feeds (all/local/subscribed), only instance pinned posts will be collapsed. Community pinned posts that show up in the general feeds will still show up as cards (see second row of screenshots)
- When viewing community feeds, the community pinned posts will be collapsed

@englut Let me know what you think of this!

<!--- Please describe what was changed -->

## Issue Being Fixed

<!-- Please describe the problem that is being fixed and, if applicable, reference a GitHub issue -->

Issue Number: https://github.com/thunder-app/thunder/issues/1736

## Screenshots / Recordings
| | |
|-|-|
|![Screenshot_1742244522](https://github.com/user-attachments/assets/d8acac03-414b-40f3-a8a7-fa419df0b43f)| |
|![Screenshot_1742245012](https://github.com/user-attachments/assets/d92fc074-4d5b-4c32-acf8-ba7207f9d77b) | ![Screenshot_1742245037](https://github.com/user-attachments/assets/e2d177cd-faf0-40e4-9668-e433d3b8dae8)|

<!-- This section is optional but highly recommended to show off your changes! -->

## Checklist

- [ ] If a new package was added, did you ensure it uses an appropriate license and is actively maintained?
- [ ] Did you use localized strings (and added appropriate descriptions) where applicable?
- [ ] Did you add `semanticLabel`s where applicable for accessibility?
