### PR TITLE
Fix the lack of a spinner on startup when slow

### DIFF
--- a/lib/thunder/pages/thunder_page.dart
+++ b/lib/thunder/pages/thunder_page.dart
@@ -518,9 +518,9 @@ class _ThunderState extends State<Thunder> {
                         case AuthStatus.initial:
                           context.read<AuthBloc>().add(CheckAuth());
                           return Scaffold(
-                            appBar: AppBar(),
+                            appBar: AppBar(toolbarHeight: 70.0),
                             body: Center(
-                              child: Container(),
+                              child: CircularProgressIndicator(),
                             ),
                           );
                         case AuthStatus.contentWarning:


### PR DESCRIPTION
## Pull Request Description

<!--- Please describe what was changed -->

This PR fixes an issue where there is no progress indicator on the initial feed page when the user first starts the app if the user is on a slow connection. I feel like we've done something like this before, so if you can think of any reason why this is a bad idea, please let me know!

Also I tweaked the height of the appbar in this initial state so that the initial progress indicator I added here and the progress indicator shown subsequently on the feed page line up.

## Issue Being Fixed

<!-- Please describe the problem that is being fixed and, if applicable, reference a GitHub issue -->

Issue Number: N/A

## Screenshots / Recordings

<!-- This section is optional but highly recommended to show off your changes! -->

### Before

https://github.com/user-attachments/assets/921a5033-dfb7-4c0c-bb50-b09d3ae75ccc

### After

https://github.com/user-attachments/assets/9dbf7e3c-258e-4c9c-aed2-e870d49bb39e

## Checklist

- [ ] If a new package was added, did you ensure it uses an appropriate license and is actively maintained?
- [ ] Did you use localized strings (and added appropriate descriptions) where applicable?
- [ ] Did you add `semanticLabel`s where applicable for accessibility?
