### PR TITLE
Refactor compact post card to use ThunderPost

### DIFF
--- a/lib/community/widgets/post_card.dart
+++ b/lib/community/widgets/post_card.dart
@@ -5,6 +5,7 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 
 import 'package:thunder/community/enums/community_action.dart';
 import 'package:thunder/community/utils/post_actions.dart';
+import 'package:thunder/core/models/models.dart';
 import 'package:thunder/feed/view/feed_page.dart';
 import 'package:thunder/post/widgets/post_action_bottom_sheet.dart';
 import 'package:thunder/community/widgets/post_card_view_comfortable.dart';
@@ -168,7 +169,9 @@ class _PostCardState extends State<PostCard> {
     // Determine which post card view to use based on the settings
     Widget child = state.useCompactView || widget.postViewMedia.postView.post.featuredLocal || (feedType == FeedType.community && widget.postViewMedia.postView.post.featuredCommunity)
         ? PostCardViewCompact(
-            postViewMedia: widget.postViewMedia,
+            post: ThunderPost(widget.postViewMedia.postView.post, postView: widget.postViewMedia.postView, media: widget.postViewMedia.media),
+            creator: ThunderUser(widget.postViewMedia.postView.creator),
+            community: ThunderCommunity(widget.postViewMedia.postView.community),
             isUserLoggedIn: isUserLoggedIn,
             indicateRead: widget.indicateRead,
             isLastTapped: widget.isLastTapped,

--- a/lib/community/widgets/post_card_metadata.dart
+++ b/lib/community/widgets/post_card_metadata.dart
@@ -548,10 +548,13 @@ class CrossPostMetaData extends StatelessWidget {
 }
 
 class PostCommunityAndAuthor extends StatelessWidget {
-  const PostCommunityAndAuthor({super.key, required this.postView, this.dim});
+  const PostCommunityAndAuthor({super.key, required this.user, required this.community, this.dim});
 
-  /// The post view to display the community and author information for
-  final PostView postView;
+  /// The user to display in the metadata
+  final ThunderUser user;
+
+  /// The community to display in the metadata
+  final ThunderCommunity community;
 
   /// Whether or not to dim the color of the text and icons. This is usually used to indicate that the post has been read.
   final bool? dim;
@@ -573,41 +576,41 @@ class PostCommunityAndAuthor extends StatelessWidget {
       children: [
         if (showCommunityIcons && feedType != FeedType.community)
           GestureDetector(
-            child: CommunityAvatar(community: ThunderCommunity(postView.community), radius: showUsername && showCommunityName ? 14 : 7),
-            onTap: () => navigateToFeedPage(context, communityId: postView.community.id, feedType: FeedType.community),
+            child: CommunityAvatar(community: community, radius: showUsername && showCommunityName ? 14 : 7),
+            onTap: () => navigateToFeedPage(context, communityId: community.id, feedType: FeedType.community),
           ),
         if (showCommunityName && showUsername)
           Column(
             crossAxisAlignment: CrossAxisAlignment.start,
             children: [
               CommunityPostCardMetadata(
-                communityName: postView.community.name,
-                displayName: postView.community.title,
-                actorId: postView.community.actorId,
-                subscribed: postView.subscribed != SubscribedType.notSubscribed,
+                communityName: community.communityName,
+                displayName: community.title,
+                actorId: community.url,
+                subscribed: community.subscribed != SubscribedType.notSubscribed,
                 dim: dim,
               ),
               UserPostCardMetadata(
-                username: postView.creator.name,
-                displayName: postView.creator.displayName,
-                actorId: postView.creator.actorId,
+                username: user.username,
+                displayName: user.displayName,
+                actorId: user.url,
                 dim: dim,
               ),
             ],
           )
         else if (showCommunityName)
           CommunityPostCardMetadata(
-            communityName: postView.community.name,
-            displayName: postView.community.title,
-            actorId: postView.community.actorId,
-            subscribed: postView.subscribed != SubscribedType.notSubscribed,
+            communityName: community.communityName,
+            displayName: community.title,
+            actorId: community.url,
+            subscribed: community.subscribed != SubscribedType.notSubscribed,
             dim: dim,
           )
         else if (showUsername)
           UserPostCardMetadata(
-            username: postView.creator.name,
-            displayName: postView.creator.displayName,
-            actorId: postView.creator.actorId,
+            username: user.username,
+            displayName: user.displayName,
+            actorId: user.url,
             dim: dim,
           ),
       ],

--- a/lib/community/widgets/post_card_view_comfortable.dart
+++ b/lib/community/widgets/post_card_view_comfortable.dart
@@ -6,6 +6,7 @@ import 'package:html/parser.dart';
 import 'package:markdown/markdown.dart' hide Text;
 
 import 'package:thunder/community/enums/community_action.dart';
+import 'package:thunder/core/models/models.dart';
 import 'package:thunder/post/enums/post_action.dart';
 import 'package:thunder/post/widgets/post_action_bottom_sheet.dart';
 import 'package:thunder/community/widgets/post_card_actions.dart';
@@ -176,7 +177,11 @@ class PostCardViewComfortable extends StatelessWidget {
                     spacing: 8.0,
                     crossAxisAlignment: CrossAxisAlignment.start,
                     children: [
-                      PostCommunityAndAuthor(postView: postViewMedia.postView, dim: dim),
+                      PostCommunityAndAuthor(
+                        user: ThunderUser(postViewMedia.postView.creator),
+                        community: ThunderCommunity(postViewMedia.postView.community),
+                        dim: dim,
+                      ),
                       PostCardMetadata(
                         postCardViewType: ViewMode.comfortable,
                         score: counts.score,

--- a/lib/community/widgets/post_card_view_compact.dart
+++ b/lib/community/widgets/post_card_view_compact.dart
@@ -5,6 +5,7 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:thunder/community/widgets/post_card_metadata.dart';
 import 'package:thunder/core/enums/media_type.dart';
 import 'package:thunder/core/enums/view_mode.dart';
+import 'package:thunder/core/models/models.dart';
 import 'package:thunder/core/models/post_view_media.dart';
 import 'package:thunder/core/theme/bloc/theme_bloc.dart';
 import 'package:thunder/post/widgets/post_card_title.dart';
@@ -14,7 +15,13 @@ import 'package:thunder/thunder/bloc/thunder_bloc.dart';
 /// Displays a compact view of a post card. This view is used in the feed related pages.
 class PostCardViewCompact extends StatelessWidget {
   /// The associated post information to display in the card.
-  final PostViewMedia postViewMedia;
+  final ThunderPost post;
+
+  /// The creator of the post.
+  final ThunderUser creator;
+
+  /// The community the post belongs to.
+  final ThunderCommunity community;
 
   /// Determines whether the user is logged in or not.
   final bool isUserLoggedIn;
@@ -33,7 +40,9 @@ class PostCardViewCompact extends StatelessWidget {
 
   const PostCardViewCompact({
     super.key,
-    required this.postViewMedia,
+    required this.post,
+    required this.creator,
+    required this.community,
     required this.isUserLoggedIn,
     this.navigateToPost,
     this.indicateRead,
@@ -65,13 +74,13 @@ class PostCardViewCompact extends StatelessWidget {
     bool indicateRead = this.indicateRead ?? context.select((ThunderBloc bloc) => bloc.state.dimReadPosts);
 
     // Post statuses
-    final read = postViewMedia.postView.read;
-    final hidden = postViewMedia.postView.hidden;
-    final removed = postViewMedia.postView.post.removed;
-    final deleted = postViewMedia.postView.post.deleted;
-    final saved = postViewMedia.postView.saved;
-    final locked = postViewMedia.postView.post.locked;
-    final pinned = postViewMedia.postView.post.featuredCommunity || postViewMedia.postView.post.featuredLocal;
+    final read = post.read;
+    final hidden = post.hidden;
+    final removed = post.removed;
+    final deleted = post.deleted;
+    final saved = post.saved;
+    final locked = post.locked;
+    final pinned = post.featuredCommunity || post.featuredLocal;
 
     final dim = indicateRead && read;
 
@@ -81,8 +90,8 @@ class PostCardViewCompact extends StatelessWidget {
       child: Row(
         crossAxisAlignment: CrossAxisAlignment.center,
         children: [
-          !showThumbnailPreviewOnRight && showMedia && (postViewMedia.media.first.mediaType == MediaType.text ? showTextPostIndicator : true)
-              ? CompactThumbnailPreview(media: postViewMedia.media.first, dim: dim, postId: postViewMedia.postView.post.id, navigateToPost: navigateToPost)
+          !showThumbnailPreviewOnRight && showMedia && (post.media.first.mediaType == MediaType.text ? showTextPostIndicator : true)
+              ? CompactThumbnailPreview(media: post.media.first, dim: dim, postId: post.id, navigateToPost: navigateToPost)
               : const SizedBox(width: 8.0),
           Expanded(
             child: Column(
@@ -90,8 +99,8 @@ class PostCardViewCompact extends StatelessWidget {
               crossAxisAlignment: CrossAxisAlignment.start,
               children: [
                 PostCardTitle(
-                  title: postViewMedia.postView.post.name,
-                  hidden: hidden ?? false,
+                  title: post.title,
+                  hidden: hidden,
                   locked: locked,
                   saved: saved,
                   pinned: pinned,
@@ -99,26 +108,26 @@ class PostCardViewCompact extends StatelessWidget {
                   removed: removed,
                   dim: dim,
                 ),
-                PostCommunityAndAuthor(postView: postViewMedia.postView, dim: dim),
+                PostCommunityAndAuthor(user: creator, community: community, dim: dim),
                 PostCardMetadata(
                   postCardViewType: ViewMode.compact,
-                  score: postViewMedia.postView.counts.score,
-                  upvoteCount: postViewMedia.postView.counts.upvotes,
-                  downvoteCount: postViewMedia.postView.counts.downvotes,
-                  voteType: postViewMedia.postView.myVote ?? 0,
-                  commentCount: postViewMedia.postView.counts.comments,
-                  unreadCommentCount: postViewMedia.postView.unreadComments,
-                  dateTime: postViewMedia.postView.post.updated != null ? postViewMedia.postView.post.updated?.toIso8601String() : postViewMedia.postView.post.published.toIso8601String(),
-                  edited: postViewMedia.postView.post.updated != null ? true : false,
-                  url: postViewMedia.media.firstOrNull != null ? postViewMedia.media.first.originalUrl : null,
-                  languageId: postViewMedia.postView.post.languageId,
+                  score: post.score,
+                  upvoteCount: post.upvotes,
+                  downvoteCount: post.downvotes,
+                  voteType: post.voteType ?? 0,
+                  commentCount: post.comments,
+                  unreadCommentCount: post.unreadComments,
+                  dateTime: post.updated != null ? post.updated?.toIso8601String() : post.created.toIso8601String(),
+                  edited: post.updated != null ? true : false,
+                  url: post.media.firstOrNull != null ? post.media.first.originalUrl : null,
+                  languageId: post.languageId,
                   dim: dim,
                 ),
               ],
             ),
           ),
-          showThumbnailPreviewOnRight && showMedia && (postViewMedia.media.first.mediaType == MediaType.text ? showTextPostIndicator : true)
-              ? CompactThumbnailPreview(media: postViewMedia.media.first, dim: dim, postId: postViewMedia.postView.post.id, navigateToPost: navigateToPost)
+          showThumbnailPreviewOnRight && showMedia && (post.media.first.mediaType == MediaType.text ? showTextPostIndicator : true)
+              ? CompactThumbnailPreview(media: post.media.first, dim: dim, postId: post.id, navigateToPost: navigateToPost)
               : const SizedBox(width: 8.0),
         ],
       ),

--- a/lib/core/models/models.dart
+++ b/lib/core/models/models.dart
@@ -1,3 +1,4 @@
 export 'thunder_community.dart';
 export 'thunder_user.dart';
 export 'thunder_instance.dart';
+export 'thunder_post.dart';

--- a/lib/core/models/thunder_post.dart
+++ b/lib/core/models/thunder_post.dart
@@ -1,0 +1,77 @@
+import 'package:lemmy_api_client/v3.dart';
+import 'package:thunder/core/models/media.dart';
+
+class ThunderPost {
+  /// The Lemmy API model for the post.
+  final Post _post;
+
+  /// The media associated with the post.
+  final List<Media> _media;
+
+  /// The Lemmy API model for the post view.
+  final PostView? _postView;
+
+  ThunderPost(this._post, {PostView? postView, List<Media> media = const []})
+      : _postView = postView,
+        _media = media;
+
+  /// The ID of the post.
+  int get id => _post.id;
+
+  /// The title of the post.
+  String get title => _post.name;
+
+  /// Whether the post was read or not.
+  bool get read => _postView?.read ?? false;
+
+  /// Whether the post was hidden by the current user.
+  bool get hidden => _postView?.hidden ?? false;
+
+  /// Whether the post was removed by a moderator or admin.
+  bool get removed => _post.removed;
+
+  /// Whether the post was deleted by the user.
+  bool get deleted => _post.deleted;
+
+  /// Whether the post was saved by the user.
+  bool get saved => _postView?.saved ?? false;
+
+  /// Whether the post was locked by a moderator or admin.
+  bool get locked => _post.locked;
+
+  /// Whether the post was featured in the community by a moderator or admin.
+  bool get featuredCommunity => _post.featuredCommunity;
+
+  /// Whether the post is featured on the instance.
+  bool get featuredLocal => _post.featuredLocal;
+
+  /// The media associated with the post.
+  List<Media> get media => _media;
+
+  /// The date the post was created.
+  DateTime get created => _post.published;
+
+  /// The date the post was last updated.
+  DateTime? get updated => _post.updated;
+
+  /// The number of comments on the post.
+  int? get comments => _postView?.counts.comments;
+
+  /// The number of upvotes on the post.
+  int? get upvotes => _postView?.counts.upvotes;
+
+  /// The number of downvotes on the post.
+  int? get downvotes => _postView?.counts.downvotes;
+
+  /// The score of the post.
+  int? get score => _postView?.counts.score;
+
+  /// The vote status by the current user.
+  int? get voteType => _postView?.myVote;
+
+  /// The number of unread comments on the post.
+  int? get unreadComments => _postView?.unreadComments;
+
+  /// The language of the post.
+  int? get languageId => _post.languageId;
+}

--- a/lib/moderator/view/report_page.dart
+++ b/lib/moderator/view/report_page.dart
@@ -12,7 +12,6 @@ import 'package:thunder/account/bloc/account_bloc.dart';
 import 'package:thunder/community/widgets/post_card_view_compact.dart';
 import 'package:thunder/core/enums/media_type.dart';
 import 'package:thunder/core/models/media.dart';
-import 'package:thunder/core/models/post_view_media.dart';
 import 'package:thunder/core/models/models.dart';
 import 'package:thunder/core/singletons/lemmy_client.dart';
 import 'package:thunder/feed/feed.dart';
@@ -228,7 +227,9 @@ class _ReportFeedViewState extends State<ReportFeedView> {
                                             padding: const EdgeInsets.only(top: 8.0),
                                             child: PostCardViewCompact(
                                               showMedia: false,
-                                              postViewMedia: PostViewMedia(postView: postView, media: [Media(mediaType: MediaType.text)]),
+                                              post: ThunderPost(postView.post, postView: postView, media: [Media(mediaType: MediaType.text)]),
+                                              creator: ThunderUser(postView.creator),
+                                              community: ThunderCommunity(postView.community),
                                               isUserLoggedIn: false,
                                               isLastTapped: false,
                                             ),

--- a/lib/settings/pages/post_appearance_settings_page.dart
+++ b/lib/settings/pages/post_appearance_settings_page.dart
@@ -17,6 +17,7 @@ import 'package:thunder/core/enums/feed_card_divider_thickness.dart';
 import 'package:thunder/core/enums/local_settings.dart';
 import 'package:thunder/core/enums/post_body_view_type.dart';
 import 'package:thunder/core/enums/view_mode.dart';
+import 'package:thunder/core/models/models.dart';
 import 'package:thunder/core/models/post_view_media.dart';
 import 'package:thunder/core/singletons/lemmy_client.dart';
 import 'package:thunder/core/singletons/preferences.dart';
@@ -505,12 +506,19 @@ class _PostAppearanceSettingsPageState extends State<PostAppearanceSettingsPage>
                             shrinkWrap: true,
                             physics: const NeverScrollableScrollPhysics(),
                             itemBuilder: (context, index) {
+                              final pvm = snapshot.data![index]!;
+                              final post = ThunderPost(pvm.postView.post, postView: pvm.postView, media: pvm.media);
+                              final creator = ThunderUser(pvm.postView.creator);
+                              final community = ThunderCommunity(pvm.postView.community);
+
                               return Column(
                                 children: [
                                   (useCompactView)
                                       ? IgnorePointer(
                                           child: PostCardViewCompact(
-                                            postViewMedia: snapshot.data![index]!,
+                                            post: post,
+                                            creator: creator,
+                                            community: community,
                                             isUserLoggedIn: true,
                                             indicateRead: dimReadPosts,
                                             isLastTapped: false,


### PR DESCRIPTION
## Pull Request Description

This PR refactors the compact post card to use `ThunderPost`. Additionally, I've adjusted `PostCommunityAndAuthor` to take in `ThunderUser` and `ThunderCommunity` rather than a `PostView`.

<!--- Please describe what was changed -->

## Issue Being Fixed

<!-- Please describe the problem that is being fixed and, if applicable, reference a GitHub issue -->

Issue Number: N/A

## Screenshots / Recordings

<!-- This section is optional but highly recommended to show off your changes! -->

## Checklist

- [ ] If a new package was added, did you ensure it uses an appropriate license and is actively maintained?
- [ ] Did you use localized strings (and added appropriate descriptions) where applicable?
- [ ] Did you add `semanticLabel`s where applicable for accessibility?
