### PR TITLE
Add prompt to inject original post body for non-text cross posts

### DIFF
--- a/lib/community/pages/create_post_page.dart
+++ b/lib/community/pages/create_post_page.dart
@@ -72,6 +72,9 @@ class CreatePostPage extends StatefulWidget {
   /// [postView] is passed in when editing an existing post
   final PostView? postView;
 
+  /// Whether or not this post is a cross post
+  final bool isCrossPost;
+
   /// Callback function that is triggered whenever the post is successfully created or updated
   final Function(PostViewMedia postViewMedia, bool userChanged)? onPostSuccess;
 
@@ -87,6 +90,7 @@ class CreatePostPage extends StatefulWidget {
     this.altText,
     this.prePopulated = false,
     this.postView,
+    this.isCrossPost = false,
     this.onPostSuccess,
   });
 
@@ -202,11 +206,25 @@ class _CreatePostPageState extends State<CreatePostPage> {
     // Logic for pre-populating the post with the given fields
     if (widget.prePopulated == true) {
       _titleTextController.text = widget.title ?? '';
-      _bodyTextController.text = widget.text ?? '';
       _urlTextController.text = widget.url ?? '';
       _customThumbnailTextController.text = widget.customThumbnail ?? '';
       _altTextTextController.text = widget.altText ?? '';
       _getDataFromLink(updateTitleField: _titleTextController.text.isEmpty);
+
+      // If the post is a cross-post, then prompt the user if they want to add the original post body
+      if (widget.url != null && widget.text?.isNotEmpty == true && widget.isCrossPost) {
+        WidgetsBinding.instance.addPostFrameCallback((timeStamp) {
+          showSnackbar(
+            l10n.addOriginalPostBody,
+            duration: const Duration(seconds: 10),
+            trailingIcon: Icons.add_rounded,
+            trailingIconColor: Theme.of(context).colorScheme.secondary,
+            trailingAction: () => _bodyTextController.text = widget.text ?? '',
+          );
+        });
+      } else {
+        _bodyTextController.text = widget.text ?? '';
+      }
 
       if (widget.image != null) {
         WidgetsBinding.instance.addPostFrameCallback((timeStamp) {

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -73,6 +73,10 @@
   "@addKeywordFilter": {
     "description": "Hint for text field to add keyword"
   },
+  "addOriginalPostBody": "Add original post body?",
+  "@addOriginalPostBody": {
+    "description": "Prompt to add the original post body to a cross post"
+  },
   "addToFavorites": "Add to favorites",
   "@addToFavorites": {
     "description": "Action to add a community in drawer to favorites"

--- a/lib/shared/avatars/community_avatar.dart
+++ b/lib/shared/avatars/community_avatar.dart
@@ -43,7 +43,7 @@ class CommunityAvatar extends StatelessWidget {
       backgroundColor: theme.colorScheme.secondaryContainer,
       maxRadius: radius,
       child: Text(
-        community.name[0].toUpperCase(),
+        community.name.isNotEmpty ? community.name[0].toUpperCase() : '',
         semanticsLabel: '',
         style: TextStyle(fontWeight: FontWeight.bold, fontSize: radius),
       ),

--- a/lib/shared/cross_posts.dart
+++ b/lib/shared/cross_posts.dart
@@ -169,14 +169,10 @@ void createCrossPost(
   String? text,
   String? postUrl,
 }) async {
-  final AppLocalizations l10n = AppLocalizations.of(context)!;
+  final l10n = AppLocalizations.of(context)!;
 
-  if (url?.isNotEmpty == true) {
-    text = null;
-  } else {
-    final String? quotedText = text?.split('\n').map((value) => '> $value\n').join();
-    text = "${l10n.crossPostedFrom(postUrl ?? '')}\n\n$quotedText";
-  }
+  final quotedText = text?.split('\n').map((value) => '> $value\n').join();
+  text = "${l10n.crossPostedFrom(postUrl ?? '')}\n\n$quotedText";
 
   await navigateToCreatePostPage(
     context,
@@ -184,5 +180,6 @@ void createCrossPost(
     url: url,
     text: text,
     prePopulated: true,
+    isCrossPost: true,
   );
 }

--- a/lib/utils/navigation.dart
+++ b/lib/utils/navigation.dart
@@ -372,6 +372,7 @@ Future<void> navigateToCreatePostPage(
   int? communityId,
   CommunityView? communityView,
   PostViewMedia? postViewMedia,
+  bool isCrossPost = false,
   Function(PostViewMedia, bool)? onPostSuccess,
 }) async {
   try {
@@ -432,6 +433,7 @@ Future<void> navigateToCreatePostPage(
                       )
                     : null),
             postView: postViewMedia?.postView,
+            isCrossPost: isCrossPost,
             onPostSuccess: (PostViewMedia pvm, bool userChanged) {
               // Update the existing post view media if it exists
               if (feedBloc != null && postViewMedia != null) feedBloc.add(FeedItemUpdatedEvent(postViewMedia: pvm));


### PR DESCRIPTION
## Pull Request Description

This PR adds the ability to inject the original post body for non-text cross posts, as described in https://github.com/thunder-app/thunder/issues/1725 and the relevant discussions. This works by displaying a snackbar whenever the create post page detects a cross post. I'm not sure if this is the best way to do it, so some feedback on this would be appreciated @DavidHiraki!

> The snackbar will only show up if there's an existing link (e.g., link, image, etc.), and if the original post contained text. For text-only crossposts, the post body will automatically be added.

See the video below for a quick demo.

<!--- Please describe what was changed -->

## Issue Being Fixed

<!-- Please describe the problem that is being fixed and, if applicable, reference a GitHub issue -->

Issue Number: https://github.com/thunder-app/thunder/issues/1725

## Screenshots / Recordings

https://github.com/user-attachments/assets/0b28f677-8e30-44f1-b436-6ef7fba6e406

<!-- This section is optional but highly recommended to show off your changes! -->

## Checklist

- [ ] If a new package was added, did you ensure it uses an appropriate license and is actively maintained?
- [ ] Did you use localized strings (and added appropriate descriptions) where applicable?
- [ ] Did you add `semanticLabel`s where applicable for accessibility?
