### PR TITLE
Add ability to mark private message as read

### DIFF
--- a/lib/inbox/bloc/inbox_bloc.dart
+++ b/lib/inbox/bloc/inbox_bloc.dart
@@ -242,13 +242,14 @@ class InboxBloc extends Bloc<InboxEvent, InboxState> {
 
   /// Handles comment related actions on a given item within the inbox
   Future<void> _inboxItemActionEvent(InboxItemActionEvent event, Emitter<InboxState> emit) async {
-    assert(!(event.commentReplyId == null && event.personMentionId == null));
+    assert(!(event.commentReplyId == null && event.personMentionId == null && event.privateMessageId == null));
     emit(state.copyWith(status: InboxStatus.refreshing, errorMessage: ''));
 
     int existingIndex = -1;
 
     CommentReplyView? existingCommentReplyView;
     PersonMentionView? existingPersonMentionView;
+    PrivateMessageView? existingPrivateMessageView;
 
     if (event.commentReplyId != null) {
       existingIndex = state.replies.indexWhere((element) => element.commentReply.id == event.commentReplyId);
@@ -256,9 +257,12 @@ class InboxBloc extends Bloc<InboxEvent, InboxState> {
     } else if (event.personMentionId != null) {
       existingIndex = state.mentions.indexWhere((element) => element.personMention.id == event.personMentionId);
       existingPersonMentionView = state.mentions[existingIndex];
+    } else if (event.privateMessageId != null) {
+      existingIndex = state.privateMessages.indexWhere((element) => element.privateMessage.id == event.privateMessageId);
+      existingPrivateMessageView = state.privateMessages[existingIndex];
     }
 
-    if (existingCommentReplyView == null && existingPersonMentionView == null) return emit(state.copyWith(status: InboxStatus.failure));
+    if (existingCommentReplyView == null && existingPersonMentionView == null && existingPrivateMessageView == null) return emit(state.copyWith(status: InboxStatus.failure));
 
     /// Convert the reply or mention to a comment
     CommentView? commentView;
@@ -307,6 +311,12 @@ class InboxBloc extends Bloc<InboxEvent, InboxState> {
             } else if (event.value == true) {
               state.mentions.remove(existingPersonMentionView);
             }
+          } else if (existingPrivateMessageView != null) {
+            if (!state.showUnreadOnly) {
+              state.privateMessages[existingIndex] = existingPrivateMessageView.copyWith(privateMessage: existingPrivateMessageView.privateMessage.copyWith(read: event.value));
+            } else if (event.value == true) {
+              state.privateMessages.remove(existingPrivateMessageView);
+            }
           }
 
           Account? account = await fetchActiveProfileAccount();
@@ -324,6 +334,12 @@ class InboxBloc extends Bloc<InboxEvent, InboxState> {
             await lemmy.run(MarkPersonMentionAsRead(
               auth: account!.jwt!,
               personMentionId: event.personMentionId!,
+              read: event.value,
+            ));
+          } else if (existingPrivateMessageView != null) {
+            await lemmy.run(MarkPrivateMessageAsRead(
+              auth: account!.jwt!,
+              privateMessageId: event.privateMessageId!,
               read: event.value,
             ));
           }

--- a/lib/inbox/bloc/inbox_event.dart
+++ b/lib/inbox/bloc/inbox_event.dart
@@ -27,16 +27,19 @@ class InboxItemActionEvent extends InboxEvent {
   /// The action to perform on the inbox item. This is generally a comment.
   final CommentAction action;
 
-  /// The id of the comment reply. Only one of [commentReplyId] or [personMentionId] should be set
+  /// The id of the comment reply. Only one of [commentReplyId], [personMentionId], or [privateMessageId] should be set
   final int? commentReplyId;
 
-  /// The id of the person mention reply. Only one of [commentReplyId] or [personMentionId] should be set
+  /// The id of the person mention reply. Only one of [commentReplyId], [personMentionId], or [privateMessageId] should be set
   final int? personMentionId;
+
+  /// The id of the private message. Only one of [commentReplyId], [personMentionId], or [privateMessageId] should be set
+  final int? privateMessageId;
 
   /// The value to pass to the action
   final dynamic value;
 
-  const InboxItemActionEvent({required this.action, this.commentReplyId, this.personMentionId, this.value});
+  const InboxItemActionEvent({required this.action, this.commentReplyId, this.personMentionId, this.privateMessageId, this.value});
 }
 
 class MarkAllAsReadEvent extends InboxEvent {}

--- a/lib/inbox/widgets/inbox_private_messages_view.dart
+++ b/lib/inbox/widgets/inbox_private_messages_view.dart
@@ -4,9 +4,11 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:lemmy_api_client/v3.dart';
 
+import 'package:thunder/comment/enums/comment_action.dart';
 import 'package:thunder/feed/view/feed_page.dart';
 import 'package:thunder/inbox/bloc/inbox_bloc.dart';
 import 'package:thunder/shared/common_markdown_body.dart';
+import 'package:thunder/shared/divider.dart';
 import 'package:thunder/utils/date_time.dart';
 
 class InboxPrivateMessagesView extends StatefulWidget {
@@ -72,8 +74,29 @@ class _InboxPrivateMessagesViewState extends State<InboxPrivateMessagesView> {
                           Text(formatTimeToString(dateTime: widget.privateMessages[index].privateMessage.published.toIso8601String()))
                         ],
                       ),
-                      const SizedBox(height: 10),
-                      CommonMarkdownBody(body: widget.privateMessages[index].privateMessage.content),
+                      Padding(
+                        padding: const EdgeInsets.symmetric(vertical: 10.0),
+                        child: CommonMarkdownBody(body: widget.privateMessages[index].privateMessage.content),
+                      ),
+                      ThunderDivider(sliver: false, padding: false),
+                      Align(
+                        alignment: Alignment.centerRight,
+                        child: IconButton(
+                          visualDensity: VisualDensity.compact,
+                          onPressed: () => context.read<InboxBloc>().add(
+                                InboxItemActionEvent(
+                                  action: CommentAction.read,
+                                  privateMessageId: widget.privateMessages[index].privateMessage.id,
+                                  value: !widget.privateMessages[index].privateMessage.read,
+                                ),
+                              ),
+                          icon: Icon(
+                            Icons.check,
+                            semanticLabel: l10n.markAsRead,
+                            color: widget.privateMessages[index].privateMessage.read ? Colors.green : null,
+                          ),
+                        ),
+                      ),
                     ],
                   ),
                 ),


### PR DESCRIPTION
## Pull Request Description

This PR adds the ability to mark a given private message as read/unread.

Note: This is just a quick implementation. I do want to eventually make private messages more feature-rich, but for now, my general focus is on refactoring the codebase to prepare it for the upcoming Lemmy update.

<!--- Please describe what was changed -->

## Issue Being Fixed

<!-- Please describe the problem that is being fixed and, if applicable, reference a GitHub issue -->

Issue Number: https://github.com/thunder-app/thunder/issues/739

## Screenshots / Recordings
https://github.com/user-attachments/assets/30720eab-c810-4175-9fef-e6e03f932af9

<!-- This section is optional but highly recommended to show off your changes! -->

## Checklist

- [ ] If a new package was added, did you ensure it uses an appropriate license and is actively maintained?
- [ ] Did you use localized strings (and added appropriate descriptions) where applicable?
- [ ] Did you add `semanticLabel`s where applicable for accessibility?
