### PR TITLE
Make the "mark all as ready" confirmation messages more clear

### DIFF
--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -485,7 +485,7 @@
   "@confirmLogOutTitle": {
     "description": "The title of the confirm logout dialog"
   },
-  "confirmMarkAllAsReadBody": "Are you sure you want to mark all messages as read?",
+  "confirmMarkAllAsReadBody": "Are you sure you want to mark all replies, mentions, and messages as read?",
   "@confirmMarkAllAsReadBody": {
     "description": "The body of the confirm mark all as read dialog"
   },


### PR DESCRIPTION
## Pull Request Description

<!--- Please describe what was changed -->

There was some confusion about what the "mark all as read" option does, so I updated the wording of the confirmation message to make it clear that it marks all types of messages as read.

## Issue Being Fixed

<!-- Please describe the problem that is being fixed and, if applicable, reference a GitHub issue -->

Issue Number: Related to #739

## Screenshots / Recordings

<!-- This section is optional but highly recommended to show off your changes! -->

## Checklist

- [ ] If a new package was added, did you ensure it uses an appropriate license and is actively maintained?
- [ ] Did you use localized strings (and added appropriate descriptions) where applicable?
- [ ] Did you add `semanticLabel`s where applicable for accessibility?
