### PR TITLE
Fix visual glitch on post page app bar

### DIFF
--- a/lib/post/widgets/post_page_app_bar.dart
+++ b/lib/post/widgets/post_page_app_bar.dart
@@ -78,30 +78,52 @@ class PostPageAppBar extends StatelessWidget {
 }
 
 /// The title of the app bar. This shows the sort type of the comments
-class PostAppBarTitle extends StatelessWidget {
+class PostAppBarTitle extends StatefulWidget {
   const PostAppBarTitle({super.key});
 
+  @override
+  State<PostAppBarTitle> createState() => _PostAppBarTitleState();
+}
+
+class _PostAppBarTitleState extends State<PostAppBarTitle> with TickerProviderStateMixin {
   @override
   Widget build(BuildContext context) {
     final l10n = AppLocalizations.of(context)!;
     final theme = Theme.of(context);
     final (sortType, sortIcon) = getSort(context);
+    final hasSubtitle = sortType.isNotEmpty && sortIcon != null;
 
-    return ListTile(
-      title: Text(
-        l10n.comments,
-        style: theme.textTheme.titleLarge,
-        maxLines: 1,
-        overflow: TextOverflow.ellipsis,
-      ),
-      subtitle: Row(
+    return SizedBox(
+      height: 56,
+      child: Stack(
+        alignment: Alignment.centerLeft,
         children: [
-          Icon(sortIcon, size: 13),
-          const SizedBox(width: 4),
-          Text(sortType),
+          AnimatedPositioned(
+            duration: const Duration(milliseconds: 300),
+            curve: Curves.easeInOut,
+            top: hasSubtitle ? 2 : 16,
+            left: 0,
+            child: Text(
+              l10n.comments,
+              style: theme.textTheme.titleLarge,
+              maxLines: 1,
+              overflow: TextOverflow.ellipsis,
+            ),
+          ),
+          if (hasSubtitle)
+            Positioned(
+              left: 0,
+              bottom: 6,
+              child: Row(
+                children: [
+                  Icon(sortIcon, size: 13),
+                  const SizedBox(width: 4),
+                  Text(sortType, style: theme.textTheme.bodyMedium),
+                ],
+              ),
+            ),
         ],
       ),
-      contentPadding: const EdgeInsets.symmetric(horizontal: 0),
     );
   }
 }


### PR DESCRIPTION
## Pull Request Description

<!--- Please describe what was changed -->

On the post page, I noticed that there's a little jarring animation that occurs when the post fully loads and the sort type is populated. The "Comments" heading moves slightly. I fixed this moving to a different widget structure so that "Comments" is centered until the sort type loads in, and then it nicely animates upwards. `ListTile` wasn't playing well with `AnimatedSize/Positioned`, so I restructured things a little. 

> Please review without whitespace.

## Issue Being Fixed

<!-- Please describe the problem that is being fixed and, if applicable, reference a GitHub issue -->

Issue Number: N/A

## Screenshots / Recordings

<!-- This section is optional but highly recommended to show off your changes! -->

### Before

https://github.com/user-attachments/assets/490ccada-be1e-485b-afc4-556ccc9bb45b

### After

https://github.com/user-attachments/assets/6f48328f-3dd9-41ea-bfcc-3adf4755b36f




## Checklist

- [ ] If a new package was added, did you ensure it uses an appropriate license and is actively maintained?
- [ ] Did you use localized strings (and added appropriate descriptions) where applicable?
- [ ] Did you add `semanticLabel`s where applicable for accessibility?
