### PR TITLE
Add semantic label to community search result subscription button

### DIFF
--- a/lib/community/widgets/community_list_entry.dart
+++ b/lib/community/widgets/community_list_entry.dart
@@ -58,6 +58,12 @@ class CommunityListEntry extends StatelessWidget {
     final l10n = AppLocalizations.of(context)!;
     assert(community.subscribers != null);
 
+    String subscriptionButtonLabel = switch (getCurrentSubscriptionStatus!(isUserLoggedIn, community, currentSubscriptions)) {
+      SubscribedType.notSubscribed => l10n.subscribe,
+      SubscribedType.pending => l10n.unsubscribePending,
+      SubscribedType.subscribed => l10n.unsubscribe,
+    };
+
     return Tooltip(
       excludeFromSemantics: true,
       message: '${community.title}\n${generateCommunityFullName(
@@ -105,18 +111,17 @@ class CommunityListEntry extends StatelessWidget {
                   showSnackbar(subscriptionStatus == SubscribedType.notSubscribed ? l10n.addedCommunityToSubscriptions : l10n.removedCommunityFromSubscriptions);
                   context.read<AccountBloc>().add(const GetAccountSubscriptions());
                 },
-                icon: Icon(
-                  switch (getCurrentSubscriptionStatus!(isUserLoggedIn, community, currentSubscriptions)) {
-                    SubscribedType.notSubscribed => Icons.add_circle_outline_rounded,
-                    SubscribedType.pending => Icons.pending_outlined,
-                    SubscribedType.subscribed => Icons.remove_circle_outline_rounded,
-                  },
+                icon: Semantics(
+                  label: subscriptionButtonLabel,
+                  child: Icon(
+                    switch (getCurrentSubscriptionStatus!(isUserLoggedIn, community, currentSubscriptions)) {
+                      SubscribedType.notSubscribed => Icons.add_circle_outline_rounded,
+                      SubscribedType.pending => Icons.pending_outlined,
+                      SubscribedType.subscribed => Icons.remove_circle_outline_rounded,
+                    },
+                  ),
                 ),
-                tooltip: switch (getCurrentSubscriptionStatus!(isUserLoggedIn, community, currentSubscriptions)) {
-                  SubscribedType.notSubscribed => l10n.subscribe,
-                  SubscribedType.pending => l10n.unsubscribePending,
-                  SubscribedType.subscribed => l10n.unsubscribe,
-                },
+                tooltip: subscriptionButtonLabel,
                 visualDensity: VisualDensity.compact,
               ),
         onTap: () async {


### PR DESCRIPTION
## Pull Request Description

<!--- Please describe what was changed -->

This PR fixes talkback for the subscription buttons in the community search results.

Note that I had to put the `Semantics` around the `Icon`, not the `IconButton` for some reason.

Please review without whitespace.

## Issue Being Fixed

<!-- Please describe the problem that is being fixed and, if applicable, reference a GitHub issue -->

Issue Number: #1787

## Screenshots / Recordings

<!-- This section is optional but highly recommended to show off your changes! -->

## Checklist

- [ ] If a new package was added, did you ensure it uses an appropriate license and is actively maintained?
- [ ] Did you use localized strings (and added appropriate descriptions) where applicable?
- [ ] Did you add `semanticLabel`s where applicable for accessibility?
