### PR TITLE
Fix appearance issue with feed FAB close button

### DIFF
--- a/lib/shared/gesture_fab.dart
+++ b/lib/shared/gesture_fab.dart
@@ -117,7 +117,7 @@ class _GestureFabState extends State<GestureFab> with SingleTickerProviderStateM
             child: Material(
               shape: widget.centered ? null : const CircleBorder(),
               clipBehavior: widget.centered ? Clip.none : Clip.antiAlias,
-              color: Colors.transparent,
+              color: widget.centered ? Colors.transparent : null,
               elevation: widget.centered ? 0 : 4,
               child: InkWell(
                 borderRadius: BorderRadius.circular(50),


### PR DESCRIPTION
## Pull Request Description

<!--- Please describe what was changed -->

This is a small PR to fix an issue with the appearance of the FAB close button in the feed (or in comments, when not combined with the comment navigation buttons). This issue was introduced in #1691.

## Issue Being Fixed

<!-- Please describe the problem that is being fixed and, if applicable, reference a GitHub issue -->

Issue Number: N/A

## Screenshots / Recordings

### Before

| ![image](https://github.com/user-attachments/assets/f2d01014-e963-4d4b-951e-2aed569866c6) |
| - |

### After

| ![image](https://github.com/user-attachments/assets/2689e510-01c4-4cce-9380-cd1f05fd6d89) |
| - |

<!-- This section is optional but highly recommended to show off your changes! -->

## Checklist

- [ ] If a new package was added, did you ensure it uses an appropriate license and is actively maintained?
- [ ] Did you use localized strings (and added appropriate descriptions) where applicable?
- [ ] Did you add `semanticLabel`s where applicable for accessibility?
