### PR TITLE
Fix displayed comment sort mode

### DIFF
--- a/lib/post/widgets/post_page_app_bar.dart
+++ b/lib/post/widgets/post_page_app_bar.dart
@@ -1,18 +1,20 @@
+import 'package:collection/collection.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+import 'package:lemmy_api_client/src/v3/enums/comment_sort_type.dart';
 import 'package:thunder/core/enums/media_type.dart';
 import 'package:thunder/core/models/post_view_media.dart';
 
 import 'package:thunder/core/singletons/lemmy_client.dart';
 import 'package:thunder/post/bloc/post_bloc.dart';
 import 'package:thunder/shared/comment_sort_picker.dart';
-import 'package:thunder/shared/sort_picker.dart';
 import 'package:thunder/shared/thunder_popup_menu_item.dart';
 import 'package:thunder/thunder/bloc/thunder_bloc.dart';
 import 'package:thunder/user/widgets/user_selector.dart';
+import 'package:thunder/utils/bottom_sheet_list_picker.dart';
 import 'package:thunder/utils/links.dart';
 
 /// Holds the app bar for the post page.
@@ -233,8 +235,8 @@ class PostAppBarActions extends StatelessWidget {
     return ('', null);
   }
 
-  final sortTypeItemIndex = CommentSortPicker.getCommentSortTypeItems(minimumVersion: LemmyClient.instance.version).indexWhere((sortTypeItem) => sortTypeItem.payload == state.sortType);
-  final sortTypeItem = sortTypeItemIndex > -1 ? allSortTypeItems[sortTypeItemIndex] : null;
+  ListPickerItem<CommentSortType>? sortTypeItem =
+      CommentSortPicker.getCommentSortTypeItems(minimumVersion: LemmyClient.instance.version).firstWhereOrNull((sortTypeItem) => sortTypeItem.payload == state.sortType);
 
   return (sortTypeItem?.label ?? '', sortTypeItem?.icon);
 }


### PR DESCRIPTION
## Pull Request Description

<!--- Please describe what was changed -->

This PR fixes an issue where the displayed comment sort type in the post page app bar was incorrect.

There was some weird mapping between `CommentSortPicker.getCommentSortTypeItems` and `allSortTypeItems`, and to be honest I don't know why that was needed since `getCommentSortTypeItems` returns a `ListPickerItem<CommentSortType>` which is exactly what we need here. If you can think of any potential problems here, please let me know!

## Issue Being Fixed

<!-- Please describe the problem that is being fixed and, if applicable, reference a GitHub issue -->

Issue Number: #1770

## Screenshots / Recordings

<!-- This section is optional but highly recommended to show off your changes! -->

## Checklist

- [ ] If a new package was added, did you ensure it uses an appropriate license and is actively maintained?
- [ ] Did you use localized strings (and added appropriate descriptions) where applicable?
- [ ] Did you add `semanticLabel`s where applicable for accessibility?
