### PR TITLE
Fix a problem with editing not updating the post content, and related bugs

### DIFF
--- a/lib/post/bloc/post_bloc.dart
+++ b/lib/post/bloc/post_bloc.dart
@@ -85,6 +85,10 @@ class PostBloc extends Bloc<PostEvent, PostState> {
     on<UpdateCollapsedComment>(
       _onUpdateCollapsedComment,
     );
+    on<PostUpdatedEvent>(
+      _onPostUpdated,
+      transformer: throttleDroppable(Duration.zero),
+    );
   }
 
   /// Fetches the post, along with the initial set of comments
@@ -655,5 +659,9 @@ class PostBloc extends Bloc<PostEvent, PostState> {
     List<int> collapsedComments = event.collapsed ? (state.collapsedComments.toList()..add(event.commentId)) : (state.collapsedComments.toList()..remove(event.commentId));
 
     return emit(state.copyWith(status: state.status, collapsedComments: collapsedComments));
+  }
+
+  void _onPostUpdated(PostUpdatedEvent event, Emitter<PostState> emit) {
+    return emit(state.copyWith(status: state.status, postView: event.postViewMedia));
   }
 }

--- a/lib/post/bloc/post_event.dart
+++ b/lib/post/bloc/post_event.dart
@@ -101,3 +101,9 @@ class UpdateCollapsedComment extends PostEvent {
 
   const UpdateCollapsedComment({required this.commentId, required this.collapsed});
 }
+
+final class PostUpdatedEvent extends PostEvent {
+  final PostViewMedia postViewMedia;
+
+  const PostUpdatedEvent({required this.postViewMedia});
+}

--- a/lib/post/pages/post_page.dart
+++ b/lib/post/pages/post_page.dart
@@ -258,7 +258,7 @@ class _PostPageState extends State<PostPage> {
             return;
           }
 
-          if (state.status == PostStatus.success && state.postView != widget.initialPostViewMedia && state.postView != null) {
+          if (state.status == PostStatus.success && state.postView != null) {
             if (!userChanged) {
               widget.onPostUpdated?.call(state.postView!);
             }
@@ -370,7 +370,7 @@ class _PostPageState extends State<PostPage> {
                                           : singlePressAction == PostFabAction.changeSort
                                               ? () => showSortBottomSheet(context, state)
                                               : singlePressAction == PostFabAction.replyToPost
-                                                  ? () => replyToPost(context, widget.initialPostViewMedia, postLocked: post.locked)
+                                                  ? () => replyToPost(context, state.postView ?? widget.initialPostViewMedia, postLocked: post.locked)
                                                   : singlePressAction == PostFabAction.search
                                                       ? () => startCommentSearch(context)
                                                       : null),
@@ -393,7 +393,7 @@ class _PostPageState extends State<PostPage> {
                                       : longPressAction == PostFabAction.changeSort
                                           ? () => showSortBottomSheet(context, state)
                                           : longPressAction == PostFabAction.replyToPost
-                                              ? () => replyToPost(context, widget.initialPostViewMedia, postLocked: post.locked)
+                                              ? () => replyToPost(context, state.postView ?? widget.initialPostViewMedia, postLocked: post.locked)
                                               : null),
                               children: [
                                 if (thunderState.postFabEnableRefresh)
@@ -420,7 +420,7 @@ class _PostPageState extends State<PostPage> {
                                     onPressed: () {
                                       HapticFeedback.mediumImpact();
                                       PostFabAction.replyToPost.execute(
-                                        override: () => replyToPost(context, widget.initialPostViewMedia, postLocked: post.locked),
+                                        override: () => replyToPost(context, state.postView ?? widget.initialPostViewMedia, postLocked: post.locked),
                                       );
                                     },
                                     title: PostFabAction.replyToPost.getTitle(context),

--- a/lib/post/widgets/post_view.dart
+++ b/lib/post/widgets/post_view.dart
@@ -96,12 +96,6 @@ class _PostSubviewState extends State<PostSubview> with SingleTickerProviderStat
   }
 
   @override
-  void didUpdateWidget(covariant PostSubview oldWidget) {
-    super.didUpdateWidget(oldWidget);
-    postViewMedia = widget.postViewMedia;
-  }
-
-  @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
     final AppLocalizations l10n = AppLocalizations.of(context)!;
@@ -195,7 +189,7 @@ class _PostSubviewState extends State<PostSubview> with SingleTickerProviderStat
                   isUserLoggedIn: isUserLoggedIn,
                 ),
               ),
-            if (widget.postViewMedia.postView.post.body?.isNotEmpty == true)
+            if (postViewMedia.postView.post.body?.isNotEmpty == true)
               Expandable(
                 controller: expandableController,
                 collapsed: PostBodyPreview(
@@ -286,12 +280,12 @@ class _PostSubviewState extends State<PostSubview> with SingleTickerProviderStat
                     hasBeenEdited: postViewMedia.postView.post.updated != null ? true : false,
                     url: postViewMedia.media.firstOrNull != null ? postViewMedia.media.first.originalUrl : null,
                   ),
-                  if (widget.showReplyEditorButtons && widget.postViewMedia.postView.post.body?.isNotEmpty == true) ...[
+                  if (widget.showReplyEditorButtons && postViewMedia.postView.post.body?.isNotEmpty == true) ...[
                     const ThunderDivider(sliver: false, padding: false),
                     ReplyToPreviewActions(
                       onViewSourceToggled: widget.onViewSourceToggled,
                       viewSource: widget.viewSource,
-                      text: widget.postViewMedia.postView.post.body!,
+                      text: postViewMedia.postView.post.body!,
                     ),
                   ],
                 ],
@@ -301,7 +295,7 @@ class _PostSubviewState extends State<PostSubview> with SingleTickerProviderStat
               const Divider(),
               CrossPosts(
                 crossPosts: sortedCrossPosts,
-                originalPost: widget.postViewMedia,
+                originalPost: postViewMedia,
               ),
             ],
             if (widget.showQuickPostActionBar) ...[
@@ -374,7 +368,7 @@ class _PostSubviewState extends State<PostSubview> with SingleTickerProviderStat
                 },
                 onReply: () async => navigateToCreateCommentPage(
                   context,
-                  postViewMedia: widget.postViewMedia,
+                  postViewMedia: postViewMedia,
                   onCommentSuccess: (commentView, userChanged) {
                     if (!userChanged) {
                       context.read<PostBloc>().add(CommentItemUpdatedEvent(commentView: commentView));

--- a/lib/utils/navigation.dart
+++ b/lib/utils/navigation.dart
@@ -390,6 +390,7 @@ Future<void> navigateToCreatePostPage(
     final l10n = AppLocalizations.of(context)!;
 
     FeedBloc? feedBloc;
+    PostBloc? postBloc;
     ThunderBloc thunderBloc = context.read<ThunderBloc>();
     AccountBloc accountBloc = context.read<AccountBloc>();
     CreatePostCubit createPostCubit = CreatePostCubit();
@@ -402,6 +403,12 @@ Future<void> navigateToCreatePostPage(
       feedBloc = context.read<FeedBloc>();
     } catch (e) {
       // Don't need feed block if we're not opening post in the context of a feed.
+    }
+
+    try {
+      postBloc = context.read<PostBloc>();
+    } catch (e) {
+      // It's ok if we don't get the PostBloc
     }
 
     ThunderCommunity? pvmCommunity;
@@ -436,6 +443,7 @@ Future<void> navigateToCreatePostPage(
         return MultiBlocProvider(
           providers: [
             feedBloc != null ? BlocProvider<FeedBloc>.value(value: feedBloc) : BlocProvider(create: (context) => FeedBloc(lemmyClient: LemmyClient.instance)),
+            if (postBloc != null) BlocProvider<PostBloc>.value(value: postBloc),
             BlocProvider<ThunderBloc>.value(value: thunderBloc),
             BlocProvider<AccountBloc>.value(value: accountBloc),
             BlocProvider<CreatePostCubit>.value(value: createPostCubit),
@@ -452,7 +460,14 @@ Future<void> navigateToCreatePostPage(
             isCrossPost: isCrossPost,
             onPostSuccess: (PostViewMedia pvm, bool userChanged) {
               // Update the existing post view media if it exists
-              if (feedBloc != null && postViewMedia != null) feedBloc.add(FeedItemUpdatedEvent(postViewMedia: pvm));
+              if (postViewMedia != null) {
+                if (feedBloc != null) {
+                  feedBloc.add(FeedItemUpdatedEvent(postViewMedia: pvm));
+                }
+                if (postBloc != null) {
+                  postBloc.add(PostUpdatedEvent(postViewMedia: pvm));
+                }
+              }
 
               // Show snackbar message if the post was just created
               if (!userChanged && postViewMedia == null) {


### PR DESCRIPTION


## Pull Request Description

<!--- Please describe what was changed -->

This PR primarily fixes an issue where, after editing a post, the post page would show the original, un-edited post.

This was caused from the implementation of `didUpdateWidget` that would update the local copy of the `postViewMedia` from the original version of the `widget.postViewMedia` very frequently.

I also discovered that `widget.postViewMedia` was used in other cases, like cross-posting, causing the unedited version of the post to be used in those cases as well. By switching everything to `postViewMedia`, the other issues are fixed as well.

One more case was related to replying. This was using the `widget.initialPostViewMedia`. I found some cases where we checked the state first, like `state.postView ?? widget.initialPostViewMedia`, and I changed the rest of the cases to be like that, but the state wasn't getting the update from the edit. So I added a new event to the `PostBloc`, like we already have in the `FeedBloc` to update the post.

Finally, per @hjiangsu's suggestion, I also retested a use case of modifying the post and ensuring that the update is reflected in the feed. Sure enough, it did not work, but it's unclear if removing `didUpdateWidget` was the cause. Regardless, I fixed it my ensuring that the callback, `onPostUpdated`, happened more often for any change.

Note: There is still one use case that's broken: opening a post, then navigating back to the feed, then updating the post in the feed (e.g., upvote), then navigating back into the post. However, I'm almost positive this was broken by #1520 because that (intentionally) pulls in a "stale" post to preserve the state. We will have to think about how to fix that use case for modifications like upvoting. That can be a separate fix.

## Issue Being Fixed

<!-- Please describe the problem that is being fixed and, if applicable, reference a GitHub issue -->

Issue Number: https://lemmy.world/post/25585479

## Screenshots / Recordings

<!-- This section is optional but highly recommended to show off your changes! -->

https://github.com/user-attachments/assets/fe9570bc-27b6-4ede-baee-84ec977518f1

## Checklist

- [ ] If a new package was added, did you ensure it uses an appropriate license and is actively maintained?
- [ ] Did you use localized strings (and added appropriate descriptions) where applicable?
- [ ] Did you add `semanticLabel`s where applicable for accessibility?
