### PR TITLE
Fix issue where inbox message is shown prematurely

### DIFF
--- a/lib/inbox/widgets/inbox_mentions_view.dart
+++ b/lib/inbox/widgets/inbox_mentions_view.dart
@@ -55,7 +55,7 @@ class _InboxMentionsViewState extends State<InboxMentionsView> {
               hasScrollBody: false,
               child: Center(child: CircularProgressIndicator()),
             ),
-          if (widget.mentions.isEmpty)
+          if (state.status != InboxStatus.loading && widget.mentions.isEmpty)
             SliverFillRemaining(
               hasScrollBody: false,
               child: Center(child: Text(l10n.noMentions)),
@@ -87,6 +87,10 @@ class _InboxMentionsViewState extends State<InboxMentionsView> {
             },
           ),
           if (state.hasReachedInboxMentionEnd && widget.mentions.isNotEmpty) const SliverToBoxAdapter(child: FeedReachedEnd()),
+          if (widget.mentions.isNotEmpty)
+            SliverToBoxAdapter(
+              child: SizedBox(height: kBottomNavigationBarHeight),
+            )
         ],
       );
     });

--- a/lib/inbox/widgets/inbox_private_messages_view.dart
+++ b/lib/inbox/widgets/inbox_private_messages_view.dart
@@ -37,7 +37,7 @@ class _InboxPrivateMessagesViewState extends State<InboxPrivateMessagesView> {
               hasScrollBody: false,
               child: Center(child: CircularProgressIndicator()),
             ),
-          if (widget.privateMessages.isEmpty)
+          if (state.status != InboxStatus.loading && widget.privateMessages.isEmpty)
             SliverFillRemaining(
               hasScrollBody: false,
               child: Center(child: Text(l10n.noMessages)),
@@ -104,6 +104,10 @@ class _InboxPrivateMessagesViewState extends State<InboxPrivateMessagesView> {
             },
           ),
           if (state.hasReachedInboxMentionEnd && widget.privateMessages.isNotEmpty) const SliverToBoxAdapter(child: FeedReachedEnd()),
+          if (widget.privateMessages.isNotEmpty)
+            SliverToBoxAdapter(
+              child: SizedBox(height: kBottomNavigationBarHeight),
+            )
         ],
       );
     });

--- a/lib/inbox/widgets/inbox_replies_view.dart
+++ b/lib/inbox/widgets/inbox_replies_view.dart
@@ -57,7 +57,7 @@ class _InboxRepliesViewState extends State<InboxRepliesView> {
               hasScrollBody: false,
               child: Center(child: CircularProgressIndicator()),
             ),
-          if (widget.replies.isEmpty)
+          if (state.status != InboxStatus.loading && widget.replies.isEmpty)
             SliverFillRemaining(
               hasScrollBody: false,
               child: Center(child: Text(l10n.noReplies)),
@@ -109,9 +109,10 @@ class _InboxRepliesViewState extends State<InboxRepliesView> {
             },
           ),
           if (state.hasReachedInboxReplyEnd && widget.replies.isNotEmpty) const SliverToBoxAdapter(child: FeedReachedEnd()),
-          SliverToBoxAdapter(
-            child: SizedBox(height: kBottomNavigationBarHeight),
-          )
+          if (widget.replies.isNotEmpty)
+            SliverToBoxAdapter(
+              child: SizedBox(height: kBottomNavigationBarHeight),
+            )
         ],
       );
     });


### PR DESCRIPTION
## Pull Request Description

<!--- Please describe what was changed -->

This fixes a tiny issue where the "No replies", "No mentions", etc., message was shown in the inbox below the spinner while it was still loading. I also standardized the bottom spacing across all three ages.

## Issue Being Fixed

<!-- Please describe the problem that is being fixed and, if applicable, reference a GitHub issue -->

Issue Number: N/A

## Screenshots / Recordings

<!-- This section is optional but highly recommended to show off your changes! -->

### Before

https://github.com/user-attachments/assets/632bc080-0900-446b-ae37-f736554898f0

### After

https://github.com/user-attachments/assets/baba41e1-eb72-453f-87d7-679bcfeb4328




## Checklist

- [ ] If a new package was added, did you ensure it uses an appropriate license and is actively maintained?
- [ ] Did you use localized strings (and added appropriate descriptions) where applicable?
- [ ] Did you add `semanticLabel`s where applicable for accessibility?
