### PR TITLE
Migrate existing community logic to ThunderCommunity

### DIFF
--- a/lib/comment/view/create_comment_page.dart
+++ b/lib/comment/view/create_comment_page.dart
@@ -443,7 +443,10 @@ class _CreateCommentPageState extends State<CreateCommentPage> {
                                     MarkdownType.community: () {
                                       showCommunityInputDialog(context, title: l10n.community, onCommunitySelected: (community) {
                                         _bodyTextController.text = _bodyTextController.text.replaceRange(
-                                            _bodyTextController.selection.end, _bodyTextController.selection.end, '!${community.communityName}@${fetchInstanceNameFromUrl(community.url)}');
+                                          _bodyTextController.selection.end,
+                                          _bodyTextController.selection.end,
+                                          '!${community.communityName}@${fetchInstanceNameFromUrl(community.url)}',
+                                        );
                                       });
                                     },
                                   },

--- a/lib/comment/view/create_comment_page.dart
+++ b/lib/comment/view/create_comment_page.dart
@@ -442,8 +442,8 @@ class _CreateCommentPageState extends State<CreateCommentPage> {
                                     },
                                     MarkdownType.community: () {
                                       showCommunityInputDialog(context, title: l10n.community, onCommunitySelected: (community) {
-                                        _bodyTextController.text = _bodyTextController.text.replaceRange(_bodyTextController.selection.end, _bodyTextController.selection.end,
-                                            '!${community.community.name}@${fetchInstanceNameFromUrl(community.community.actorId)}');
+                                        _bodyTextController.text = _bodyTextController.text.replaceRange(
+                                            _bodyTextController.selection.end, _bodyTextController.selection.end, '!${community.communityName}@${fetchInstanceNameFromUrl(community.url)}');
                                       });
                                     },
                                   },

--- a/lib/community/bloc/anonymous_subscriptions_bloc.dart
+++ b/lib/community/bloc/anonymous_subscriptions_bloc.dart
@@ -2,10 +2,11 @@ import 'dart:async';
 import 'package:bloc/bloc.dart';
 import 'package:bloc_concurrency/bloc_concurrency.dart';
 import 'package:equatable/equatable.dart';
-import 'package:lemmy_api_client/v3.dart';
 import 'package:stream_transform/stream_transform.dart';
+
 import 'package:thunder/community/helpers/anonymous_subscriptions_helper.dart';
 import 'package:thunder/community/models/anonymous_subscriptions.dart';
+import 'package:thunder/core/models/models.dart';
 
 part 'anonymous_subscriptions_event.dart';
 part 'anonymous_subscriptions_state.dart';
@@ -57,7 +58,7 @@ class AnonymousSubscriptionsBloc extends Bloc<AnonymousSubscriptionsEvent, Anony
   Future<void> _getSubscribedCommunities(GetSubscribedCommunitiesEvent event, Emitter<AnonymousSubscriptionsState> emit) async {
     emit(const AnonymousSubscriptionsState(status: AnonymousSubscriptionsStatus.loading));
     try {
-      List<Community> subscribedCommunities = await getSubscriptions();
+      List<ThunderCommunity> subscribedCommunities = await getSubscriptions();
       emit(state.copyWith(
         status: AnonymousSubscriptionsStatus.success,
         subscriptions: subscribedCommunities,

--- a/lib/community/bloc/anonymous_subscriptions_event.dart
+++ b/lib/community/bloc/anonymous_subscriptions_event.dart
@@ -10,7 +10,7 @@ abstract class AnonymousSubscriptionsEvent extends Equatable {
 class GetSubscribedCommunitiesEvent extends AnonymousSubscriptionsEvent {}
 
 class AddSubscriptionsEvent extends AnonymousSubscriptionsEvent {
-  final Set<Community> communities;
+  final Set<ThunderCommunity> communities;
 
   const AddSubscriptionsEvent({required this.communities});
 }

--- a/lib/community/bloc/anonymous_subscriptions_state.dart
+++ b/lib/community/bloc/anonymous_subscriptions_state.dart
@@ -12,12 +12,12 @@ class AnonymousSubscriptionsState extends Equatable {
 
   final AnonymousSubscriptionsStatus status;
   final String? errorMessage;
-  final List<Community> subscriptions;
+  final List<ThunderCommunity> subscriptions;
   final Set<int> ids;
 
   AnonymousSubscriptionsState copyWith({
     AnonymousSubscriptionsStatus? status,
-    List<Community>? subscriptions,
+    List<ThunderCommunity>? subscriptions,
     Set<int>? ids,
     String? errorMessage,
   }) {

--- a/lib/community/helpers/anonymous_subscriptions_helper.dart
+++ b/lib/community/helpers/anonymous_subscriptions_helper.dart
@@ -9,8 +9,8 @@ Future<List<ThunderCommunity>> getSubscriptions() async {
 }
 
 Future<void> insertSubscriptions(Set<ThunderCommunity> communities) async {
-  Set<LocalCommunity> newCommunities = communities.map((e) => e.toLocalCommunity).toSet();
-  await AnonymousSubscriptions.insertCommunities(newCommunities);
+  Set<LocalCommunity> subscriptions = communities.map((c) => LocalCommunity(id: c.id, name: c.communityName, title: c.title, actorId: c.url)).toSet();
+  await AnonymousSubscriptions.insertCommunities(subscriptions);
 }
 
 extension on LocalCommunity {
@@ -32,11 +32,5 @@ extension on LocalCommunity {
         instanceId: -1,
       ),
     );
-  }
-}
-
-extension on ThunderCommunity {
-  LocalCommunity get toLocalCommunity {
-    return LocalCommunity(id: id, name: name, title: title, icon: icon, actorId: url);
   }
 }

--- a/lib/community/helpers/anonymous_subscriptions_helper.dart
+++ b/lib/community/helpers/anonymous_subscriptions_helper.dart
@@ -1,39 +1,42 @@
 import 'package:lemmy_api_client/v3.dart';
 
-import '../models/anonymous_subscriptions.dart';
+import 'package:thunder/community/models/anonymous_subscriptions.dart';
+import 'package:thunder/core/models/thunder_community.dart';
 
-Future<List<Community>> getSubscriptions() async {
+Future<List<ThunderCommunity>> getSubscriptions() async {
   List<LocalCommunity> subscribedCommunities = await AnonymousSubscriptions.getSubscribedCommunities();
   return subscribedCommunities.map((e) => e.toCommunity).toList();
 }
 
-Future<void> insertSubscriptions(Set<Community> communities) async {
+Future<void> insertSubscriptions(Set<ThunderCommunity> communities) async {
   Set<LocalCommunity> newCommunities = communities.map((e) => e.toLocalCommunity).toSet();
   await AnonymousSubscriptions.insertCommunities(newCommunities);
 }
 
 extension on LocalCommunity {
-  Community get toCommunity {
-    return Community(
-      id: id,
-      name: name,
-      title: title,
-      removed: false,
-      published: DateTime.now(),
-      deleted: false,
-      nsfw: false,
-      actorId: actorId,
-      local: false,
-      icon: icon,
-      hidden: false,
-      postingRestrictedToMods: false,
-      instanceId: -1,
+  ThunderCommunity get toCommunity {
+    return ThunderCommunity(
+      Community(
+        id: id,
+        name: name,
+        title: title,
+        removed: false,
+        published: DateTime.now(),
+        deleted: false,
+        nsfw: false,
+        actorId: actorId,
+        local: false,
+        icon: icon,
+        hidden: false,
+        postingRestrictedToMods: false,
+        instanceId: -1,
+      ),
     );
   }
 }
 
-extension on Community {
+extension on ThunderCommunity {
   LocalCommunity get toLocalCommunity {
-    return LocalCommunity(id: id, name: name, title: title, icon: icon, actorId: actorId);
+    return LocalCommunity(id: id, name: name, title: title, icon: icon, actorId: url);
   }
 }

--- a/lib/community/pages/create_post_page.dart
+++ b/lib/community/pages/create_post_page.dart
@@ -145,8 +145,8 @@ class _CreatePostPageState extends State<CreatePostPage> {
 
   int? languageId;
 
-  /// The [CommunityView] associated with the post. This is used to display the community information
-  CommunityView? communityView;
+  /// The community associated with the post. This is used to display the community information
+  ThunderCommunity? community;
 
   /// A list of cross posts for the given post. This is determined by the URL parameter
   List<PostView> crossPosts = [];
@@ -174,7 +174,10 @@ class _CreatePostPageState extends State<CreatePostPage> {
     super.initState();
 
     communityId = widget.communityId;
-    communityView = widget.communityView;
+
+    if (widget.communityView != null) {
+      community = ThunderCommunity(widget.communityView!.community, communityView: widget.communityView);
+    }
 
     // Set up any text controller listeners
     _titleTextController.addListener(() {
@@ -417,12 +420,11 @@ class _CreatePostPageState extends State<CreatePostPage> {
                           padding: const EdgeInsets.symmetric(horizontal: 16.0),
                           child: Column(crossAxisAlignment: CrossAxisAlignment.start, children: <Widget>[
                             CommunitySelector(
-                              communityId: communityId,
-                              communityView: communityView,
-                              onCommunitySelected: (CommunityView cv) {
+                              community: ThunderCommunity(widget.communityView!.community, communityView: widget.communityView),
+                              onCommunitySelected: (ThunderCommunity c) {
                                 setState(() {
-                                  communityId = cv.community.id;
-                                  communityView = cv;
+                                  communityId = c.id;
+                                  community = c;
                                 });
                                 _validateSubmission();
                               },
@@ -430,7 +432,7 @@ class _CreatePostPageState extends State<CreatePostPage> {
                             const SizedBox(height: 4.0),
                             UserSelector(
                               profileModalHeading: l10n.selectAccountToPostAs,
-                              communityActorId: communityView?.community.actorId,
+                              communityActorId: community?.url,
                               onCommunityChanged: (CommunityView? cv) {
                                 if (cv == null) {
                                   showSnackbar(l10n.unableToFindCommunityOnInstance);
@@ -438,7 +440,7 @@ class _CreatePostPageState extends State<CreatePostPage> {
 
                                 setState(() {
                                   communityId = cv?.community.id;
-                                  communityView = cv;
+                                  community = cv != null ? ThunderCommunity(cv.community, communityView: cv) : null;
                                 });
                                 _validateSubmission();
                               },
@@ -661,8 +663,8 @@ class _CreatePostPageState extends State<CreatePostPage> {
                                 },
                                 MarkdownType.community: () {
                                   showCommunityInputDialog(context, title: l10n.community, onCommunitySelected: (community) {
-                                    _bodyTextController.text = _bodyTextController.text.replaceRange(
-                                        _bodyTextController.selection.end, _bodyTextController.selection.end, '!${community.community.name}@${fetchInstanceNameFromUrl(community.community.actorId)}');
+                                    _bodyTextController.text = _bodyTextController.text
+                                        .replaceRange(_bodyTextController.selection.end, _bodyTextController.selection.end, '!${community.communityName}@${fetchInstanceNameFromUrl(community.url)}');
                                   });
                                 },
                               },
@@ -809,19 +811,15 @@ class _CreatePostPageState extends State<CreatePostPage> {
 class CommunitySelector extends StatefulWidget {
   const CommunitySelector({
     super.key,
-    this.communityId,
-    this.communityView,
+    this.community,
     required this.onCommunitySelected,
   });
 
-  /// The initial community id to be passed in
-  final int? communityId;
-
-  /// The initial [CommunityView] to be passed in
-  final CommunityView? communityView;
+  /// The initial community to be passed in
+  final ThunderCommunity? community;
 
   /// A callback function to trigger whenever a community is selected from the dropdown
-  final Function(CommunityView) onCommunitySelected;
+  final Function(ThunderCommunity) onCommunitySelected;
 
   @override
   State<CommunitySelector> createState() => _CommunitySelectorState();
@@ -851,22 +849,22 @@ class _CommunitySelectorState extends State<CommunitySelector> {
             children: [
               Row(
                 children: [
-                  if (widget.communityView?.community != null)
+                  if (widget.community != null)
                     CommunityAvatar(
-                      community: ThunderCommunity(widget.communityView!.community),
+                      community: widget.community!,
                       radius: 16,
                     ),
                   const SizedBox(width: 12),
-                  widget.communityId != null
+                  widget.community != null
                       ? Column(
                           crossAxisAlignment: CrossAxisAlignment.start,
                           children: [
-                            Text('${widget.communityView?.community.title} '),
+                            Text('${widget.community!.title} '),
                             CommunityFullNameWidget(
                               context,
-                              widget.communityView?.community.name,
-                              widget.communityView?.community.title,
-                              fetchInstanceNameFromUrl(widget.communityView?.community.actorId),
+                              widget.community!.communityName,
+                              widget.community!.title,
+                              fetchInstanceNameFromUrl(widget.community!.url),
                               // Override, because we have the display name right above
                               useDisplayName: false,
                             )

--- a/lib/community/pages/create_post_page.dart
+++ b/lib/community/pages/create_post_page.dart
@@ -420,7 +420,7 @@ class _CreatePostPageState extends State<CreatePostPage> {
                           padding: const EdgeInsets.symmetric(horizontal: 16.0),
                           child: Column(crossAxisAlignment: CrossAxisAlignment.start, children: <Widget>[
                             CommunitySelector(
-                              community: ThunderCommunity(widget.communityView!.community, communityView: widget.communityView),
+                              community: community,
                               onCommunitySelected: (ThunderCommunity c) {
                                 setState(() {
                                   communityId = c.id;
@@ -806,7 +806,7 @@ class _CreatePostPageState extends State<CreatePostPage> {
 
 /// Creates a widget which displays a preview of a pre-selected community, with the ability to change the selected community
 ///
-/// Passing in either [communityId] or [communityView] will set the initial state of the widget to display that given community.
+/// Passing in a [community] will set the initial state of the widget to display that given community.
 /// A callback function [onCommunitySelected] will be triggered whenever a new community is selected from the dropdown.
 class CommunitySelector extends StatefulWidget {
   const CommunitySelector({
@@ -848,13 +848,9 @@ class _CommunitySelectorState extends State<CommunitySelector> {
             mainAxisAlignment: MainAxisAlignment.spaceBetween,
             children: [
               Row(
+                spacing: 12.0,
                 children: [
-                  if (widget.community != null)
-                    CommunityAvatar(
-                      community: widget.community!,
-                      radius: 16,
-                    ),
-                  const SizedBox(width: 12),
+                  if (widget.community != null) CommunityAvatar(community: widget.community!, radius: 16),
                   widget.community != null
                       ? Column(
                           crossAxisAlignment: CrossAxisAlignment.start,

--- a/lib/community/widgets/community_drawer.dart
+++ b/lib/community/widgets/community_drawer.dart
@@ -57,7 +57,7 @@ class _CommunityDrawerState extends State<CommunityDrawer> {
 
     bool isLoggedIn = context.watch<AuthBloc>().state.isLoggedIn;
 
-    List<Community> subscriptions = [];
+    List<ThunderCommunity> subscriptions = [];
 
     if (isLoggedIn) {
       Set<int> favoriteCommunityIds = accountState.favorites.map((cv) => cv.community.id).toSet();
@@ -66,7 +66,8 @@ class _CommunityDrawerState extends State<CommunityDrawer> {
       List<CommunityView> filteredSubscriptions = accountState.subsciptions
           .where((CommunityView communityView) => !favoriteCommunityIds.contains(communityView.community.id) && !moderatedCommunityIds.contains(communityView.community.id))
           .toList();
-      subscriptions = filteredSubscriptions.map((CommunityView communityView) => communityView.community).toList();
+
+      subscriptions = filteredSubscriptions.map((CommunityView cv) => ThunderCommunity(cv.community, communityView: cv)).toList();
     } else {
       subscriptions = subscriptionsBloc.state.subscriptions;
     }
@@ -298,7 +299,9 @@ class FavoriteCommunities extends StatelessWidget {
             physics: const NeverScrollableScrollPhysics(),
             itemCount: accountState.favorites.length,
             itemBuilder: (context, index) {
-              Community community = accountState.favorites[index].community;
+              final c = accountState.favorites[index].community;
+              final community = ThunderCommunity(c);
+
               bool isCommunitySelected = feedState.communityId == community.id;
 
               return TextButton(
@@ -359,7 +362,8 @@ class ModeratedCommunities extends StatelessWidget {
               physics: const NeverScrollableScrollPhysics(),
               itemCount: moderatedCommunities.length,
               itemBuilder: (context, index) {
-                Community community = moderatedCommunities[index].community;
+                final c = moderatedCommunities[index].community;
+                final community = ThunderCommunity(c);
 
                 final bool isCommunitySelected = feedState.communityId == community.id;
 
@@ -472,7 +476,7 @@ class DrawerItem extends StatelessWidget {
 class CommunityItem extends StatelessWidget {
   const CommunityItem({super.key, required this.community, this.showFavoriteAction = true, this.isFavorite = false});
 
-  final Community community;
+  final ThunderCommunity community;
   final bool isFavorite;
   final bool showFavoriteAction;
 
@@ -484,7 +488,7 @@ class CommunityItem extends StatelessWidget {
     return Row(
       children: [
         CommunityAvatar(
-          community: ThunderCommunity(community),
+          community: community,
           radius: 16,
           thumbnailSize: 100,
           format: 'png',
@@ -497,7 +501,7 @@ class CommunityItem extends StatelessWidget {
               context,
               community.name,
               community.title,
-              fetchInstanceNameFromUrl(community.actorId),
+              fetchInstanceNameFromUrl(community.url),
             )}',
             preferBelow: false,
             child: Column(
@@ -510,7 +514,7 @@ class CommunityItem extends StatelessWidget {
                   maxLines: 1,
                 ),
                 Text(
-                  fetchInstanceNameFromUrl(community.actorId) ?? '',
+                  fetchInstanceNameFromUrl(community.url) ?? '',
                   style: theme.textTheme.bodyMedium,
                   overflow: TextOverflow.ellipsis,
                 ),

--- a/lib/community/widgets/community_header.dart
+++ b/lib/community/widgets/community_header.dart
@@ -97,7 +97,7 @@ class _CommunityHeaderState extends State<CommunityHeader> {
                       Row(
                         children: [
                           CommunityAvatar(
-                            community: ThunderCommunity(widget.getCommunityResponse.communityView.community),
+                            community: ThunderCommunity(widget.getCommunityResponse.communityView.community, communityView: widget.getCommunityResponse.communityView),
                             radius: 45.0,
                             showCommunityStatus: true,
                           ),

--- a/lib/community/widgets/community_list_entry.dart
+++ b/lib/community/widgets/community_list_entry.dart
@@ -17,20 +17,33 @@ import 'package:thunder/utils/navigation.dart';
 import 'package:thunder/utils/numbers.dart';
 
 class CommunityListEntry extends StatelessWidget {
-  final CommunityView communityView;
+  /// The community to display.
+  final ThunderCommunity community;
+
+  /// Whether the user is logged in.
   final bool isUserLoggedIn;
+
+  /// The current user subscriptions.
   final Set<int>? currentSubscriptions;
+
+  /// Whether to indicate that the community is a favorite.
   final bool indicateFavorites;
-  final bool Function(BuildContext context, Community community)? getFavoriteStatus;
-  final SubscribedType Function(bool isUserLoggedIn, CommunityView communityView, Set<int>? currentSubscriptions)? getCurrentSubscriptionStatus;
-  final void Function(bool isUserLoggedIn, BuildContext context, CommunityView communityView)? onSubscribeIconPressed;
+
+  /// Callback function that occurs when the favorite status is requested.
+  final bool Function(BuildContext context, ThunderCommunity community)? getFavoriteStatus;
+
+  /// Callback function that occurs when the subscription status is requested.
+  final SubscribedType Function(bool isUserLoggedIn, ThunderCommunity community, Set<int>? currentSubscriptions)? getCurrentSubscriptionStatus;
+
+  /// Callback function that occurs when the subscribe icon is pressed.
+  final void Function(bool isUserLoggedIn, BuildContext context, ThunderCommunity community)? onSubscribeIconPressed;
 
   /// Whether the community should be resolved to a different instance
   final String? resolutionInstance;
 
   const CommunityListEntry({
     super.key,
-    required this.communityView,
+    required this.community,
     required this.isUserLoggedIn,
     this.currentSubscriptions,
     this.indicateFavorites = true,
@@ -42,67 +55,64 @@ class CommunityListEntry extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final AppLocalizations l10n = AppLocalizations.of(context)!;
+    final l10n = AppLocalizations.of(context)!;
+    assert(community.subscribers != null);
 
     return Tooltip(
       excludeFromSemantics: true,
-      message: '${communityView.community.title}\n${generateCommunityFullName(
+      message: '${community.title}\n${generateCommunityFullName(
         context,
-        communityView.community.name,
-        communityView.community.title,
-        fetchInstanceNameFromUrl(communityView.community.actorId),
+        community.communityName,
+        community.title,
+        fetchInstanceNameFromUrl(community.url),
       )}',
       preferBelow: false,
       child: ListTile(
-        leading: CommunityAvatar(
-          community: ThunderCommunity(communityView.community),
-          radius: 25,
-        ),
-        title: Text(
-          communityView.community.title,
-          overflow: TextOverflow.ellipsis,
-        ),
-        subtitle: Row(children: [
-          Flexible(
-            child: CommunityFullNameWidget(
-              context,
-              communityView.community.name,
-              communityView.community.title,
-              fetchInstanceNameFromUrl(communityView.community.actorId),
-              // Override because we're showing display name above
-              useDisplayName: false,
+        leading: CommunityAvatar(community: community, radius: 25),
+        title: Text(community.title, overflow: TextOverflow.ellipsis),
+        subtitle: Row(
+          children: [
+            Flexible(
+              child: CommunityFullNameWidget(
+                context,
+                community.communityName,
+                community.title,
+                fetchInstanceNameFromUrl(community.url),
+                // Override because we're showing display name above
+                useDisplayName: false,
+              ),
             ),
-          ),
-          Text(
-            ' · ${formatLongNumber(communityView.counts.subscribers)}',
-            semanticsLabel: l10n.countSubscribers(communityView.counts.subscribers),
-          ),
-          const SizedBox(width: 4),
-          const Icon(Icons.people_rounded, size: 16.0),
-          if (indicateFavorites &&
-              getFavoriteStatus?.call(context, communityView.community) == true &&
-              getCurrentSubscriptionStatus?.call(isUserLoggedIn, communityView, currentSubscriptions) == SubscribedType.subscribed) ...const [
-            Text(' · '),
-            Icon(Icons.star_rounded, size: 15),
-          ]
-        ]),
+            Text(
+              ' · ${formatLongNumber(community.subscribers!)}',
+              semanticsLabel: l10n.countSubscribers(community.subscribers!),
+            ),
+            const SizedBox(width: 4),
+            const Icon(Icons.people_rounded, size: 16.0),
+            if (indicateFavorites &&
+                getFavoriteStatus?.call(context, community) == true &&
+                getCurrentSubscriptionStatus?.call(isUserLoggedIn, community, currentSubscriptions) == SubscribedType.subscribed) ...const [
+              Text(' · '),
+              Icon(Icons.star_rounded, size: 15),
+            ]
+          ],
+        ),
         trailing: getCurrentSubscriptionStatus == null
             ? null
             : IconButton(
                 onPressed: () {
-                  SubscribedType? subscriptionStatus = getCurrentSubscriptionStatus!(isUserLoggedIn, communityView, currentSubscriptions);
-                  onSubscribeIconPressed?.call(isUserLoggedIn, context, communityView);
+                  SubscribedType? subscriptionStatus = getCurrentSubscriptionStatus!(isUserLoggedIn, community, currentSubscriptions);
+                  onSubscribeIconPressed?.call(isUserLoggedIn, context, community);
                   showSnackbar(subscriptionStatus == SubscribedType.notSubscribed ? l10n.addedCommunityToSubscriptions : l10n.removedCommunityFromSubscriptions);
                   context.read<AccountBloc>().add(const GetAccountSubscriptions());
                 },
                 icon: Icon(
-                  switch (getCurrentSubscriptionStatus!(isUserLoggedIn, communityView, currentSubscriptions)) {
+                  switch (getCurrentSubscriptionStatus!(isUserLoggedIn, community, currentSubscriptions)) {
                     SubscribedType.notSubscribed => Icons.add_circle_outline_rounded,
                     SubscribedType.pending => Icons.pending_outlined,
                     SubscribedType.subscribed => Icons.remove_circle_outline_rounded,
                   },
                 ),
-                tooltip: switch (getCurrentSubscriptionStatus!(isUserLoggedIn, communityView, currentSubscriptions)) {
+                tooltip: switch (getCurrentSubscriptionStatus!(isUserLoggedIn, community, currentSubscriptions)) {
                   SubscribedType.notSubscribed => l10n.subscribe,
                   SubscribedType.pending => l10n.unsubscribePending,
                   SubscribedType.subscribed => l10n.unsubscribe,
@@ -110,12 +120,14 @@ class CommunityListEntry extends StatelessWidget {
                 visualDensity: VisualDensity.compact,
               ),
         onTap: () async {
-          int? communityId = communityView.community.id;
+          int? communityId = community.id;
+
           if (resolutionInstance != null) {
-            final LemmyApiV3 lemmy = (LemmyClient()..changeBaseUrl(resolutionInstance!)).lemmyApiV3;
             try {
-              final ResolveObjectResponse resolveObjectResponse = await lemmy.run(ResolveObject(q: communityView.community.actorId));
-              communityId = resolveObjectResponse.community?.community.id;
+              final lemmy = (LemmyClient()..changeBaseUrl(resolutionInstance!)).lemmyApiV3;
+              final response = await lemmy.run(ResolveObject(q: community.url));
+
+              communityId = response.community?.community.id;
             } catch (e) {
               // If we can't find it, then we'll get a standard error message about communityId being un-navigable
             }

--- a/lib/core/models/thunder_community.dart
+++ b/lib/core/models/thunder_community.dart
@@ -2,28 +2,37 @@ import 'package:lemmy_api_client/v3.dart';
 
 class ThunderCommunity {
   /// The Lemmy API model for the community.
-  Community community;
+  final Community _community;
 
-  ThunderCommunity(this.community);
+  /// The Lemmy API model for the community view.
+  final CommunityView? _communityView;
+
+  ThunderCommunity(this._community, {CommunityView? communityView}) : _communityView = communityView;
 
   /// The ID of the community.
-  int get id => community.id;
+  int get id => _community.id;
 
   /// The name of the community. If the community has a title, it is used. Otherwise, the name is used.
-  String get name => community.title.isNotEmpty == true ? community.title : community.name;
+  String get name => _community.title.isNotEmpty == true ? _community.title : _community.name;
 
   /// The name of the community.
-  String get communityName => community.name;
+  String get communityName => _community.name;
 
   /// The title of the community.
-  String get title => community.title;
+  String get title => _community.title;
 
   /// Whether the community is locked from posting.
-  bool get locked => community.postingRestrictedToMods;
+  bool get locked => _community.postingRestrictedToMods;
 
   /// The icon of the community.
-  String? get icon => community.icon;
+  String? get icon => _community.icon;
 
   /// The URL to the community. This is generally associated with the ActivityPub actor URL.
-  String get url => community.actorId;
+  String get url => _community.actorId;
+
+  /// The number of subscribers to the community.
+  int? get subscribers => _communityView?.counts.subscribers;
+
+  /// The current user subscription status to the community.
+  SubscribedType? get subscribed => _communityView?.subscribed;
 }

--- a/lib/feed/utils/community.dart
+++ b/lib/feed/utils/community.dart
@@ -5,6 +5,7 @@ import 'package:thunder/account/bloc/account_bloc.dart';
 import 'package:thunder/account/models/account.dart';
 import 'package:thunder/account/models/favourite.dart';
 import 'package:thunder/core/auth/helpers/fetch_account.dart';
+import 'package:thunder/core/models/models.dart';
 import 'package:thunder/core/singletons/lemmy_client.dart';
 
 /// Logic to block a community
@@ -53,7 +54,7 @@ Future<GetCommunityResponse> fetchCommunityInformation({int? id, String? name}) 
   return fullCommunityView;
 }
 
-Future<void> toggleFavoriteCommunity(BuildContext context, Community community, bool isFavorite) async {
+Future<void> toggleFavoriteCommunity(BuildContext context, ThunderCommunity community, bool isFavorite) async {
   if (isFavorite) {
     await Favorite.deleteFavorite(communityId: community.id);
     if (context.mounted) context.read<AccountBloc>().add(const RefreshAccountInformation());
@@ -74,21 +75,21 @@ Future<void> toggleFavoriteCommunity(BuildContext context, Community community, 
 
 /// Takes a list of [communities] and returns the list with any [favoriteCommunities] at the beginning of the list
 /// Note that you may need to call [toList] when passing in lists that are marked as readonly.
-List<CommunityView>? prioritizeFavorites(List<CommunityView>? communities, List<CommunityView>? favoriteCommunities) {
+List<ThunderCommunity>? prioritizeFavorites(List<ThunderCommunity>? communities, List<ThunderCommunity>? favoriteCommunities) {
   // If either communities or favorites are empty, no reason to prioritize.
   if (communities?.isNotEmpty != true || favoriteCommunities?.isNotEmpty != true) {
     return communities;
   }
 
   // Create a set of the favorited community ids for filtering later
-  Set<int> favoriteCommunityIds = Set<int>.from(favoriteCommunities!.map((c) => c.community.id));
+  Set<int> favoriteCommunityIds = Set<int>.from(favoriteCommunities!.map((c) => c.id));
 
   // Filters out communities that are part of the favorites, and keeps the same order
-  List<CommunityView>? sortedFavorites = communities!.where((c) => favoriteCommunityIds.contains(c.community.id)).toList();
+  List<ThunderCommunity>? sortedFavorites = communities!.where((c) => favoriteCommunityIds.contains(c.id)).toList();
 
   // Filters out communities that are not a part of the favorites, and keeps the same order
-  List<CommunityView>? sortedNonFavorites = communities.where((c) => !favoriteCommunityIds.contains(c.community.id)).toList();
+  List<ThunderCommunity>? sortedNonFavorites = communities.where((c) => !favoriteCommunityIds.contains(c.id)).toList();
 
   // Combine them together, with favorites at the top
-  return List<CommunityView>.from(sortedFavorites)..addAll(sortedNonFavorites);
+  return List<ThunderCommunity>.from(sortedFavorites)..addAll(sortedNonFavorites);
 }

--- a/lib/feed/widgets/feed_page_app_bar.dart
+++ b/lib/feed/widgets/feed_page_app_bar.dart
@@ -224,7 +224,9 @@ class FeedAppBarCommunityActions extends StatelessWidget {
               if (_getSubscriptionStatus(context) == SubscribedType.subscribed)
                 ThunderPopupMenuItem(
                   onTap: () async {
-                    final Community community = context.read<FeedBloc>().state.fullCommunityView!.communityView.community;
+                    final cv = context.read<FeedBloc>().state.fullCommunityView!.communityView;
+                    final community = ThunderCommunity(cv.community, communityView: cv);
+
                     bool isFavorite = _getFavoriteStatus(context);
                     await toggleFavoriteCommunity(context, community, isFavorite);
                   },
@@ -396,7 +398,7 @@ void _onSubscribeIconPressed(BuildContext context) async {
   final FeedBloc feedBloc = context.read<FeedBloc>();
   final FeedState feedState = feedBloc.state;
 
-  final Community community = feedBloc.state.fullCommunityView!.communityView.community;
+  final community = ThunderCommunity(feedState.fullCommunityView!.communityView.community, communityView: feedState.fullCommunityView!.communityView);
   final Set<int> currentSubscriptions = context.read<AnonymousSubscriptionsBloc>().state.ids;
 
   final AppLocalizations l10n = AppLocalizations.of(context)!;

--- a/lib/instance/pages/instance_page.dart
+++ b/lib/instance/pages/instance_page.dart
@@ -317,7 +317,7 @@ class _InstancePageState extends State<InstancePage> {
                                 return Material(
                                   child: communityView != null
                                       ? CommunityListEntry(
-                                          communityView: communityView,
+                                          community: ThunderCommunity(communityView.community, communityView: communityView),
                                           isUserLoggedIn: false,
                                           resolutionInstance: state.resolutionInstance,
                                         )

--- a/lib/moderator/view/report_page.dart
+++ b/lib/moderator/view/report_page.dart
@@ -13,6 +13,7 @@ import 'package:thunder/community/widgets/post_card_view_compact.dart';
 import 'package:thunder/core/enums/media_type.dart';
 import 'package:thunder/core/models/media.dart';
 import 'package:thunder/core/models/post_view_media.dart';
+import 'package:thunder/core/models/models.dart';
 import 'package:thunder/core/singletons/lemmy_client.dart';
 import 'package:thunder/feed/feed.dart';
 import 'package:thunder/moderator/bloc/report_bloc.dart';
@@ -137,13 +138,13 @@ class _ReportFeedViewState extends State<ReportFeedView> {
                           context: context,
                           builder: (builderContext) => ReportFilterBottomSheet(
                             status: showResolved ? ReportResolveStatus.all : ReportResolveStatus.unresolved,
-                            onSubmit: (ReportResolveStatus status, CommunityView? communityView) async => {
+                            onSubmit: (ReportResolveStatus status, ThunderCommunity? community) async => {
                               HapticFeedback.mediumImpact(),
                               Navigator.of(context).maybePop(),
                               setState(() => showResolved = status != ReportResolveStatus.unresolved),
                               BlocProvider.of<ReportBloc>(context).add(ReportFeedChangeFilterTypeEvent(
                                 showResolved: status != ReportResolveStatus.unresolved,
-                                communityId: communityView?.community.id,
+                                communityId: community?.id,
                               ))
                             },
                           ),

--- a/lib/moderator/widgets/report_page_filter_bottom_sheet.dart
+++ b/lib/moderator/widgets/report_page_filter_bottom_sheet.dart
@@ -4,7 +4,7 @@ import 'package:flutter/services.dart';
 import 'package:lemmy_api_client/v3.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 
-import 'package:thunder/utils/global_context.dart';
+import 'package:thunder/core/models/models.dart';
 import 'package:thunder/community/pages/create_post_page.dart';
 
 enum ReportResolveStatus { unresolved, all }
@@ -18,7 +18,7 @@ class ReportFilterBottomSheet extends StatefulWidget {
   final ReportResolveStatus status;
 
   /// The function to call when the submit button is pressed
-  final void Function(ReportResolveStatus reportResolveStatus, CommunityView? communityView) onSubmit;
+  final void Function(ReportResolveStatus reportResolveStatus, ThunderCommunity? community) onSubmit;
 
   @override
   State<ReportFilterBottomSheet> createState() => _ReportFilterBottomSheetState();
@@ -29,7 +29,7 @@ class _ReportFilterBottomSheetState extends State<ReportFilterBottomSheet> {
   ReportResolveStatus status = ReportResolveStatus.all;
 
   /// The community to filter by
-  CommunityView? communityView;
+  ThunderCommunity? community;
 
   @override
   void initState() {
@@ -40,7 +40,7 @@ class _ReportFilterBottomSheetState extends State<ReportFilterBottomSheet> {
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
-    final l10n = AppLocalizations.of(GlobalContext.context)!;
+    final l10n = AppLocalizations.of(context)!;
 
     return SafeArea(
       child: Padding(
@@ -79,16 +79,15 @@ class _ReportFilterBottomSheetState extends State<ReportFilterBottomSheet> {
             Text(l10n.community, style: const TextStyle(fontWeight: FontWeight.bold)),
             const SizedBox(height: 8.0),
             CommunitySelector(
-              communityId: communityView?.community.id,
-              communityView: communityView,
-              onCommunitySelected: (CommunityView cv) {
-                setState(() => communityView = cv);
+              community: community,
+              onCommunitySelected: (ThunderCommunity c) {
+                setState(() => community = c);
               },
             ),
             Align(
               alignment: Alignment.bottomRight,
               child: TextButton(
-                onPressed: () => widget.onSubmit(status, communityView),
+                onPressed: () => widget.onSubmit(status, community),
                 child: Text(l10n.apply),
               ),
             ),

--- a/lib/search/bloc/search_bloc.dart
+++ b/lib/search/bloc/search_bloc.dart
@@ -9,6 +9,7 @@ import 'package:collection/collection.dart';
 import 'package:thunder/account/models/account.dart';
 import 'package:thunder/core/auth/helpers/fetch_account.dart';
 import 'package:thunder/core/enums/meta_search_type.dart';
+import 'package:thunder/core/models/models.dart';
 import 'package:thunder/core/models/post_view_media.dart';
 import 'package:thunder/core/singletons/lemmy_client.dart';
 import 'package:thunder/feed/utils/community.dart';
@@ -182,7 +183,7 @@ class SearchBloc extends Bloc<SearchEvent, SearchState> {
 
       return emit(state.copyWith(
         status: SearchStatus.success,
-        communities: prioritizeFavorites(searchResponse?.communities.toList(), event.favoriteCommunities),
+        communities: prioritizeFavorites(searchResponse?.communities.map((cv) => ThunderCommunity(cv.community, communityView: cv)).toList(), event.favoriteCommunities),
         users: searchResponse?.users,
         comments: searchResponse?.comments,
         posts: await parsePostViews(searchResponse?.posts ?? []),
@@ -236,7 +237,7 @@ class SearchBloc extends Bloc<SearchEvent, SearchState> {
           }
 
           // Append the search results
-          state.communities = [...state.communities ?? [], ...searchResponse?.communities ?? []];
+          state.communities = [...state.communities ?? [], ...searchResponse?.communities.map((cv) => ThunderCommunity(cv.community, communityView: cv)) ?? []];
           state.users = [...state.users ?? [], ...searchResponse?.users ?? []];
           state.comments = [...state.comments ?? [], ...searchResponse?.comments ?? []];
           state.posts = [...state.posts ?? [], ...await parsePostViews(searchResponse?.posts ?? [])];
@@ -281,20 +282,17 @@ class SearchBloc extends Bloc<SearchEvent, SearchState> {
       ));
 
       // Refetch the status of the community - communityResponse does not return back with the proper subscription status
-      GetCommunityResponse fullCommunityView = await lemmy.run(GetCommunity(
-        auth: account.jwt,
-        id: event.communityId,
-      ));
+      GetCommunityResponse response = await lemmy.run(GetCommunity(auth: account.jwt, id: event.communityId));
+      ThunderCommunity community = ThunderCommunity(response.communityView.community, communityView: response.communityView);
 
-      List<CommunityView> communities;
+      List<ThunderCommunity> communities;
+
       if (event.query.isNotEmpty || state.viewingAll) {
         communities = state.communities ?? [];
 
-        communities = state.communities?.map((CommunityView communityView) {
-              if (communityView.community.id == fullCommunityView.communityView.community.id) {
-                return fullCommunityView.communityView;
-              }
-              return communityView;
+        communities = state.communities?.map((ThunderCommunity c) {
+              if (c.id == community.id) return community;
+              return c;
             }).toList() ??
             [];
 
@@ -302,11 +300,9 @@ class SearchBloc extends Bloc<SearchEvent, SearchState> {
       } else {
         communities = state.trendingCommunities ?? [];
 
-        communities = state.trendingCommunities?.map((CommunityView communityView) {
-              if (communityView.community.id == fullCommunityView.communityView.community.id) {
-                return fullCommunityView.communityView;
-              }
-              return communityView;
+        communities = state.trendingCommunities?.map((ThunderCommunity c) {
+              if (c.id == community.id) return community;
+              return c;
             }).toList() ??
             [];
 
@@ -316,19 +312,15 @@ class SearchBloc extends Bloc<SearchEvent, SearchState> {
       // Delay a bit then refetch the status of the community again for a better chance of getting the right subscribed type
       await Future.delayed(const Duration(seconds: 1));
 
-      fullCommunityView = await lemmy.run(GetCommunity(
-        auth: account.jwt,
-        id: event.communityId,
-      ));
+      response = await lemmy.run(GetCommunity(auth: account.jwt, id: event.communityId));
+      community = ThunderCommunity(response.communityView.community, communityView: response.communityView);
 
       if (event.query.isNotEmpty || state.viewingAll) {
         communities = state.communities ?? [];
 
-        communities = state.communities?.map((CommunityView communityView) {
-              if (communityView.community.id == fullCommunityView.communityView.community.id) {
-                return fullCommunityView.communityView;
-              }
-              return communityView;
+        communities = state.communities?.map((ThunderCommunity c) {
+              if (c.id == community.id) return community;
+              return c;
             }).toList() ??
             [];
 
@@ -336,11 +328,9 @@ class SearchBloc extends Bloc<SearchEvent, SearchState> {
       } else {
         communities = state.trendingCommunities ?? [];
 
-        communities = state.trendingCommunities?.map((CommunityView communityView) {
-              if (communityView.community.id == fullCommunityView.communityView.community.id) {
-                return fullCommunityView.communityView;
-              }
-              return communityView;
+        communities = state.trendingCommunities?.map((ThunderCommunity c) {
+              if (c.id == community.id) return community;
+              return c;
             }).toList() ??
             [];
 
@@ -356,14 +346,15 @@ class SearchBloc extends Bloc<SearchEvent, SearchState> {
       LemmyApiV3 lemmy = LemmyClient.instance.lemmyApiV3;
       Account? account = await fetchActiveProfileAccount();
 
-      ListCommunitiesResponse listCommunitiesResponse = await lemmy.run(ListCommunities(
+      final response = await lemmy.run(ListCommunities(
         type: ListingType.local,
         sort: SortType.active,
         limit: 5,
         auth: account?.jwt,
       ));
 
-      return emit(state.copyWith(status: SearchStatus.trending, trendingCommunities: listCommunitiesResponse.communities));
+      final communities = response.communities.map((cv) => ThunderCommunity(cv.community, communityView: cv)).toList();
+      return emit(state.copyWith(status: SearchStatus.trending, trendingCommunities: communities));
     } catch (e) {
       // Not the end of the world if we can't load trending
     }

--- a/lib/search/bloc/search_event.dart
+++ b/lib/search/bloc/search_event.dart
@@ -14,7 +14,7 @@ class StartSearchEvent extends SearchEvent {
   final MetaSearchType searchType;
   final int? communityId;
   final int? creatorId;
-  final List<CommunityView>? favoriteCommunities;
+  final List<ThunderCommunity>? favoriteCommunities;
   final bool? force;
 
   const StartSearchEvent({

--- a/lib/search/bloc/search_state.dart
+++ b/lib/search/bloc/search_state.dart
@@ -19,8 +19,8 @@ class SearchState extends Equatable {
   });
 
   final SearchStatus status;
-  List<CommunityView>? communities;
-  List<CommunityView>? trendingCommunities;
+  List<ThunderCommunity>? communities;
+  List<ThunderCommunity>? trendingCommunities;
   List<PersonView>? users;
   List<CommentView>? comments;
   List<PostViewMedia>? posts;
@@ -36,8 +36,8 @@ class SearchState extends Equatable {
 
   SearchState copyWith({
     SearchStatus? status,
-    List<CommunityView>? communities,
-    List<CommunityView>? trendingCommunities,
+    List<ThunderCommunity>? communities,
+    List<ThunderCommunity>? trendingCommunities,
     List<PersonView>? users,
     List<CommentView>? comments,
     List<PostViewMedia>? posts,

--- a/lib/search/pages/search_page.dart
+++ b/lib/search/pages/search_page.dart
@@ -69,7 +69,7 @@ class _SearchPageState extends State<SearchPage> with AutomaticKeepAliveClientMi
   SortType sortType = SortType.active;
   IconData? sortTypeIcon;
   String? sortTypeLabel;
-  final Set<Community> newAnonymousSubscriptions = {};
+  final Set<ThunderCommunity> newAnonymousSubscriptions = {};
   final Set<int> removedSubs = {};
   int _previousFocusSearchId = 0;
   final searchTextFieldFocus = FocusNode();
@@ -553,13 +553,13 @@ class _SearchPageState extends State<SearchPage> with AutomaticKeepAliveClientMi
                           shrinkWrap: true,
                           itemCount: context.read<AccountBloc>().state.favorites.length,
                           itemBuilder: (BuildContext context, int index) {
-                            final communityView = context.read<AccountBloc>().state.favorites[index];
-                            final currentSubscriptions = context.read<AnonymousSubscriptionsBloc>().state.ids;
+                            final cv = context.read<AccountBloc>().state.favorites[index];
+                            final subscriptions = context.read<AnonymousSubscriptionsBloc>().state.ids;
 
                             return CommunityListEntry(
-                              community: ThunderCommunity(communityView.community, communityView: communityView),
+                              community: ThunderCommunity(cv.community, communityView: cv),
                               isUserLoggedIn: isUserLoggedIn,
-                              currentSubscriptions: currentSubscriptions,
+                              currentSubscriptions: subscriptions,
                               indicateFavorites: false,
                               getFavoriteStatus: _getFavoriteStatus,
                               getCurrentSubscriptionStatus: _getCurrentSubscriptionStatus,
@@ -695,12 +695,12 @@ class _SearchPageState extends State<SearchPage> with AutomaticKeepAliveClientMi
                       : Container();
                 } else {
                   final community = state.communities![index];
-                  final currentSubscriptions = context.read<AnonymousSubscriptionsBloc>().state.ids;
+                  final subscriptions = context.read<AnonymousSubscriptionsBloc>().state.ids;
 
                   return CommunityListEntry(
                     community: community,
                     isUserLoggedIn: isUserLoggedIn,
-                    currentSubscriptions: currentSubscriptions,
+                    currentSubscriptions: subscriptions,
                     getFavoriteStatus: _getFavoriteStatus,
                     getCurrentSubscriptionStatus: _getCurrentSubscriptionStatus,
                     onSubscribeIconPressed: _onSubscribeIconPressed,
@@ -887,8 +887,8 @@ class _SearchPageState extends State<SearchPage> with AutomaticKeepAliveClientMi
     setState(() {
       if (currentSubscriptions.contains(community.id) && !removedSubs.contains(community.id)) {
         removedSubs.add(community.id);
-      } else if (newAnonymousSubscriptions.contains(community)) {
-        newAnonymousSubscriptions.remove(community);
+      } else if (newAnonymousSubscriptions.map((c) => c.id).contains(community.id)) {
+        newAnonymousSubscriptions.removeWhere((c) => c.id == community.id);
       } else if (removedSubs.contains(community.id)) {
         removedSubs.remove(community.id);
       } else {

--- a/lib/search/pages/search_page.dart
+++ b/lib/search/pages/search_page.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 import 'dart:io';
 
 import 'package:back_button_interceptor/back_button_interceptor.dart';
+import 'package:collection/collection.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
@@ -422,14 +423,14 @@ class _SearchPageState extends State<SearchPage> with AutomaticKeepAliveClientMi
                                       });
                                       _doSearch();
                                     } else {
-                                      showCommunityInputDialog(context, title: l10n.community, onCommunitySelected: (communityView) {
+                                      showCommunityInputDialog(context, title: l10n.community, onCommunitySelected: (ThunderCommunity community) {
                                         setState(() {
-                                          _currentCommunityFilter = communityView.community.id;
+                                          _currentCommunityFilter = community.id;
                                           _currentCommunityFilterName = generateCommunityFullName(
                                             context,
-                                            communityView.community.name,
-                                            communityView.community.title,
-                                            fetchInstanceNameFromUrl(communityView.community.actorId),
+                                            community.communityName,
+                                            community.title,
+                                            fetchInstanceNameFromUrl(community.url),
                                           );
                                         });
                                         _doSearch();
@@ -552,10 +553,11 @@ class _SearchPageState extends State<SearchPage> with AutomaticKeepAliveClientMi
                           shrinkWrap: true,
                           itemCount: context.read<AccountBloc>().state.favorites.length,
                           itemBuilder: (BuildContext context, int index) {
-                            CommunityView communityView = context.read<AccountBloc>().state.favorites[index];
-                            final Set<int> currentSubscriptions = context.read<AnonymousSubscriptionsBloc>().state.ids;
+                            final communityView = context.read<AccountBloc>().state.favorites[index];
+                            final currentSubscriptions = context.read<AnonymousSubscriptionsBloc>().state.ids;
+
                             return CommunityListEntry(
-                              communityView: communityView,
+                              community: ThunderCommunity(communityView.community, communityView: communityView),
                               isUserLoggedIn: isUserLoggedIn,
                               currentSubscriptions: currentSubscriptions,
                               indicateFavorites: false,
@@ -579,12 +581,13 @@ class _SearchPageState extends State<SearchPage> with AutomaticKeepAliveClientMi
                         shrinkWrap: true,
                         itemCount: state.trendingCommunities!.length,
                         itemBuilder: (BuildContext context, int index) {
-                          CommunityView communityView = state.trendingCommunities![index];
-                          final Set<int> currentSubscriptions = context.read<AnonymousSubscriptionsBloc>().state.ids;
+                          final community = state.trendingCommunities![index];
+                          final subscriptions = context.read<AnonymousSubscriptionsBloc>().state.ids;
+
                           return CommunityListEntry(
-                            communityView: communityView,
+                            community: community,
                             isUserLoggedIn: isUserLoggedIn,
-                            currentSubscriptions: currentSubscriptions,
+                            currentSubscriptions: subscriptions,
                             getFavoriteStatus: _getFavoriteStatus,
                             getCurrentSubscriptionStatus: _getCurrentSubscriptionStatus,
                             onSubscribeIconPressed: _onSubscribeIconPressed,
@@ -691,10 +694,11 @@ class _SearchPageState extends State<SearchPage> with AutomaticKeepAliveClientMi
                         )
                       : Container();
                 } else {
-                  CommunityView communityView = state.communities![index];
-                  final Set<int> currentSubscriptions = context.read<AnonymousSubscriptionsBloc>().state.ids;
+                  final community = state.communities![index];
+                  final currentSubscriptions = context.read<AnonymousSubscriptionsBloc>().state.ids;
+
                   return CommunityListEntry(
-                    communityView: communityView,
+                    community: community,
                     isUserLoggedIn: isUserLoggedIn,
                     currentSubscriptions: currentSubscriptions,
                     getFavoriteStatus: _getFavoriteStatus,
@@ -827,9 +831,9 @@ class _SearchPageState extends State<SearchPage> with AutomaticKeepAliveClientMi
     }
   }
 
-  bool _getFavoriteStatus(BuildContext context, Community community) {
-    final AccountState accountState = context.read<AccountBloc>().state;
-    return accountState.favorites.any((communityView) => communityView.community.id == community.id);
+  bool _getFavoriteStatus(BuildContext context, ThunderCommunity community) {
+    final state = context.read<AccountBloc>().state;
+    return state.favorites.any((cv) => cv.community.id == community.id);
   }
 
   void showSortBottomSheet(BuildContext context) {
@@ -858,35 +862,37 @@ class _SearchPageState extends State<SearchPage> with AutomaticKeepAliveClientMi
     );
   }
 
-  SubscribedType _getCurrentSubscriptionStatus(bool isUserLoggedIn, CommunityView communityView, Set<int>? currentSubscriptions) {
-    if (isUserLoggedIn) {
-      return communityView.subscribed;
-    }
+  SubscribedType _getCurrentSubscriptionStatus(bool isUserLoggedIn, ThunderCommunity community, Set<int>? currentSubscriptions) {
+    assert(community.subscribed != null);
+    if (isUserLoggedIn) return community.subscribed!;
+
     bool isSubscribed =
-        newAnonymousSubscriptions.contains(communityView.community) || (currentSubscriptions?.contains(communityView.community.id) == true && !removedSubs.contains(communityView.community.id));
+        newAnonymousSubscriptions.firstWhereOrNull((c) => c.id == community.id) != null || (currentSubscriptions?.contains(community.id) == true && !removedSubs.contains(community.id));
+
     return isSubscribed ? SubscribedType.subscribed : SubscribedType.notSubscribed;
   }
 
-  void _onSubscribeIconPressed(bool isUserLoggedIn, BuildContext context, CommunityView communityView) {
+  void _onSubscribeIconPressed(bool isUserLoggedIn, BuildContext context, ThunderCommunity community) {
     if (isUserLoggedIn) {
       context.read<SearchBloc>().add(ChangeCommunitySubsciptionStatusEvent(
-            communityId: communityView.community.id,
-            follow: communityView.subscribed == SubscribedType.notSubscribed ? true : false,
+            communityId: community.id,
+            follow: community.subscribed == SubscribedType.notSubscribed ? true : false,
             query: _controller.text,
           ));
       return;
     }
 
     Set<int> currentSubscriptions = context.read<AnonymousSubscriptionsBloc>().state.ids;
+
     setState(() {
-      if (currentSubscriptions.contains(communityView.community.id) && !removedSubs.contains(communityView.community.id)) {
-        removedSubs.add(communityView.community.id);
-      } else if (newAnonymousSubscriptions.contains(communityView.community)) {
-        newAnonymousSubscriptions.remove(communityView.community);
-      } else if (removedSubs.contains(communityView.community.id)) {
-        removedSubs.remove(communityView.community.id);
+      if (currentSubscriptions.contains(community.id) && !removedSubs.contains(community.id)) {
+        removedSubs.add(community.id);
+      } else if (newAnonymousSubscriptions.contains(community)) {
+        newAnonymousSubscriptions.remove(community);
+      } else if (removedSubs.contains(community.id)) {
+        removedSubs.remove(community.id);
       } else {
-        newAnonymousSubscriptions.add(communityView.community);
+        newAnonymousSubscriptions.add(community);
       }
     });
     return;
@@ -921,7 +927,7 @@ class _SearchPageState extends State<SearchPage> with AutomaticKeepAliveClientMi
         searchType: _getSearchTypeToUse(),
         communityId: widget.communityToSearch?.community.id ?? _currentCommunityFilter,
         creatorId: _currentCreatorFilter,
-        favoriteCommunities: context.read<AccountBloc>().state.favorites,
+        favoriteCommunities: context.read<AccountBloc>().state.favorites.map((cv) => ThunderCommunity(cv.community, communityView: cv)).toList(),
         force: force || searchBloc.state.viewingAll,
       ));
     } else {

--- a/lib/search/utils/search_utils.dart
+++ b/lib/search/utils/search_utils.dart
@@ -1,11 +1,13 @@
 import 'package:lemmy_api_client/v3.dart';
+
 import 'package:thunder/core/enums/meta_search_type.dart';
+import 'package:thunder/core/models/models.dart';
 import 'package:thunder/search/bloc/search_bloc.dart';
 import 'package:thunder/utils/instance.dart';
 
 /// Checks whether there are any results for the current given [searchType] in the [searchState] or the given [searchResponse].
 bool searchIsEmpty(MetaSearchType searchType, {SearchState? searchState, SearchResponse? searchResponse}) {
-  final List<CommunityView>? communities = searchState?.communities ?? searchResponse?.communities;
+  final List<ThunderCommunity>? communities = searchState?.communities ?? searchResponse?.communities.map((cv) => ThunderCommunity(cv.community, communityView: cv)).toList();
   final List<PersonView>? users = searchState?.users ?? searchResponse?.users;
   final List<CommentView>? comments = searchState?.comments ?? searchResponse?.comments;
   final List<PostView>? posts = searchState?.posts?.map((pvm) => pvm.postView).toList() ?? searchResponse?.posts;

--- a/lib/shared/input_dialogs.dart
+++ b/lib/shared/input_dialogs.dart
@@ -120,8 +120,8 @@ void showCommunityInputDialog(BuildContext context, {required String title, requ
 
   try {
     final state = context.read<AccountBloc>().state;
-    emptySuggestions ??= state.subsciptions.map((cv) => ThunderCommunity(cv.community)).toList();
-    emptySuggestions = prioritizeFavorites(emptySuggestions.toList(), state.favorites.map((cv) => ThunderCommunity(cv.community)).toList());
+    emptySuggestions ??= state.subsciptions.map((cv) => ThunderCommunity(cv.community, communityView: cv)).toList();
+    emptySuggestions = prioritizeFavorites(emptySuggestions.toList(), state.favorites.map((cv) => ThunderCommunity(cv.community, communityView: cv)).toList());
   } catch (e) {
     // If we can't read the AccountBloc here, for whatever reason, it's ok. No need for subscriptions.
   }

--- a/lib/shared/input_dialogs.dart
+++ b/lib/shared/input_dialogs.dart
@@ -21,7 +21,6 @@ import 'package:thunder/shared/dialogs.dart';
 import 'package:thunder/shared/avatars/user_avatar.dart';
 import 'package:thunder/shared/full_name_widgets.dart';
 import 'package:thunder/shared/marquee_widget.dart';
-import 'package:thunder/utils/global_context.dart';
 import 'package:thunder/utils/instance.dart';
 import 'package:thunder/utils/numbers.dart';
 
@@ -46,10 +45,10 @@ void showUserInputDialog(BuildContext context, {required String title, required 
           onUserSelected(user);
           Navigator.of(context).pop();
         } catch (e) {
-          return AppLocalizations.of(context)!.unableToFindUser;
+          return l10n.unableToFindUser;
         }
       } else {
-        return AppLocalizations.of(context)!.unableToFindUser;
+        return l10n.unableToFindUser;
       }
     }
     return null;
@@ -116,59 +115,58 @@ Widget buildUserSuggestionWidget(BuildContext context, ThunderUser payload, {voi
 }
 
 /// Shows a dialog which allows typing/search for a community
-void showCommunityInputDialog(BuildContext context, {required String title, required void Function(CommunityView) onCommunitySelected, List<CommunityView>? emptySuggestions}) async {
+void showCommunityInputDialog(BuildContext context, {required String title, required void Function(ThunderCommunity) onCommunitySelected, List<ThunderCommunity>? emptySuggestions}) async {
+  final l10n = AppLocalizations.of(context)!;
+
   try {
-    final AccountState accountState = context.read<AccountBloc>().state;
-    emptySuggestions ??= accountState.subsciptions;
-    emptySuggestions = prioritizeFavorites(emptySuggestions.toList(), accountState.favorites);
+    final state = context.read<AccountBloc>().state;
+    emptySuggestions ??= state.subsciptions.map((cv) => ThunderCommunity(cv.community)).toList();
+    emptySuggestions = prioritizeFavorites(emptySuggestions.toList(), state.favorites.map((cv) => ThunderCommunity(cv.community)).toList());
   } catch (e) {
     // If we can't read the AccountBloc here, for whatever reason, it's ok. No need for subscriptions.
   }
 
-  Future<String?> onSubmitted({CommunityView? payload, String? value}) async {
+  Future<String?> onSubmitted({ThunderCommunity? payload, String? value}) async {
     if (payload != null) {
       onCommunitySelected(payload);
       Navigator.of(context).pop();
     } else if (value != null) {
       // Normalize the community name
-      final String? normalizedCommunity = await getLemmyCommunity(value);
+      final normalizedCommunity = await getLemmyCommunity(value);
+
       if (normalizedCommunity != null) {
         try {
-          Account? account = await fetchActiveProfileAccount();
-          final GetCommunityResponse getCommunityResponse = await LemmyClient.instance.lemmyApiV3.run(GetCommunity(
-            auth: account?.jwt,
-            name: normalizedCommunity,
-          ));
+          final account = await fetchActiveProfileAccount();
+          final response = await LemmyClient.instance.lemmyApiV3.run(GetCommunity(auth: account?.jwt, name: normalizedCommunity));
+          final community = ThunderCommunity(response.communityView.community, communityView: response.communityView);
 
-          onCommunitySelected(getCommunityResponse.communityView);
-
+          onCommunitySelected(community);
           Navigator.of(context).pop();
         } catch (e) {
-          return AppLocalizations.of(context)!.unableToFindCommunity;
+          return l10n.unableToFindCommunity;
         }
       } else {
-        return AppLocalizations.of(context)!.unableToFindCommunity;
+        return l10n.unableToFindCommunity;
       }
     }
     return null;
   }
 
-  showInputDialog<CommunityView>(
+  showInputDialog<ThunderCommunity>(
     context: context,
     title: title,
-    inputLabel: AppLocalizations.of(context)!.community,
+    inputLabel: l10n.community,
     onSubmitted: onSubmitted,
     getSuggestions: (query) => getCommunitySuggestions(context, query, emptySuggestions),
-    suggestionBuilder: (communityView) => buildCommunitySuggestionWidget(context, communityView),
+    suggestionBuilder: (payload) => buildCommunitySuggestionWidget(context, payload),
   );
 }
 
-Future<List<CommunityView>> getCommunitySuggestions(BuildContext context, String query, List<CommunityView>? emptySuggestions) async {
-  if (query.isNotEmpty != true) {
-    return emptySuggestions ?? [];
-  }
-  Account? account = await fetchActiveProfileAccount();
-  final SearchResponse searchResponse = await LemmyClient.instance.lemmyApiV3.run(Search(
+Future<List<ThunderCommunity>> getCommunitySuggestions(BuildContext context, String query, List<ThunderCommunity>? emptySuggestions) async {
+  if (query.isNotEmpty != true) return emptySuggestions ?? [];
+
+  final account = await fetchActiveProfileAccount();
+  final response = await LemmyClient.instance.lemmyApiV3.run(Search(
     q: query,
     auth: account?.jwt,
     type: SearchType.communities,
@@ -176,38 +174,38 @@ Future<List<CommunityView>> getCommunitySuggestions(BuildContext context, String
     sort: SortType.topAll,
   ));
 
-  List<CommunityView>? favorites;
+  List<ThunderCommunity>? favorites;
+
   if (context.mounted) {
     try {
-      favorites = context.read<AccountBloc>().state.favorites;
+      favorites = context.read<AccountBloc>().state.favorites.map((cv) => ThunderCommunity(cv.community, communityView: cv)).toList();
     } catch (e) {
       // Don't worry if we can't fetch favorites
     }
   }
 
-  return prioritizeFavorites(searchResponse.communities.toList(), favorites) ?? [];
+  final communities = response.communities.map((cv) => ThunderCommunity(cv.community, communityView: cv)).toList();
+  return prioritizeFavorites(communities, favorites) ?? [];
 }
 
-Widget buildCommunitySuggestionWidget(BuildContext context, CommunityView payload, {void Function(CommunityView)? onSelected}) {
-  final AppLocalizations l10n = AppLocalizations.of(GlobalContext.context)!;
+Widget buildCommunitySuggestionWidget(BuildContext context, ThunderCommunity payload, {void Function(ThunderCommunity)? onSelected}) {
+  final l10n = AppLocalizations.of(context)!;
+
+  assert(payload.subscribers != null);
 
   return Tooltip(
     message: generateCommunityFullName(
       context,
-      payload.community.name,
-      payload.community.title,
-      fetchInstanceNameFromUrl(payload.community.actorId),
+      payload.communityName,
+      payload.title,
+      fetchInstanceNameFromUrl(payload.url),
     ),
     preferBelow: false,
     child: InkWell(
       onTap: onSelected == null ? null : () => onSelected(payload),
       child: ListTile(
-        leading: CommunityAvatar(community: ThunderCommunity(payload.community)),
-        title: Text(
-          payload.community.title,
-          maxLines: 1,
-          overflow: TextOverflow.ellipsis,
-        ),
+        leading: CommunityAvatar(community: payload),
+        title: Text(payload.title, maxLines: 1, overflow: TextOverflow.ellipsis),
         subtitle: Semantics(
           excludeSemantics: true,
           child: Column(
@@ -219,9 +217,9 @@ Widget buildCommunitySuggestionWidget(BuildContext context, CommunityView payloa
                 pauseDuration: const Duration(seconds: 1),
                 child: CommunityFullNameWidget(
                   context,
-                  payload.community.name,
-                  payload.community.title,
-                  fetchInstanceNameFromUrl(payload.community.actorId),
+                  payload.communityName,
+                  payload.title,
+                  fetchInstanceNameFromUrl(payload.url),
                   // Override because we're showing display name above
                   useDisplayName: false,
                 ),
@@ -230,7 +228,7 @@ Widget buildCommunitySuggestionWidget(BuildContext context, CommunityView payloa
                 children: [
                   const Icon(Icons.people_rounded, size: 16),
                   const SizedBox(width: 5),
-                  Text(formatNumberToK(payload.counts.subscribers)),
+                  Text(formatNumberToK(payload.subscribers ?? -1)),
                   if (payload.subscribed != SubscribedType.notSubscribed) ...[
                     Text(' · ${switch (payload.subscribed) {
                       SubscribedType.pending => l10n.pending,
@@ -238,7 +236,7 @@ Widget buildCommunitySuggestionWidget(BuildContext context, CommunityView payloa
                       _ => '',
                     }}'),
                   ],
-                  if (_getFavoriteStatus(context, payload.community)) ...const [
+                  if (_getFavoriteStatus(context, payload)) ...const [
                     Text(' · '),
                     Icon(Icons.star_rounded, size: 15),
                   ],
@@ -253,9 +251,9 @@ Widget buildCommunitySuggestionWidget(BuildContext context, CommunityView payloa
 }
 
 /// Checks whether the current community is a favorite of the current user
-bool _getFavoriteStatus(BuildContext context, Community community) {
-  final AccountState accountState = context.read<AccountBloc>().state;
-  return accountState.favorites.any((communityView) => communityView.community.id == community.id);
+bool _getFavoriteStatus(BuildContext context, ThunderCommunity community) {
+  final state = context.read<AccountBloc>().state;
+  return state.favorites.any((communityView) => communityView.community.id == community.id);
 }
 
 /// Shows a dialog which allows typing/search for an instance

--- a/lib/user/pages/user_settings_block_page.dart
+++ b/lib/user/pages/user_settings_block_page.dart
@@ -197,8 +197,8 @@ class _UserSettingsBlockPageState extends State<UserSettingsBlockPage> with Sing
               showCommunityInputDialog(
                 context,
                 title: l10n.blockCommunity,
-                onCommunitySelected: (communityView) {
-                  context.read<UserSettingsBloc>().add(UnblockCommunityEvent(communityId: communityView.community.id, unblock: false));
+                onCommunitySelected: (ThunderCommunity community) {
+                  context.read<UserSettingsBloc>().add(UnblockCommunityEvent(communityId: community.id, unblock: false));
                 },
               );
               break;


### PR DESCRIPTION
## Pull Request Description

This PR migrates some of our existing logic to use `ThunderCommunity`. This includes the anonymous subscriptions, community autocomplete dialogs, the search pages and more. As always, there will likely be additional follow up PRs to migrate more of the existing logic to use `ThunderCommunity`.

I did some general tests with this change and haven't noticed any issues yet, but will address any issues that pop up!

<!--- Please describe what was changed -->

## Issue Being Fixed

<!-- Please describe the problem that is being fixed and, if applicable, reference a GitHub issue -->

Issue Number: N/A

## Screenshots / Recordings

<!-- This section is optional but highly recommended to show off your changes! -->

## Checklist

- [ ] If a new package was added, did you ensure it uses an appropriate license and is actively maintained?
- [ ] Did you use localized strings (and added appropriate descriptions) where applicable?
- [ ] Did you add `semanticLabel`s where applicable for accessibility?
