### PR TITLE
Fix instance display in post

### DIFF
--- a/lib/post/widgets/post_view.dart
+++ b/lib/post/widgets/post_view.dart
@@ -250,7 +250,7 @@ class _PostSubviewState extends State<PostSubview> with SingleTickerProviderStat
                           format: 'png',
                         ),
                         userGroups: userGroups,
-                        includeInstance: thunderState.postBodyShowCommunityInstance,
+                        includeInstance: thunderState.postBodyShowUserInstance,
                       ),
                       ScalableText(
                         'to',
@@ -270,6 +270,7 @@ class _PostSubviewState extends State<PostSubview> with SingleTickerProviderStat
                         communityName: postView.community.name,
                         communityTitle: postView.community.title,
                         communityUrl: postView.community.actorId,
+                        includeInstance: thunderState.postBodyShowCommunityInstance,
                       ),
                     ],
                   ),

--- a/lib/shared/chips/community_chip.dart
+++ b/lib/shared/chips/community_chip.dart
@@ -20,6 +20,7 @@ class CommunityChip extends StatelessWidget {
     required this.communityName,
     required this.communityTitle,
     required this.communityUrl,
+    this.includeInstance,
   });
 
   /// The ID of the community.
@@ -36,6 +37,9 @@ class CommunityChip extends StatelessWidget {
 
   /// The URL of the community.
   final String communityUrl;
+
+  /// Whether or not to include the instance name
+  final bool? includeInstance;
 
   @override
   Widget build(BuildContext context) {
@@ -65,7 +69,7 @@ class CommunityChip extends StatelessWidget {
               communityName,
               communityTitle,
               fetchInstanceNameFromUrl(communityUrl),
-              includeInstance: state.postBodyShowCommunityInstance,
+              includeInstance: includeInstance ?? state.postBodyShowCommunityInstance,
               fontScale: state.metadataFontSizeScale,
               transformColor: (color) => color?.withValues(alpha: 0.75),
             ),


### PR DESCRIPTION
## Pull Request Description

<!--- Please describe what was changed -->

This PR fixes an issue with the instance display setting for post bodies. The first problem is that the user instance display was pulling the setting from the community instance display. The second problem (not really a problem, but to keep it in parity with the user one) is to allow the setting to be passed in rather than pulling directly from the state.

## Issue Being Fixed

<!-- Please describe the problem that is being fixed and, if applicable, reference a GitHub issue -->

Issue Number: #1798

## Screenshots / Recordings

<!-- This section is optional but highly recommended to show off your changes! -->

## Checklist

- [ ] If a new package was added, did you ensure it uses an appropriate license and is actively maintained?
- [ ] Did you use localized strings (and added appropriate descriptions) where applicable?
- [ ] Did you add `semanticLabel`s where applicable for accessibility?
