### PR TITLE
Fix an issue where image previews would not be dimmed when read

### DIFF
--- a/lib/shared/image/image_preview.dart
+++ b/lib/shared/image/image_preview.dart
@@ -106,6 +106,8 @@ class _ImagePreviewState extends State<ImagePreview> with SingleTickerProviderSt
       height: widget.height,
       width: widget.width,
       fit: widget.fit,
+      color: widget.viewed == true ? const Color.fromRGBO(255, 255, 255, 0.55) : null,
+      colorBlendMode: widget.viewed == true ? BlendMode.modulate : null,
       cache: true,
       clearMemoryCacheWhenDispose: imageCachingMode == ImageCachingMode.relaxed,
       cacheWidth: widget.width != null ? (widget.width! * devicePixelRatio).toInt() : null,


### PR DESCRIPTION
## Pull Request Description

<!--- Please describe what was changed -->

This PR fixes an issue where the image preview would not get dimmed when the post is marked as read. This seems to have been lost during a refactor, and I copied the logic from a similarly named file, `lib\shared\image_preview.dart`, which makes me concerned that some other logic might have been lost as well.

## Issue Being Fixed

<!-- Please describe the problem that is being fixed and, if applicable, reference a GitHub issue -->

Issue Number: N/A

## Screenshots / Recordings

<!-- This section is optional but highly recommended to show off your changes! -->

## Checklist

- [ ] If a new package was added, did you ensure it uses an appropriate license and is actively maintained?
- [ ] Did you use localized strings (and added appropriate descriptions) where applicable?
- [ ] Did you add `semanticLabel`s where applicable for accessibility?
