### PR TITLE
Add spacer at bottom of notification page

### DIFF
--- a/lib/inbox/widgets/inbox_replies_view.dart
+++ b/lib/inbox/widgets/inbox_replies_view.dart
@@ -109,6 +109,9 @@ class _InboxRepliesViewState extends State<InboxRepliesView> {
             },
           ),
           if (state.hasReachedInboxReplyEnd && widget.replies.isNotEmpty) const SliverToBoxAdapter(child: FeedReachedEnd()),
+          SliverToBoxAdapter(
+            child: SizedBox(height: kBottomNavigationBarHeight),
+          )
         ],
       );
     });


### PR DESCRIPTION
## Pull Request Description

<!--- Please describe what was changed -->

This is a super small change which adds a little bit of space at the bottom of the notification page so it doesn't bump up against the bottom navigation bar.