### PR TITLE
Fix lag when favouriting a community

### DIFF
--- a/lib/account/bloc/account_bloc.dart
+++ b/lib/account/bloc/account_bloc.dart
@@ -92,7 +92,7 @@ class AccountBloc extends Bloc<AccountEvent, AccountState> {
       bool hasFetchedAllSubsciptions = false;
 
       while (!hasFetchedAllSubsciptions) {
-        final response = await lemmy.run(ListCommunities(auth: account.jwt, page: currentPage, type: ListingType.subscribed));
+        final response = await lemmy.run(ListCommunities(auth: account.jwt, page: currentPage, limit: 50, type: ListingType.subscribed));
         subscriptions.addAll(response.communities.map((cv) => ThunderCommunity(cv.community, communityView: cv)));
 
         currentPage++;

--- a/lib/account/bloc/account_bloc.dart
+++ b/lib/account/bloc/account_bloc.dart
@@ -43,9 +43,9 @@ class AccountBloc extends Bloc<AccountEvent, AccountState> {
   }
 
   Future<void> _refreshAccountInformation(RefreshAccountInformation event, Emitter<AccountState> emit) async {
+    await _getFavoritedCommunities(GetFavoritedCommunities(reload: event.reload), emit);
     await _getAccountInformation(GetAccountInformation(reload: event.reload), emit);
     await _getAccountSubscriptions(GetAccountSubscriptions(reload: event.reload), emit);
-    await _getFavoritedCommunities(GetFavoritedCommunities(reload: event.reload), emit);
   }
 
   /// Fetches the current account's information. This updates [personView] which holds moderated community information.

--- a/lib/account/models/favourite.dart
+++ b/lib/account/models/favourite.dart
@@ -33,7 +33,7 @@ class Favorite {
       return favourite.copyWith(id: id.toString());
     } catch (e) {
       debugPrint(e.toString());
-      return null;
+      rethrow;
     }
   }
 
@@ -84,6 +84,7 @@ class Favorite {
       }
     } catch (e) {
       debugPrint(e.toString());
+      rethrow;
     }
   }
 }

--- a/lib/feed/utils/community.dart
+++ b/lib/feed/utils/community.dart
@@ -56,7 +56,7 @@ Future<Map<String, dynamic>> fetchCommunityInformation({int? id, String? name}) 
 Future<void> toggleFavoriteCommunity(BuildContext context, ThunderCommunity community, bool isFavorite) async {
   if (isFavorite) {
     await Favorite.deleteFavorite(communityId: community.id);
-    if (context.mounted) context.read<AccountBloc>().add(const RefreshAccountInformation());
+    if (context.mounted) context.read<AccountBloc>().add(const GetFavoritedCommunities());
     return;
   }
 

--- a/lib/feed/utils/community.dart
+++ b/lib/feed/utils/community.dart
@@ -7,6 +7,7 @@ import 'package:thunder/account/models/favourite.dart';
 import 'package:thunder/core/auth/helpers/fetch_account.dart';
 import 'package:thunder/core/models/models.dart';
 import 'package:thunder/core/singletons/lemmy_client.dart';
+import 'package:thunder/shared/snackbar.dart';
 import 'package:thunder/utils/global_context.dart';
 
 /// Logic to block a community
@@ -54,22 +55,26 @@ Future<Map<String, dynamic>> fetchCommunityInformation({int? id, String? name}) 
 }
 
 Future<void> toggleFavoriteCommunity(BuildContext context, ThunderCommunity community, bool isFavorite) async {
-  if (isFavorite) {
-    await Favorite.deleteFavorite(communityId: community.id);
+  try {
+    if (isFavorite) {
+      await Favorite.deleteFavorite(communityId: community.id);
+      if (context.mounted) context.read<AccountBloc>().add(const GetFavoritedCommunities());
+      return;
+    }
+
+    Account? account = await fetchActiveProfileAccount();
+
+    Favorite favorite = Favorite(
+      id: '',
+      communityId: community.id,
+      accountId: account!.id,
+    );
+
+    await Favorite.insertFavorite(favorite);
     if (context.mounted) context.read<AccountBloc>().add(const GetFavoritedCommunities());
-    return;
+  } catch (e) {
+    showSnackbar(e.toString());
   }
-
-  Account? account = await fetchActiveProfileAccount();
-
-  Favorite favorite = Favorite(
-    id: '',
-    communityId: community.id,
-    accountId: account!.id,
-  );
-
-  await Favorite.insertFavorite(favorite);
-  if (context.mounted) context.read<AccountBloc>().add(const GetFavoritedCommunities());
 }
 
 /// Takes a list of [communities] and returns the list with any [favoriteCommunities] at the beginning of the list

--- a/lib/feed/utils/community.dart
+++ b/lib/feed/utils/community.dart
@@ -8,6 +8,7 @@ import 'package:thunder/core/auth/helpers/fetch_account.dart';
 import 'package:thunder/core/models/models.dart';
 import 'package:thunder/core/singletons/lemmy_client.dart';
 import 'package:thunder/shared/snackbar.dart';
+import 'package:thunder/utils/error_messages.dart';
 import 'package:thunder/utils/global_context.dart';
 
 /// Logic to block a community
@@ -73,7 +74,7 @@ Future<void> toggleFavoriteCommunity(BuildContext context, ThunderCommunity comm
     await Favorite.insertFavorite(favorite);
     if (context.mounted) context.read<AccountBloc>().add(const GetFavoritedCommunities());
   } catch (e) {
-    showSnackbar(e.toString());
+    showSnackbar(getExceptionErrorMessage(e));
   }
 }
 

--- a/lib/feed/utils/community.dart
+++ b/lib/feed/utils/community.dart
@@ -69,7 +69,7 @@ Future<void> toggleFavoriteCommunity(BuildContext context, ThunderCommunity comm
   );
 
   await Favorite.insertFavorite(favorite);
-  if (context.mounted) context.read<AccountBloc>().add(const RefreshAccountInformation());
+  if (context.mounted) context.read<AccountBloc>().add(const GetFavoritedCommunities());
 }
 
 /// Takes a list of [communities] and returns the list with any [favoriteCommunities] at the beginning of the list

--- a/lib/feed/widgets/feed_page_app_bar.dart
+++ b/lib/feed/widgets/feed_page_app_bar.dart
@@ -165,8 +165,10 @@ class FeedAppBarCommunityActions extends StatelessWidget {
     final community = context.read<FeedBloc>().state.community!;
     final sortType = context.read<FeedBloc>().state.sortType;
 
-    final favorited = _getFavoriteStatus(context);
     final subscriptionStatus = _getSubscriptionStatus(context);
+
+    final favorites = context.select<AccountBloc, List<ThunderCommunity>>((bloc) => bloc.state.favorites);
+    final favorited = favorites.any((c) => c.id == community.id);
 
     return Row(
       children: [
@@ -373,14 +375,6 @@ SubscribedType? _getSubscriptionStatus(BuildContext context) {
 
   final subscriptions = context.read<AnonymousSubscriptionsBloc>().state.ids;
   return subscriptions.contains(community?.id) ? SubscribedType.subscribed : SubscribedType.notSubscribed;
-}
-
-/// Checks whether the current community is a favorite of the current user
-bool _getFavoriteStatus(BuildContext context) {
-  final state = context.read<AccountBloc>().state;
-  final community = context.read<FeedBloc>().state.community;
-
-  return state.favorites.any((c) => c.id == community?.id);
 }
 
 void _onSubscribeIconPressed(BuildContext context) async {


### PR DESCRIPTION
## Pull Request Description

> Hide whitespace when reviewing

This PR fixes an issue where favouriting a community would take a while to occur (upwards of a few seconds). After investigation, it looks like we're refreshing the entire account information when we favourite a community, rather than just refreshing the favourited communities.

This PR also adds snackbar messages when an error occurs, and fixes an issue where tapping on the "Add/Remove favourite" from the community feed popup menu would not refresh properly.

## Issue Being Fixed

<!-- Please describe the problem that is being fixed and, if applicable, reference a GitHub issue -->

Issue Number: https://lemmy.world/post/27418233/16093814

## Screenshots / Recordings

<!-- This section is optional but highly recommended to show off your changes! -->

## Checklist

- [ ] If a new package was added, did you ensure it uses an appropriate license and is actively maintained?
- [ ] Did you use localized strings (and added appropriate descriptions) where applicable?
- [ ] Did you add `semanticLabel`s where applicable for accessibility?
