### PR TITLE
Improve comment depth indicators

### DIFF
--- a/lib/comment/widgets/comment_card.dart
+++ b/lib/comment/widgets/comment_card.dart
@@ -6,17 +6,16 @@ import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:lemmy_api_client/v3.dart';
 
 import 'package:thunder/comment/enums/comment_action.dart';
+import 'package:thunder/comment/widgets/comment_depth_indicator.dart';
 import 'package:thunder/utils/navigation.dart';
 import 'package:thunder/comment/widgets/comment_action_bottom_sheet.dart';
 import 'package:thunder/core/auth/bloc/auth_bloc.dart';
-import 'package:thunder/core/enums/nested_comment_indicator.dart';
 import 'package:thunder/core/enums/swipe_action.dart';
 import 'package:thunder/post/bloc/post_bloc.dart';
 import 'package:thunder/post/utils/comment_actions.dart';
 import 'package:thunder/shared/comment_content.dart';
 import 'package:thunder/shared/text/scalable_text.dart';
 import 'package:thunder/thunder/bloc/thunder_bloc.dart';
-import 'package:thunder/utils/colors.dart';
 
 class CommentCard extends StatefulWidget {
   /// The [CommentView] containing the comment information
@@ -131,272 +130,240 @@ class _CommentCardState extends State<CommentCard> with SingleTickerProviderStat
     // Hide the comment if it is hidden - this happens when a parent comment is collapsed
     if (widget.hidden) return const SizedBox.shrink();
 
-    NestedCommentIndicatorStyle nestedCommentIndicatorStyle = state.nestedCommentIndicatorStyle;
-    NestedCommentIndicatorColor nestedCommentIndicatorColor = state.nestedCommentIndicatorColor;
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      mainAxisAlignment: MainAxisAlignment.start,
+      children: [
+        Listener(
+          behavior: HitTestBehavior.opaque,
+          onPointerUp: (event) {
+            if (isOverridingSwipeGestureAction) {
+              setState(() => isOverridingSwipeGestureAction = false);
+            }
 
-    return Container(
-      margin: EdgeInsets.only(left: widget.level * 4.0),
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        mainAxisAlignment: MainAxisAlignment.start,
-        children: [
-          const Divider(height: 1),
-          Listener(
-            behavior: HitTestBehavior.opaque,
-            onPointerUp: (event) {
-              if (isOverridingSwipeGestureAction) {
+            if (swipeAction != null && swipeAction != SwipeAction.none) {
+              triggerCommentAction(
+                context: context,
+                swipeAction: swipeAction,
+                onSaveAction: (int commentId, bool saved) => widget.onSaveAction?.call(commentId, saved),
+                onVoteAction: (int commentId, int vote) => widget.onVoteAction?.call(commentId, vote),
+                onReplyEditAction: (CommentView commentView, bool isEdit) => widget.onReplyEditAction?.call(commentView, isEdit),
+                voteType: widget.commentView.myVote ?? 0,
+                saved: widget.commentView.saved,
+                commentView: widget.commentView,
+                selectedCommentId: widget.selectCommentId,
+                selectedCommentPath: widget.selectedCommentPath,
+              );
+            }
+          },
+          onPointerMove: (PointerMoveEvent event) {
+            // Get the horizontal drag distance
+            double horizontalDragDistance = event.delta.dx;
+
+            // We are checking to see if there is a left to right swipe here. If there is a left to right swipe, and LTR swipe actions are disabled, then we disable the DismissDirection temporarily
+            // to allow for the full screen swipe to go back. Otherwise, we retain the default behaviour
+            if (horizontalDragDistance > 0) {
+              if (determineCommentSwipeDirection(isUserLoggedIn, state) == DismissDirection.endToStart && isOverridingSwipeGestureAction == false && dismissThreshold == 0.0) {
+                setState(() => isOverridingSwipeGestureAction = true);
+              }
+            } else {
+              if (determineCommentSwipeDirection(isUserLoggedIn, state) == DismissDirection.endToStart && isOverridingSwipeGestureAction == true) {
                 setState(() => isOverridingSwipeGestureAction = false);
               }
+            }
+          },
+          child: Dismissible(
+            key: ObjectKey(widget.commentView.comment.id),
+            direction: isOverridingSwipeGestureAction == true ? DismissDirection.none : determineCommentSwipeDirection(isUserLoggedIn, state),
+            resizeDuration: Duration.zero,
+            dismissThresholds: const {DismissDirection.endToStart: 1, DismissDirection.startToEnd: 1},
+            confirmDismiss: (DismissDirection direction) async => false,
+            onUpdate: (DismissUpdateDetails details) {
+              SwipeAction? updatedSwipeAction;
 
-              if (swipeAction != null && swipeAction != SwipeAction.none) {
-                triggerCommentAction(
-                  context: context,
-                  swipeAction: swipeAction,
-                  onSaveAction: (int commentId, bool saved) => widget.onSaveAction?.call(commentId, saved),
-                  onVoteAction: (int commentId, int vote) => widget.onVoteAction?.call(commentId, vote),
-                  onReplyEditAction: (CommentView commentView, bool isEdit) => widget.onReplyEditAction?.call(commentView, isEdit),
-                  voteType: widget.commentView.myVote ?? 0,
-                  saved: widget.commentView.saved,
-                  commentView: widget.commentView,
-                  selectedCommentId: widget.selectCommentId,
-                  selectedCommentPath: widget.selectedCommentPath,
-                );
-              }
-            },
-            onPointerMove: (PointerMoveEvent event) {
-              // Get the horizontal drag distance
-              double horizontalDragDistance = event.delta.dx;
+              if (details.progress > firstActionThreshold && details.progress < secondActionThreshold && details.direction == DismissDirection.startToEnd) {
+                updatedSwipeAction = state.leftPrimaryCommentGesture;
 
-              // We are checking to see if there is a left to right swipe here. If there is a left to right swipe, and LTR swipe actions are disabled, then we disable the DismissDirection temporarily
-              // to allow for the full screen swipe to go back. Otherwise, we retain the default behaviour
-              if (horizontalDragDistance > 0) {
-                if (determineCommentSwipeDirection(isUserLoggedIn, state) == DismissDirection.endToStart && isOverridingSwipeGestureAction == false && dismissThreshold == 0.0) {
-                  setState(() => isOverridingSwipeGestureAction = true);
+                // Change the swipe action to edit for comments
+                if (updatedSwipeAction == SwipeAction.reply && isOwnComment) {
+                  updatedSwipeAction = SwipeAction.edit;
                 }
-              } else {
-                if (determineCommentSwipeDirection(isUserLoggedIn, state) == DismissDirection.endToStart && isOverridingSwipeGestureAction == true) {
-                  setState(() => isOverridingSwipeGestureAction = false);
-                }
-              }
-            },
-            child: Dismissible(
-              key: ObjectKey(widget.commentView.comment.id),
-              direction: isOverridingSwipeGestureAction == true ? DismissDirection.none : determineCommentSwipeDirection(isUserLoggedIn, state),
-              resizeDuration: Duration.zero,
-              dismissThresholds: const {DismissDirection.endToStart: 1, DismissDirection.startToEnd: 1},
-              confirmDismiss: (DismissDirection direction) async => false,
-              onUpdate: (DismissUpdateDetails details) {
-                SwipeAction? updatedSwipeAction;
 
-                if (details.progress > firstActionThreshold && details.progress < secondActionThreshold && details.direction == DismissDirection.startToEnd) {
-                  updatedSwipeAction = state.leftPrimaryCommentGesture;
-
-                  // Change the swipe action to edit for comments
-                  if (updatedSwipeAction == SwipeAction.reply && isOwnComment) {
-                    updatedSwipeAction = SwipeAction.edit;
-                  }
-
-                  if (updatedSwipeAction != swipeAction) HapticFeedback.mediumImpact();
-                } else if (details.progress > secondActionThreshold && details.direction == DismissDirection.startToEnd) {
-                  if (state.leftSecondaryCommentGesture != SwipeAction.none) {
-                    updatedSwipeAction = state.leftSecondaryCommentGesture;
-                  } else {
-                    updatedSwipeAction = state.leftPrimaryCommentGesture;
-                  }
-
-                  // Change the swipe action to edit for comments
-                  if (updatedSwipeAction == SwipeAction.reply && isOwnComment) {
-                    updatedSwipeAction = SwipeAction.edit;
-                  }
-
-                  if (updatedSwipeAction != swipeAction) HapticFeedback.mediumImpact();
-                } else if (details.progress > firstActionThreshold && details.progress < secondActionThreshold && details.direction == DismissDirection.endToStart) {
-                  updatedSwipeAction = state.rightPrimaryCommentGesture;
-
-                  // Change the swipe action to edit for comments
-                  if (updatedSwipeAction == SwipeAction.reply && isOwnComment) {
-                    updatedSwipeAction = SwipeAction.edit;
-                  }
-
-                  if (updatedSwipeAction != swipeAction) HapticFeedback.mediumImpact();
-                } else if (details.progress > secondActionThreshold && details.direction == DismissDirection.endToStart) {
-                  if (state.rightSecondaryCommentGesture != SwipeAction.none) {
-                    updatedSwipeAction = state.rightSecondaryCommentGesture;
-                  } else {
-                    updatedSwipeAction = state.rightPrimaryCommentGesture;
-                  }
-
-                  // Change the swipe action to edit for comments
-                  if (updatedSwipeAction == SwipeAction.reply && isOwnComment) {
-                    updatedSwipeAction = SwipeAction.edit;
-                  }
-
-                  if (updatedSwipeAction != swipeAction) HapticFeedback.mediumImpact();
+                if (updatedSwipeAction != swipeAction) HapticFeedback.mediumImpact();
+              } else if (details.progress > secondActionThreshold && details.direction == DismissDirection.startToEnd) {
+                if (state.leftSecondaryCommentGesture != SwipeAction.none) {
+                  updatedSwipeAction = state.leftSecondaryCommentGesture;
                 } else {
-                  updatedSwipeAction = null;
+                  updatedSwipeAction = state.leftPrimaryCommentGesture;
                 }
 
-                setState(() {
-                  dismissThreshold = details.progress;
-                  dismissDirection = details.direction;
-                  swipeAction = updatedSwipeAction;
-                });
-              },
-              background: dismissDirection == DismissDirection.startToEnd
-                  ? AnimatedContainer(
-                      alignment: Alignment.centerLeft,
-                      color: swipeAction == null
-                          ? state.leftPrimaryCommentGesture.getColor(context).withValues(alpha: dismissThreshold / firstActionThreshold)
-                          : (swipeAction ?? SwipeAction.none).getColor(context),
-                      duration: const Duration(milliseconds: 200),
-                      child: SizedBox(
-                        width: MediaQuery.of(context).size.width * dismissThreshold,
-                        child: swipeAction == null ? Container() : Icon((swipeAction ?? SwipeAction.none).getIcon()),
-                      ),
-                    )
-                  : AnimatedContainer(
-                      alignment: Alignment.centerRight,
-                      color: swipeAction == null
-                          ? (state.rightPrimaryCommentGesture).getColor(context).withValues(alpha: dismissThreshold / firstActionThreshold)
-                          : (swipeAction ?? SwipeAction.none).getColor(context),
-                      duration: const Duration(milliseconds: 200),
-                      child: SizedBox(
-                        width: MediaQuery.of(context).size.width * dismissThreshold,
-                        child: swipeAction == null ? Container() : Icon((swipeAction ?? SwipeAction.none).getIcon()),
-                      ),
+                // Change the swipe action to edit for comments
+                if (updatedSwipeAction == SwipeAction.reply && isOwnComment) {
+                  updatedSwipeAction = SwipeAction.edit;
+                }
+
+                if (updatedSwipeAction != swipeAction) HapticFeedback.mediumImpact();
+              } else if (details.progress > firstActionThreshold && details.progress < secondActionThreshold && details.direction == DismissDirection.endToStart) {
+                updatedSwipeAction = state.rightPrimaryCommentGesture;
+
+                // Change the swipe action to edit for comments
+                if (updatedSwipeAction == SwipeAction.reply && isOwnComment) {
+                  updatedSwipeAction = SwipeAction.edit;
+                }
+
+                if (updatedSwipeAction != swipeAction) HapticFeedback.mediumImpact();
+              } else if (details.progress > secondActionThreshold && details.direction == DismissDirection.endToStart) {
+                if (state.rightSecondaryCommentGesture != SwipeAction.none) {
+                  updatedSwipeAction = state.rightSecondaryCommentGesture;
+                } else {
+                  updatedSwipeAction = state.rightPrimaryCommentGesture;
+                }
+
+                // Change the swipe action to edit for comments
+                if (updatedSwipeAction == SwipeAction.reply && isOwnComment) {
+                  updatedSwipeAction = SwipeAction.edit;
+                }
+
+                if (updatedSwipeAction != swipeAction) HapticFeedback.mediumImpact();
+              } else {
+                updatedSwipeAction = null;
+              }
+
+              setState(() {
+                dismissThreshold = details.progress;
+                dismissDirection = details.direction;
+                swipeAction = updatedSwipeAction;
+              });
+            },
+            background: dismissDirection == DismissDirection.startToEnd
+                ? AnimatedContainer(
+                    alignment: Alignment.centerLeft,
+                    color: swipeAction == null
+                        ? state.leftPrimaryCommentGesture.getColor(context).withValues(alpha: dismissThreshold / firstActionThreshold)
+                        : (swipeAction ?? SwipeAction.none).getColor(context),
+                    duration: const Duration(milliseconds: 200),
+                    child: SizedBox(
+                      width: MediaQuery.of(context).size.width * dismissThreshold,
+                      child: swipeAction == null ? Container() : Icon((swipeAction ?? SwipeAction.none).getIcon()),
                     ),
-              child: Container(
-                decoration: BoxDecoration(
-                  border: nestedCommentIndicatorStyle == NestedCommentIndicatorStyle.thin
-                      ? Border(
-                          left: BorderSide(
-                            width: widget.level == 0 ? 0 : 1.0,
-                            // This is the color of the nested comment indicator in thin mode
-                            color: widget.level == 0
-                                ? theme.colorScheme.surface
-                                : nestedCommentIndicatorColor == NestedCommentIndicatorColor.colorful
-                                    ? getCommentLevelColor(context, (widget.level - 1) % 6)
-                                    : theme.hintColor.withValues(alpha: 0.25),
-                          ),
-                        )
-                      : Border(
-                          left: BorderSide(
-                            width: widget.level == 0 ? 0 : 4.0,
-                            // This is the color of the nested comment indicator in thin mode
-                            color: widget.level == 0
-                                ? theme.colorScheme.surface
-                                : nestedCommentIndicatorColor == NestedCommentIndicatorColor.colorful
-                                    ? getCommentLevelColor(context, (widget.level - 1) % 6)
-                                    : theme.hintColor,
-                          ),
-                        ),
-                ),
-                child: Material(
-                  color: highlightComment ? theme.highlightColor : null,
-                  child: Column(
-                    crossAxisAlignment: CrossAxisAlignment.start,
-                    mainAxisAlignment: MainAxisAlignment.start,
-                    children: [
-                      InkWell(
-                        onLongPress: () {
-                          HapticFeedback.mediumImpact();
-                          showCommentActionBottomModalSheet(
-                            context,
-                            widget.commentView,
-                            isShowingSource: viewSource,
-                            onAction: ({commentAction, required commentView, communityAction, userAction, value}) async {
-                              if (commentAction != null) {
-                                switch (commentAction) {
-                                  case CommentAction.vote:
-                                    widget.onVoteAction?.call(commentView.comment.id, value);
-                                    break;
-                                  case CommentAction.save:
-                                    widget.onSaveAction?.call(commentView.comment.id, value);
-                                    break;
-                                  case CommentAction.reply:
-                                    return navigateToCreateCommentPage(
-                                      context,
-                                      commentView: null,
-                                      parentCommentView: commentView,
-                                      onCommentSuccess: (commentView, isEdit) => widget.onReplyEditAction?.call(commentView, isEdit),
-                                    );
-                                  case CommentAction.edit:
-                                    return navigateToCreateCommentPage(
-                                      context,
-                                      commentView: commentView,
-                                      parentCommentView: null,
-                                      onCommentSuccess: (commentView, isEdit) => widget.onReplyEditAction?.call(commentView, isEdit),
-                                    );
-                                  case CommentAction.delete:
-                                    widget.onDeleteAction?.call(commentView.comment.id, value);
-                                    break;
-                                  case CommentAction.report:
-                                    context.read<PostBloc>().add(ReportCommentEvent(commentId: commentView.comment.id, message: value));
-                                    break;
-                                  case CommentAction.viewSource:
-                                    setState(() => viewSource = !viewSource);
-                                    break;
-                                  default:
-                                    break;
-                                }
-                              } else if (communityAction != null) {
-                                // @todo - implement community actions
-                              } else if (userAction != null) {
-                                setState(() {});
-                              }
-                            },
-                          );
-                        },
-                        onTap: () {
-                          widget.onCollapseCommentChange?.call(widget.commentView.comment.id, !widget.collapsed);
-                        },
-                        child: CommentContent(
-                          comment: widget.commentView,
-                          isUserLoggedIn: isUserLoggedIn,
-                          onSaveAction: (int commentId, bool save) => widget.onSaveAction?.call(commentId, save),
-                          onVoteAction: (int commentId, int vote) => widget.onVoteAction?.call(commentId, vote),
-                          onDeleteAction: (int commentId, bool deleted) => widget.onDeleteAction?.call(commentId, deleted),
-                          onReplyEditAction: (CommentView commentView, bool isEdit) {
-                            return navigateToCreateCommentPage(
-                              context,
-                              commentView: isEdit ? commentView : null,
-                              parentCommentView: isEdit ? null : commentView,
-                              onCommentSuccess: (commentView, isEdit) => widget.onReplyEditAction?.call(commentView, isEdit),
-                            );
-                          },
-                          isOwnComment: isOwnComment,
-                          isHidden: widget.collapsed,
-                          viewSource: viewSource,
-                          onViewSourceToggled: () => setState(() => viewSource = !viewSource),
-                        ),
-                      ),
-                    ],
+                  )
+                : AnimatedContainer(
+                    alignment: Alignment.centerRight,
+                    color: swipeAction == null
+                        ? (state.rightPrimaryCommentGesture).getColor(context).withValues(alpha: dismissThreshold / firstActionThreshold)
+                        : (swipeAction ?? SwipeAction.none).getColor(context),
+                    duration: const Duration(milliseconds: 200),
+                    child: SizedBox(
+                      width: MediaQuery.of(context).size.width * dismissThreshold,
+                      child: swipeAction == null ? Container() : Icon((swipeAction ?? SwipeAction.none).getIcon()),
+                    ),
                   ),
-                ),
+            child: Material(
+              color: highlightComment ? theme.highlightColor : null,
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                mainAxisAlignment: MainAxisAlignment.start,
+                children: [
+                  InkWell(
+                    onLongPress: () {
+                      HapticFeedback.mediumImpact();
+                      showCommentActionBottomModalSheet(
+                        context,
+                        widget.commentView,
+                        isShowingSource: viewSource,
+                        onAction: ({commentAction, required commentView, communityAction, userAction, value}) async {
+                          if (commentAction != null) {
+                            switch (commentAction) {
+                              case CommentAction.vote:
+                                widget.onVoteAction?.call(commentView.comment.id, value);
+                                break;
+                              case CommentAction.save:
+                                widget.onSaveAction?.call(commentView.comment.id, value);
+                                break;
+                              case CommentAction.reply:
+                                return navigateToCreateCommentPage(
+                                  context,
+                                  commentView: null,
+                                  parentCommentView: commentView,
+                                  onCommentSuccess: (commentView, isEdit) => widget.onReplyEditAction?.call(commentView, isEdit),
+                                );
+                              case CommentAction.edit:
+                                return navigateToCreateCommentPage(
+                                  context,
+                                  commentView: commentView,
+                                  parentCommentView: null,
+                                  onCommentSuccess: (commentView, isEdit) => widget.onReplyEditAction?.call(commentView, isEdit),
+                                );
+                              case CommentAction.delete:
+                                widget.onDeleteAction?.call(commentView.comment.id, value);
+                                break;
+                              case CommentAction.report:
+                                context.read<PostBloc>().add(ReportCommentEvent(commentId: commentView.comment.id, message: value));
+                                break;
+                              case CommentAction.viewSource:
+                                setState(() => viewSource = !viewSource);
+                                break;
+                              default:
+                                break;
+                            }
+                          } else if (communityAction != null) {
+                            // @todo - implement community actions
+                          } else if (userAction != null) {
+                            setState(() {});
+                          }
+                        },
+                      );
+                    },
+                    onTap: () {
+                      widget.onCollapseCommentChange?.call(widget.commentView.comment.id, !widget.collapsed);
+                    },
+                    child: CommentContent(
+                      level: widget.level,
+                      comment: widget.commentView,
+                      dragged: dismissThreshold > 0,
+                      isUserLoggedIn: isUserLoggedIn,
+                      onSaveAction: (int commentId, bool save) => widget.onSaveAction?.call(commentId, save),
+                      onVoteAction: (int commentId, int vote) => widget.onVoteAction?.call(commentId, vote),
+                      onDeleteAction: (int commentId, bool deleted) => widget.onDeleteAction?.call(commentId, deleted),
+                      onReplyEditAction: (CommentView commentView, bool isEdit) {
+                        return navigateToCreateCommentPage(
+                          context,
+                          commentView: isEdit ? commentView : null,
+                          parentCommentView: isEdit ? null : commentView,
+                          onCommentSuccess: (commentView, isEdit) => widget.onReplyEditAction?.call(commentView, isEdit),
+                        );
+                      },
+                      isOwnComment: isOwnComment,
+                      isHidden: widget.collapsed,
+                      viewSource: viewSource,
+                      onViewSourceToggled: () => setState(() => viewSource = !viewSource),
+                    ),
+                  ),
+                ],
               ),
             ),
           ),
-          if (widget.replyCount == 0 && widget.commentView.counts.childCount > 0)
-            AnimatedSwitcher(
-              duration: const Duration(milliseconds: 200),
-              switchInCurve: Curves.easeInOutCubicEmphasized,
-              switchOutCurve: Curves.easeInOutCubicEmphasized,
-              transitionBuilder: (Widget child, Animation<double> animation) {
-                return SizeTransition(
-                  sizeFactor: animation,
-                  child: SlideTransition(position: _offsetAnimation, child: child),
-                );
-              },
-              child: widget.collapsed
-                  ? Container()
-                  : AdditionalCommentCard(
-                      depth: widget.level,
-                      replies: widget.commentView.counts.childCount,
-                      onTap: () => context.read<PostBloc>().add(GetPostCommentsEvent(commentParentId: widget.commentView.comment.id)),
-                    ),
-            ),
-        ],
-      ),
+        ),
+        if (widget.replyCount == 0 && widget.commentView.counts.childCount > 0)
+          AnimatedSwitcher(
+            duration: const Duration(milliseconds: 200),
+            switchInCurve: Curves.easeInOutCubicEmphasized,
+            switchOutCurve: Curves.easeInOutCubicEmphasized,
+            transitionBuilder: (Widget child, Animation<double> animation) {
+              return SizeTransition(
+                sizeFactor: animation,
+                child: SlideTransition(position: _offsetAnimation, child: child),
+              );
+            },
+            child: widget.collapsed
+                ? Container()
+                : AdditionalCommentCard(
+                    depth: widget.level,
+                    replies: widget.commentView.counts.childCount,
+                    onTap: () => context.read<PostBloc>().add(GetPostCommentsEvent(commentParentId: widget.commentView.comment.id)),
+                  ),
+          ),
+      ],
     );
   }
 }
@@ -429,52 +396,46 @@ class _AdditionalCommentCardState extends State<AdditionalCommentCard> {
   Widget build(BuildContext context) {
     final l10n = AppLocalizations.of(context)!;
     final theme = Theme.of(context);
-    final state = context.watch<ThunderBloc>().state;
 
-    NestedCommentIndicatorStyle nestedCommentIndicatorStyle = state.nestedCommentIndicatorStyle;
-    NestedCommentIndicatorColor nestedCommentIndicatorColor = state.nestedCommentIndicatorColor;
+    final style = context.select((ThunderBloc bloc) => bloc.state.nestedCommentIndicatorStyle);
+    final scheme = context.select((ThunderBloc bloc) => bloc.state.nestedCommentIndicatorColor);
+    final fontScale = context.select((ThunderBloc bloc) => bloc.state.commentFontSizeScale);
 
     return Container(
-      margin: EdgeInsets.only(left: widget.depth + 1 * 4.0),
-      child: InkWell(
-        onTap: () {
-          setState(() => isLoading = true);
-          widget.onTap?.call();
-        },
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            const Divider(height: 1),
-            Row(
-              mainAxisAlignment: MainAxisAlignment.spaceBetween,
-              children: [
-                Container(
-                  decoration: BoxDecoration(
-                    border: Border(
-                      left: BorderSide(
-                        width: nestedCommentIndicatorStyle == NestedCommentIndicatorStyle.thick ? 4.0 : 1,
-                        // This is the color of the nested comment indicator for deferred load
-                        color: nestedCommentIndicatorColor == NestedCommentIndicatorColor.colorful ? getCommentLevelColor(context, (widget.depth % 6).toInt()) : theme.hintColor,
+      decoration: CommentDepthIndicatorDecoration(context, level: widget.depth + 1, style: style, scheme: scheme),
+      child: Container(
+        margin: EdgeInsets.only(left: widget.depth * 4.0),
+        child: InkWell(
+          onTap: () {
+            setState(() => isLoading = true);
+            widget.onTap?.call();
+          },
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Divider(height: 1),
+              Row(
+                mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                children: [
+                  Container(
+                    padding: EdgeInsets.only(left: 12.0).copyWith(top: 12.0, bottom: 12.0),
+                    child: ScalableText(
+                      widget.replies == 1 ? l10n.loadMoreSingular(widget.replies) : l10n.loadMorePlural(widget.replies),
+                      fontScale: fontScale,
+                      style: theme.textTheme.bodyMedium?.copyWith(
+                        color: theme.textTheme.bodyMedium?.color?.withValues(alpha: 0.5),
                       ),
                     ),
                   ),
-                  padding: const EdgeInsets.symmetric(vertical: 12.0, horizontal: 8.0),
-                  child: ScalableText(
-                    widget.replies == 1 ? l10n.loadMoreSingular(widget.replies) : l10n.loadMorePlural(widget.replies),
-                    fontScale: state.commentFontSizeScale,
-                    style: theme.textTheme.bodyMedium?.copyWith(
-                      color: theme.textTheme.bodyMedium?.color?.withValues(alpha: 0.5),
-                    ),
-                  ),
-                ),
-                if (isLoading)
-                  const Padding(
-                    padding: EdgeInsets.symmetric(horizontal: 8.0),
-                    child: SizedBox(width: 20, height: 20, child: CircularProgressIndicator()),
-                  )
-              ],
-            )
-          ],
+                  if (isLoading)
+                    const Padding(
+                      padding: EdgeInsets.symmetric(horizontal: 8.0),
+                      child: SizedBox(width: 20, height: 20, child: CircularProgressIndicator()),
+                    )
+                ],
+              )
+            ],
+          ),
         ),
       ),
     );

--- a/lib/comment/widgets/comment_depth_indicator.dart
+++ b/lib/comment/widgets/comment_depth_indicator.dart
@@ -3,27 +3,39 @@ import 'package:flutter/material.dart';
 import 'package:thunder/core/enums/nested_comment_indicator.dart';
 import 'package:thunder/utils/colors.dart';
 
-/// A decoration applied to a [Container] that is used to draw the vertical lines that indicate the depth of a comment.
-///
-/// Given the [level] of the comment, this decoration will draw a vertical line for each level of the comment.
-/// When the [level] is 0, no lines will be drawn.
 class CommentDepthIndicatorDecoration extends Decoration {
-  /// The build context to determine the theme and colours.
+  /// The [BuildContext] used to access the theme and colors for rendering.
+  ///
+  /// This is required to determine the appropriate colors based on the current theme.
   final BuildContext context;
 
-  /// The level of the comment.
+  /// The nesting level of the comment.
+  ///
+  /// This determines how many vertical lines are drawn. A value of 0 means no lines are drawn.
   final int level;
 
-  /// The style to use for the nested comment indicator.
+  /// The style of the nested comment indicator.
   ///
-  /// This determines the width of the vertical lines, and whether or not to render all levels of the indicator.
-  /// When [style] is [NestedCommentIndicatorStyle.thick], only the current level of the indicator will be rendered.
-  /// When [style] is [NestedCommentIndicatorStyle.thin], all levels of the indicator will be rendered.
+  /// - [NestedCommentIndicatorStyle.thick]: Only the current level's line is rendered with a thicker stroke.
+  /// - [NestedCommentIndicatorStyle.thin]: All levels' lines are rendered with a thinner stroke.
   final NestedCommentIndicatorStyle style;
 
-  /// The color scheme to use for the nested comment indicator.
+  /// The color scheme of the nested comment indicator.
+  ///
+  /// - [NestedCommentIndicatorColor.monochrome]: Lines are rendered in a single color with reduced opacity.
+  /// - [NestedCommentIndicatorColor.colorful]: Lines are rendered in a sequence of colors based on the level.
   final NestedCommentIndicatorColor scheme;
 
+  /// A decoration that visually represents the depth of a comment in a nested comment structure.
+  ///
+  /// This decoration is applied to a [Container] and draws vertical lines to indicate the nesting level of a comment.
+  /// The number of lines corresponds to the [level] of the comment. If the [level] is 0, no lines are drawn.
+  ///
+  /// The appearance of the lines is controlled by the [style] and [scheme] parameters:
+  /// - [style] determines the thickness of the lines and whether all levels or only the current level are rendered.
+  /// - [scheme] defines the color scheme of the lines, either monochrome or colorful.
+  ///
+  /// This widget is useful for visually organizing nested comments in a discussion thread or similar UI.
   const CommentDepthIndicatorDecoration(
     this.context, {
     this.level = 0,
@@ -91,7 +103,6 @@ class _BoxDecorationPainter extends BoxPainter {
       if (_decoration.scheme == NestedCommentIndicatorColor.monochrome) {
         paint.color = theme.hintColor.withValues(alpha: 0.25);
       } else {
-        // Fixed: Use proper modulo for level color
         paint.color = getCommentLevelColor(_decoration.context, (_decoration.level - 1) % 6);
       }
 

--- a/lib/comment/widgets/comment_depth_indicator.dart
+++ b/lib/comment/widgets/comment_depth_indicator.dart
@@ -1,0 +1,106 @@
+import 'package:flutter/material.dart';
+
+import 'package:thunder/core/enums/nested_comment_indicator.dart';
+import 'package:thunder/utils/colors.dart';
+
+/// A decoration applied to a [Container] that is used to draw the vertical lines that indicate the depth of a comment.
+///
+/// Given the [level] of the comment, this decoration will draw a vertical line for each level of the comment.
+/// When the [level] is 0, no lines will be drawn.
+class CommentDepthIndicatorDecoration extends Decoration {
+  /// The build context to determine the theme and colours.
+  final BuildContext context;
+
+  /// The level of the comment.
+  final int level;
+
+  /// The style to use for the nested comment indicator.
+  ///
+  /// This determines the width of the vertical lines, and whether or not to render all levels of the indicator.
+  /// When [style] is [NestedCommentIndicatorStyle.thick], only the current level of the indicator will be rendered.
+  /// When [style] is [NestedCommentIndicatorStyle.thin], all levels of the indicator will be rendered.
+  final NestedCommentIndicatorStyle style;
+
+  /// The color scheme to use for the nested comment indicator.
+  final NestedCommentIndicatorColor scheme;
+
+  const CommentDepthIndicatorDecoration(
+    this.context, {
+    this.level = 0,
+    this.style = NestedCommentIndicatorStyle.thin,
+    this.scheme = NestedCommentIndicatorColor.colorful,
+  });
+
+  @override
+  Path getClipPath(Rect rect, TextDirection textDirection) {
+    return Path()..addRect(rect);
+  }
+
+  @override
+  bool hitTest(Size size, Offset position, {TextDirection? textDirection}) {
+    assert((Offset.zero & size).contains(position));
+    return true;
+  }
+
+  @override
+  BoxPainter createBoxPainter([VoidCallback? onChanged]) {
+    assert(onChanged != null);
+    return _BoxDecorationPainter(this, onChanged);
+  }
+}
+
+/// An object that paints a [CommentDepthIndicatorDecoration] into a canvas.
+class _BoxDecorationPainter extends BoxPainter {
+  _BoxDecorationPainter(this._decoration, super.onChanged);
+
+  final CommentDepthIndicatorDecoration _decoration;
+
+  static const double _spacing = 4.0;
+  static const double _offset = 2.0;
+
+  /// Paint the box decoration into the given location on the given canvas.
+  @override
+  void paint(Canvas canvas, Offset offset, ImageConfiguration configuration) {
+    if (_decoration.level == 0) return;
+    assert(configuration.size != null);
+
+    final theme = Theme.of(_decoration.context);
+    final rect = offset & configuration.size!;
+    final paint = Paint()..style = PaintingStyle.stroke;
+
+    if (_decoration.style == NestedCommentIndicatorStyle.thin) {
+      paint.strokeWidth = 1.0;
+
+      // Draw each level of the comment indicator
+      for (int i = 0; i < _decoration.level; i++) {
+        if (_decoration.scheme == NestedCommentIndicatorColor.monochrome) {
+          paint.color = theme.hintColor.withValues(alpha: 0.25);
+        } else {
+          paint.color = getCommentLevelColor(_decoration.context, i % 6);
+        }
+
+        canvas.drawLine(
+          rect.translate((i + 1) * _spacing, 0).topLeft,
+          rect.translate((i + 1) * _spacing, 0).bottomLeft,
+          paint,
+        );
+      }
+    } else {
+      paint.strokeWidth = 4.0;
+
+      if (_decoration.scheme == NestedCommentIndicatorColor.monochrome) {
+        paint.color = theme.hintColor.withValues(alpha: 0.25);
+      } else {
+        // Fixed: Use proper modulo for level color
+        paint.color = getCommentLevelColor(_decoration.context, (_decoration.level - 1) % 6);
+      }
+
+      // Draw only the current level of the comment indicator
+      canvas.drawLine(
+        rect.translate(_decoration.level * _spacing - _offset, 0).topLeft,
+        rect.translate(_decoration.level * _spacing - _offset, 0).bottomLeft,
+        paint,
+      );
+    }
+  }
+}

--- a/lib/shared/comment_content.dart
+++ b/lib/shared/comment_content.dart
@@ -5,6 +5,8 @@ import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:lemmy_api_client/v3.dart';
 import 'package:thunder/comment/utils/comment.dart';
+import 'package:thunder/comment/widgets/comment_depth_indicator.dart';
+import 'package:thunder/core/enums/nested_comment_indicator.dart';
 import 'package:thunder/shared/common_markdown_body.dart';
 import 'package:thunder/shared/conditional_parent_widget.dart';
 import 'package:thunder/shared/divider.dart';
@@ -22,6 +24,9 @@ class CommentContent extends StatefulWidget {
   final bool isHidden;
   final bool excludeSemantics;
   final bool disableActions;
+  final int level;
+
+  final bool dragged;
 
   final Function(int, int) onVoteAction;
   final Function(int, bool) onSaveAction;
@@ -53,6 +58,8 @@ class CommentContent extends StatefulWidget {
     this.selectable = false,
     this.showReplyEditorButtons = false,
     this.onSelectionChanged,
+    this.level = 0,
+    this.dragged = false,
   });
 
   @override
@@ -82,101 +89,119 @@ class _CommentContentState extends State<CommentContent> with SingleTickerProvid
     bool collapseParentCommentOnGesture = state.collapseParentCommentOnGesture;
     final ThemeData theme = Theme.of(context);
 
-    return ExcludeSemantics(
-      excluding: widget.excludeSemantics,
-      child: AnimatedSize(
-        duration: const Duration(milliseconds: 250),
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          mainAxisAlignment: MainAxisAlignment.start,
-          children: [
-            CommentHeader(
-              moddingCommentId: widget.moddingCommentId ?? -1,
-              comment: widget.comment,
-              isOwnComment: widget.isOwnComment,
-              isHidden: widget.isHidden,
+    NestedCommentIndicatorStyle nestedCommentIndicatorStyle = state.nestedCommentIndicatorStyle;
+    NestedCommentIndicatorColor nestedCommentIndicatorColor = state.nestedCommentIndicatorColor;
+
+    return Container(
+      decoration: widget.dragged
+          ? null
+          : CommentDepthIndicatorDecoration(
+              context,
+              level: widget.level,
+              style: nestedCommentIndicatorStyle,
+              scheme: nestedCommentIndicatorColor,
             ),
-            AnimatedSwitcher(
-              duration: const Duration(milliseconds: 130),
-              switchInCurve: Curves.easeInOut,
-              switchOutCurve: Curves.easeInOut,
-              transitionBuilder: (Widget child, Animation<double> animation) {
-                return SizeTransition(
-                  sizeFactor: animation,
-                  child: SlideTransition(
-                    position: _offsetAnimation,
-                    child: child,
-                  ),
-                );
-              },
-              child: (widget.isHidden && collapseParentCommentOnGesture)
-                  ? Container()
-                  : Column(
-                      crossAxisAlignment: CrossAxisAlignment.start,
-                      children: [
-                        Padding(
-                          padding: EdgeInsets.only(top: 0, right: 8.0, left: 8.0, bottom: (state.showCommentButtonActions && widget.isUserLoggedIn && !widget.disableActions) ? 0.0 : 8.0),
-                          child: ConditionalParentWidget(
-                            condition: widget.selectable,
-                            parentBuilder: (child) {
-                              return SelectableRegion(
-                                focusNode: _selectableRegionFocusNode,
-                                // See comments on [SelectableTextModal] regarding the next two properties
-                                selectionControls: Platform.isIOS ? cupertinoTextSelectionHandleControls : materialTextSelectionHandleControls,
-                                contextMenuBuilder: (context, selectableRegionState) {
-                                  return AdaptiveTextSelectionToolbar.buttonItems(
-                                    buttonItems: selectableRegionState.contextMenuButtonItems,
-                                    anchors: selectableRegionState.contextMenuAnchors,
+      child: ExcludeSemantics(
+        excluding: widget.excludeSemantics,
+        child: Container(
+          padding: widget.level > 0 ? EdgeInsets.only(left: (widget.level) * 4.0) : null,
+          child: AnimatedSize(
+            duration: const Duration(milliseconds: 250),
+            curve: Curves.easeInOutCubicEmphasized,
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              mainAxisAlignment: MainAxisAlignment.start,
+              children: [
+                Divider(height: 1),
+                CommentHeader(
+                  moddingCommentId: widget.moddingCommentId ?? -1,
+                  comment: widget.comment,
+                  isOwnComment: widget.isOwnComment,
+                  isHidden: widget.isHidden,
+                ),
+                AnimatedSwitcher(
+                  duration: const Duration(milliseconds: 130),
+                  switchInCurve: Curves.easeInOut,
+                  switchOutCurve: Curves.easeInOut,
+                  transitionBuilder: (Widget child, Animation<double> animation) {
+                    return SizeTransition(
+                      sizeFactor: animation,
+                      child: SlideTransition(
+                        position: _offsetAnimation,
+                        child: child,
+                      ),
+                    );
+                  },
+                  child: (widget.isHidden && collapseParentCommentOnGesture)
+                      ? Container()
+                      : Column(
+                          crossAxisAlignment: CrossAxisAlignment.start,
+                          children: [
+                            Padding(
+                              padding: EdgeInsets.only(top: 0, right: 8.0, left: 8.0, bottom: (state.showCommentButtonActions && widget.isUserLoggedIn && !widget.disableActions) ? 0.0 : 8.0),
+                              child: ConditionalParentWidget(
+                                condition: widget.selectable,
+                                parentBuilder: (child) {
+                                  return SelectableRegion(
+                                    focusNode: _selectableRegionFocusNode,
+                                    // See comments on [SelectableTextModal] regarding the next two properties
+                                    selectionControls: Platform.isIOS ? cupertinoTextSelectionHandleControls : materialTextSelectionHandleControls,
+                                    contextMenuBuilder: (context, selectableRegionState) {
+                                      return AdaptiveTextSelectionToolbar.buttonItems(
+                                        buttonItems: selectableRegionState.contextMenuButtonItems,
+                                        anchors: selectableRegionState.contextMenuAnchors,
+                                      );
+                                    },
+                                    onSelectionChanged: (value) => widget.onSelectionChanged?.call(value?.plainText),
+                                    child: child,
                                   );
                                 },
-                                onSelectionChanged: (value) => widget.onSelectionChanged?.call(value?.plainText),
-                                child: child,
-                              );
-                            },
-                            child: widget.viewSource
-                                ? ScalableText(
-                                    cleanCommentContent(widget.comment.comment),
-                                    style: theme.textTheme.bodySmall?.copyWith(fontFamily: 'monospace'),
-                                    fontScale: state.contentFontSizeScale,
-                                  )
-                                : CommonMarkdownBody(
-                                    body: cleanCommentContent(widget.comment.comment),
-                                    isComment: true,
-                                  ),
-                          ),
-                        ),
-                        if (state.showCommentButtonActions && widget.isUserLoggedIn && !widget.disableActions)
-                          Padding(
-                            padding: const EdgeInsets.only(bottom: 4, top: 6, right: 4.0),
-                            child: CommentCardActions(
-                              commentView: widget.comment,
-                              onVoteAction: (int commentId, int vote) => widget.onVoteAction(commentId, vote),
-                              isEdit: widget.isOwnComment,
-                              onSaveAction: widget.onSaveAction,
-                              onDeleteAction: widget.onDeleteAction,
-                              onReplyEditAction: widget.onReplyEditAction,
-                              onViewSourceToggled: widget.onViewSourceToggled,
-                              viewSource: widget.viewSource,
+                                child: widget.viewSource
+                                    ? ScalableText(
+                                        cleanCommentContent(widget.comment.comment),
+                                        style: theme.textTheme.bodySmall?.copyWith(fontFamily: 'monospace'),
+                                        fontScale: state.contentFontSizeScale,
+                                      )
+                                    : CommonMarkdownBody(
+                                        body: cleanCommentContent(widget.comment.comment),
+                                        isComment: true,
+                                      ),
+                              ),
                             ),
-                          ),
-                      ],
-                    ),
-            ),
-            if (widget.showReplyEditorButtons && widget.comment.comment.content.isNotEmpty == true) ...[
-              const Padding(
-                padding: EdgeInsets.only(left: 8.0, right: 8.0),
-                child: ThunderDivider(sliver: false, padding: false),
-              ),
-              Padding(
-                padding: const EdgeInsets.only(left: 8.0, bottom: 8.0),
-                child: ReplyToPreviewActions(
-                  onViewSourceToggled: widget.onViewSourceToggled,
-                  viewSource: widget.viewSource,
-                  text: cleanCommentContent(widget.comment.comment),
+                            if (state.showCommentButtonActions && widget.isUserLoggedIn && !widget.disableActions)
+                              Padding(
+                                padding: const EdgeInsets.only(bottom: 4, top: 6, right: 4.0),
+                                child: CommentCardActions(
+                                  commentView: widget.comment,
+                                  onVoteAction: (int commentId, int vote) => widget.onVoteAction(commentId, vote),
+                                  isEdit: widget.isOwnComment,
+                                  onSaveAction: widget.onSaveAction,
+                                  onDeleteAction: widget.onDeleteAction,
+                                  onReplyEditAction: widget.onReplyEditAction,
+                                  onViewSourceToggled: widget.onViewSourceToggled,
+                                  viewSource: widget.viewSource,
+                                ),
+                              ),
+                          ],
+                        ),
                 ),
-              ),
-            ],
-          ],
+                if (widget.showReplyEditorButtons && widget.comment.comment.content.isNotEmpty == true) ...[
+                  const Padding(
+                    padding: EdgeInsets.only(left: 8.0, right: 8.0),
+                    child: ThunderDivider(sliver: false, padding: false),
+                  ),
+                  Padding(
+                    padding: const EdgeInsets.only(left: 8.0, bottom: 8.0),
+                    child: ReplyToPreviewActions(
+                      onViewSourceToggled: widget.onViewSourceToggled,
+                      viewSource: widget.viewSource,
+                      text: cleanCommentContent(widget.comment.comment),
+                    ),
+                  ),
+                ],
+              ],
+            ),
+          ),
         ),
       ),
     );


### PR DESCRIPTION
## Pull Request Description

> Review with whitespace off

This PR improves on our current comment depth indicators and fixes an issue with the thin-style comment indicator mentioned in https://github.com/thunder-app/thunder/issues/1786.

The following changes were made:
- Implemented a custom decoration widget (`CommentDepthIndicatorDecoration`) which renders the proper comment indicator based on the indicator style and colours.
- Simplified logic within the comment-related widgets to use the new comment indicator decoration widget.

> Note: This is the first time I've implemented a custom Decoration class, so there may be bugs associated with this. Let me know if you encounter any issues!

**Additional Context**
The reason why we lost the previous thin-styled comment depth indicators was due to changes in the way we handle the rendering of comments in the new post page. Previously, we were rendering comments in a somewhat recursive manner (parent comment renders the child comments, and the child comments render their children, and so on).

When we rendered comments in that recursive fashion, we were able to apply a border to each of the comment's `Container`, and likewise, render the depth indicators. However, we are now rendering each comment one at a time rather than recursively. This new method provides some benefits:
- Improved performance for large comment chains
  - Imagine a comment chain consisting of hundreds of comments - in the previous method, if the parent comment was in the viewport, then all it's child comments would likely need to be rendered even if they were not in the viewport simply because the parent was in view
- Ability to navigate between child comments - since we no longer render comments recursively, it made it much easier to implement next/previous comment navigation
- Simplification of the comment rendering logic - removing the recursive nature of the comment rendering makes it much easier to understand and potentially optimize

However, due to this change, I wasn't able to apply our existing logic to handle the depth indicators. I did attempt some alternative methods of rendering the depth indicators but none of them accomplished what I needed (e.g., some implementations didn't fully fill the height of the comment, other implementations weren't performant because it required additional layout calculations to determine the height, etc.)

To solve this, I created a new `Decoration` which renders the comment indicators. This implementation seems to work fairly well (from my testing so far), and allows us to add more customization in the future! For example, we could have thick style indicators that show all of the comment levels (e.g., how the thin style is implemented) and vice versa

<!--- Please describe what was changed -->

## Issue Being Fixed

<!-- Please describe the problem that is being fixed and, if applicable, reference a GitHub issue -->

Issue Number: https://github.com/thunder-app/thunder/issues/1786

## Screenshots / Recordings

@everdred I've attached some screenshots of the implementation - let me know your thoughts on this as it might not exactly match up with the pre 0.7.0-1 versions.

The video was too large for GitHub, so here's a link to it: https://files.catbox.moe/uh2nij.mp4

| Thin | Thick |
|-|-|
|![Screenshot_1743174277](https://github.com/user-attachments/assets/a7fbd84a-de45-44b0-8ef0-8e2432af9813)| ![Screenshot_1743174256](https://github.com/user-attachments/assets/93615a5f-1186-42e2-bb6b-68e2bed43575)|
|![Screenshot_1743174323](https://github.com/user-attachments/assets/27129832-c6c3-4d53-9d03-1914e7958869)|![Screenshot_1743174351](https://github.com/user-attachments/assets/b99433b4-eadd-4fa7-a6d0-ba449008c1a1)|

<!-- This section is optional but highly recommended to show off your changes! -->

## Checklist

- [ ] If a new package was added, did you ensure it uses an appropriate license and is actively maintained?
- [ ] Did you use localized strings (and added appropriate descriptions) where applicable?
- [ ] Did you add `semanticLabel`s where applicable for accessibility?
