### PR TITLE
Fix Bluesky image URL parsing

### DIFF
--- a/lib/utils/media/image.dart
+++ b/lib/utils/media/image.dart
@@ -20,7 +20,9 @@ String generateRandomHeroString({int? len}) {
 }
 
 bool isImageUrl(String url) {
-  final imageExtensions = ['.png', '.jpg', '.jpeg', '.gif', '.bmp', '.webp'];
+  // '@jpeg' is added to support Bluesky's image URLs
+  // e.g., https://cdn.bsky.app/img/feed_fullsize/plain/did:plc:wf7nfy2us3h5gpa7zfettmzl/bafkreib6k2uwcy52wi654fdfmfqakzqu54m4eq7vi6cwrolwud6yhehihy@jpeg?.jpg
+  final imageExtensions = ['.png', '.jpg', '.jpeg', '.gif', '.bmp', '.webp', '@jpeg'];
 
   Uri uri;
   try {


### PR DESCRIPTION
## Pull Request Description

This PR fixes an issue where `isImageUrl` was not properly detecting Bluesky image URLs due to how their URLs are constructed. See https://lemmy.world/post/27449421 for more details on the issue.

> Also thanks to the Connect dev for bringing this into my attention!

The quick fix for now is to simply add `@jpeg` to the list of accepted image URLs. In the future, we should rely more on Lemmy's API response `url_content_type` to determine the content type.

<!--- Please describe what was changed -->

## Issue Being Fixed

<!-- Please describe the problem that is being fixed and, if applicable, reference a GitHub issue -->

Issue Number: https://lemmy.world/post/27449421

## Screenshots / Recordings

<!-- This section is optional but highly recommended to show off your changes! -->

## Checklist

- [ ] If a new package was added, did you ensure it uses an appropriate license and is actively maintained?
- [ ] Did you use localized strings (and added appropriate descriptions) where applicable?
- [ ] Did you add `semanticLabel`s where applicable for accessibility?
