### PR TITLE
Fix an issue with the feed FAB appearing on the account page

### DIFF
--- a/lib/feed/view/feed_page.dart
+++ b/lib/feed/view/feed_page.dart
@@ -605,7 +605,8 @@ class _FeedViewState extends State<FeedView> {
                     ),
                     if (Navigator.of(context).canPop() &&
                         (state.communityId != null || state.communityName != null || state.userId != null || state.username != null) &&
-                        thunderBloc.state.enableFeedsFab)
+                        thunderBloc.state.enableFeedsFab &&
+                        state.feedType != FeedType.account)
                       AnimatedOpacity(
                         opacity: (thunderBloc.state.enableFeedsFab) ? 1.0 : 0.0,
                         duration: const Duration(milliseconds: 150),


### PR DESCRIPTION
## Pull Request Description

<!--- Please describe what was changed -->

This PR fixes a small issue where the feed FAB could appear on the account page after navigating back from a post.

## Issue Being Fixed

<!-- Please describe the problem that is being fixed and, if applicable, reference a GitHub issue -->

Issue Number: N/A

## Screenshots / Recordings

<!-- This section is optional but highly recommended to show off your changes! -->

### Before

https://github.com/user-attachments/assets/89a08de0-9d6c-4740-a4d3-1af2a16a10af

### After

https://github.com/user-attachments/assets/173be524-25d9-45b6-96ab-55e6b1176b8f

## Checklist

- [ ] If a new package was added, did you ensure it uses an appropriate license and is actively maintained?
- [ ] Did you use localized strings (and added appropriate descriptions) where applicable?
- [ ] Did you add `semanticLabel`s where applicable for accessibility?
