### PR TITLE
Fix issue navigating to post after creation

### DIFF
--- a/lib/community/pages/create_post_page.dart
+++ b/lib/community/pages/create_post_page.dart
@@ -424,7 +424,6 @@ class _CreatePostPageState extends State<CreatePostPage> {
               resizeToAvoidBottomInset: false,
               appBar: AppBar(
                 title: Text(widget.postView != null ? l10n.editPost : l10n.createPost),
-                toolbarHeight: 70.0,
                 centerTitle: false,
               ),
               body: SafeArea(
@@ -435,7 +434,7 @@ class _CreatePostPageState extends State<CreatePostPage> {
                     Expanded(
                       child: SingleChildScrollView(
                         child: Padding(
-                          padding: const EdgeInsets.symmetric(horizontal: 16.0),
+                          padding: const EdgeInsets.only(left: 16.0, right: 16.0, top: 8.0),
                           child: Column(crossAxisAlignment: CrossAxisAlignment.start, children: <Widget>[
                             CommunitySelector(
                               community: community,
@@ -884,7 +883,7 @@ class _CommunitySelectorState extends State<CommunitySelector> {
                           ],
                         )
                       : SizedBox(
-                          height: 36,
+                          height: 39,
                           child: Align(
                             alignment: Alignment.centerLeft,
                             child: Text(

--- a/lib/utils/navigation.dart
+++ b/lib/utils/navigation.dart
@@ -476,7 +476,7 @@ Future<void> navigateToCreatePostPage(
                     l10n.postCreatedSuccessfully,
                     trailingIcon: Icons.remove_red_eye_rounded,
                     trailingAction: () {
-                      navigateToPost(navigatorContext, postViewMedia: pvm);
+                      navigateToPost(context, postViewMedia: pvm);
                     },
                   );
                 } catch (e) {


### PR DESCRIPTION
## Pull Request Description

<!--- Please describe what was changed -->

This PR fixes an issue where navigating to a new post after creating it (from the eyeball icon on the snackbar) didn't work. The problem was that it was referencing the wrong context, which was already gone at that point.

I also made some very minor visual adjustments to make the create post page look a little better.

## Issue Being Fixed

<!-- Please describe the problem that is being fixed and, if applicable, reference a GitHub issue -->

Issue Number: N/A

## Screenshots / Recordings

<!-- This section is optional but highly recommended to show off your changes! -->

## Checklist

- [ ] If a new package was added, did you ensure it uses an appropriate license and is actively maintained?
- [ ] Did you use localized strings (and added appropriate descriptions) where applicable?
- [ ] Did you add `semanticLabel`s where applicable for accessibility?
