### PR TITLE
Improve post loading

### DIFF
--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -2729,6 +2729,10 @@
   },
   "unableToLoadInstance": "Unable to load {instance}",
   "@unableToLoadInstance": {},
+  "unableToLoadPost": "Unable to load post",
+  "@unableToLoadPost": {
+    "description": "Error message shown when we are unable to load a post."
+  },
   "unableToLoadPostsFrominstance": "Unable to load posts from {instance}",
   "@unableToLoadPostsFrominstance": {},
   "unableToLoadReplies": "Unable to load more replies.",

--- a/lib/post/bloc/post_bloc.dart
+++ b/lib/post/bloc/post_bloc.dart
@@ -30,7 +30,7 @@ part 'post_event.dart';
 part 'post_state.dart';
 
 const throttleDuration = Duration(seconds: 1);
-const timeout = Duration(seconds: 10);
+const timeout = Duration(seconds: 30);
 int commentLimit = 50;
 
 EventTransformer<E> throttleDroppable<E>(Duration duration) {

--- a/lib/post/pages/post_page.dart
+++ b/lib/post/pages/post_page.dart
@@ -16,6 +16,7 @@ import 'package:thunder/core/enums/fab_action.dart';
 import 'package:thunder/core/models/comment_view_tree.dart';
 import 'package:thunder/core/singletons/lemmy_client.dart';
 import 'package:thunder/shared/comment_sort_picker.dart';
+import 'package:thunder/shared/error_message.dart';
 import 'package:thunder/shared/gesture_fab.dart';
 import 'package:thunder/shared/input_dialogs.dart';
 import 'package:thunder/shared/snackbar.dart';
@@ -264,6 +265,10 @@ class _PostPageState extends State<PostPage> {
             }
             setState(() {});
           }
+
+          if (state.status == PostStatus.failure) {
+            showSnackbar(state.errorMessage ?? l10n.missingErrorMessage);
+          }
         },
         buildWhen: (previous, current) {
           return !current.didScrollPositionChange;
@@ -505,6 +510,33 @@ class _PostPageState extends State<PostPage> {
                         const SliverFillRemaining(
                           hasScrollBody: false,
                           child: Center(child: CircularProgressIndicator()),
+                        )
+                      else if (state.status == PostStatus.failure)
+                        SliverFillRemaining(
+                          hasScrollBody: false,
+                          child: Center(
+                            child: StatefulBuilder(
+                              builder: (context, setState) => ErrorMessage(
+                                title: l10n.unableToLoadPost,
+                                message: l10n.internetOrInstanceIssues,
+                                actions: [
+                                  (
+                                    text: AppLocalizations.of(context)!.retry,
+                                    action: () {
+                                      context.read<PostBloc>().add(
+                                            GetPostEvent(
+                                              postView: widget.initialPostViewMedia,
+                                              selectedCommentPath: widget.commentPath,
+                                              selectedCommentId: widget.highlightedCommentId,
+                                            ),
+                                          );
+                                    },
+                                    loading: false,
+                                  ),
+                                ],
+                              ),
+                            ),
+                          ),
                         )
                       else ...[
                         SliverToBoxAdapter(

--- a/lib/post/pages/post_page.dart
+++ b/lib/post/pages/post_page.dart
@@ -521,7 +521,7 @@ class _PostPageState extends State<PostPage> {
                                 message: l10n.internetOrInstanceIssues,
                                 actions: [
                                   (
-                                    text: AppLocalizations.of(context)!.retry,
+                                    text: l10n.retry,
                                     action: () {
                                       context.read<PostBloc>().add(
                                             GetPostEvent(


### PR DESCRIPTION
## Pull Request Description

<!--- Please describe what was changed -->

Following onto #1795, I was doing some network latency testing, and I noticed when I was on a slow connection, I would navigate to a post, it would spin for a while, and then I would get just the post with no comments. I thought perhaps the comments were still loading in the background without a progress indicator, so my original plan was just to tweak the UI to add a spinner.

https://github.com/user-attachments/assets/61bfc882-97e4-439f-a03f-c4c4c2f00e6e

However, in debugging, I found that the request was actually timing out! And the post I was seeing was populated using info from the feed. (Now, I do have a question about why we don't show that info initially, and just fetch the comments, but that's a separate problem.)

Therefore, I made two changes.

First, if the request really times out, we should show that to the user. I implemented a similar strategy as we have on the feed, indicating the problem and giving the option to retry. We previously didn't have any logic in the post page to handle a failure.

https://github.com/user-attachments/assets/13313612-a00e-4361-865d-25eb896fbaad

Second, I increased the timeout so that, even on a slow connection, the post and comments will eventually load! Because, to be honest, if I'm on a slow connection, sometimes I'm just willing to wait for it to load rather than prematurely/artificially timing out.

## Issue Being Fixed

<!-- Please describe the problem that is being fixed and, if applicable, reference a GitHub issue -->

Issue Number: N/A

## Screenshots / Recordings

<!-- This section is optional but highly recommended to show off your changes! -->

## Checklist

- [ ] If a new package was added, did you ensure it uses an appropriate license and is actively maintained?
- [ ] Did you use localized strings (and added appropriate descriptions) where applicable?
- [ ] Did you add `semanticLabel`s where applicable for accessibility?
