### PR TITLE
Show user avatars only when they have an associated image

### DIFF
--- a/lib/shared/chips/user_chip.dart
+++ b/lib/shared/chips/user_chip.dart
@@ -79,7 +79,7 @@ class UserChip extends StatelessWidget {
               child: Row(
                 mainAxisSize: MainAxisSize.min,
                 children: [
-                  if (showUserAvatar && personAvatar != null) Padding(padding: const EdgeInsets.only(top: 3, bottom: 3, right: 3), child: personAvatar!),
+                  if (showUserAvatar && personAvatar != null && user.icon != null) Padding(padding: const EdgeInsets.only(top: 3, bottom: 3, right: 3), child: personAvatar!),
                   UserFullNameWidget(
                     context,
                     user.username,


### PR DESCRIPTION
## Pull Request Description

This PR changes the logic for showing user avatars in the post page (comments). When user avatars are enabled, only user avatars that have images will be displayed within comments. Otherwise, they will be hidden.

I'm not sure whether this change should be its own separate option, or if it's good to use this as the default. If you have any opinions on this, let me know!

<!--- Please describe what was changed -->

## Issue Being Fixed

<!-- Please describe the problem that is being fixed and, if applicable, reference a GitHub issue -->

Issue Number: https://github.com/thunder-app/thunder/issues/1776

## Screenshots / Recordings

|Before|After|
|-|-|
|![Screenshot_1743283908](https://github.com/user-attachments/assets/9bc5e377-2adf-4296-b2d9-b0ff848e8b0f)|![Screenshot_1743283862](https://github.com/user-attachments/assets/b9abf4ab-bf5b-4a12-bf80-a51c8a065e0f)|


<!-- This section is optional but highly recommended to show off your changes! -->

## Checklist

- [ ] If a new package was added, did you ensure it uses an appropriate license and is actively maintained?
- [ ] Did you use localized strings (and added appropriate descriptions) where applicable?
- [ ] Did you add `semanticLabel`s where applicable for accessibility?
