### PR TITLE
Fix visual glitch navigating to posts via link

### DIFF
--- a/lib/post/pages/post_page.dart
+++ b/lib/post/pages/post_page.dart
@@ -484,7 +484,7 @@ class _PostPageState extends State<PostPage> {
                         onUserChanged: () => userChanged = true,
                         onPostChanged: (newPostViewMedia) => context.read<PostBloc>().add(GetPostEvent(postView: newPostViewMedia)),
                       ),
-                      if (state.status == PostStatus.loading)
+                      if (state.status == PostStatus.initial || state.status == PostStatus.loading)
                         const SliverFillRemaining(
                           hasScrollBody: false,
                           child: Center(child: CircularProgressIndicator()),


### PR DESCRIPTION
## Pull Request Description

<!--- Please describe what was changed -->

This PR fixes a visual glitch that appears when navigating to a post via a link.

## Issue Being Fixed

<!-- Please describe the problem that is being fixed and, if applicable, reference a GitHub issue -->

Issue Number: N/A

## Screenshots / Recordings

<!-- This section is optional but highly recommended to show off your changes! -->

### Before

(It happens every time, but the screen recording only catches it sometimes.)

https://github.com/user-attachments/assets/f0bc00d0-3cae-4b7e-8437-cce139d9b7b8

### After

https://github.com/user-attachments/assets/6090d75e-08bc-42d7-93b5-8196d740c0a4

## Checklist

- [ ] If a new package was added, did you ensure it uses an appropriate license and is actively maintained?
- [ ] Did you use localized strings (and added appropriate descriptions) where applicable?
- [ ] Did you add `semanticLabel`s where applicable for accessibility?
