### PR TITLE
Show message when navigating to a post with a blocked community

### DIFF
--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -1607,6 +1607,10 @@
   },
   "noUsersFound": "No users found.",
   "@noUsersFound": {},
+  "noVisibleComments": "Comments may not be visible because the community is blocked.",
+  "@noVisibleComments": {
+    "description": "A message that shows up when a user navigates to a post but the associated community is blocked."
+  },
   "none": "None",
   "@none": {
     "description": "Describes the notification type when push notifications are disabled"

--- a/lib/post/pages/post_page.dart
+++ b/lib/post/pages/post_page.dart
@@ -254,6 +254,17 @@ class _PostPageState extends State<PostPage> {
         }
       },
       child: BlocConsumer<PostBloc, PostState>(
+        listenWhen: (previous, current) {
+          if (previous.status == PostStatus.loading && current.status == PostStatus.success && current.postView != null && current.hasReachedCommentEnd) {
+            // Check if the post's community is blocked by the user. If so, show a message.
+            final blockedCommunities = context.read<AuthBloc>().state.getSiteResponse?.myUser?.communityBlocks;
+            final isCommunityBlocked = blockedCommunities?.any((community) => community.community.id == current.postView?.postView.post.communityId) ?? false;
+
+            if (isCommunityBlocked) showSnackbar(l10n.noVisibleComments);
+          }
+
+          return true;
+        },
         listener: (context, state) {
           if (state.didScrollPositionChange) {
             return;
@@ -263,12 +274,6 @@ class _PostPageState extends State<PostPage> {
             if (!userChanged) {
               widget.onPostUpdated?.call(state.postView!);
             }
-
-            // Check if the post's community is blocked by the user. If so, show a message.
-            final blockedCommunities = context.read<AuthBloc>().state.getSiteResponse?.myUser?.communityBlocks;
-            final isCommunityBlocked = blockedCommunities?.any((community) => community.community.id == state.postView?.postView.post.communityId) ?? false;
-            if (isCommunityBlocked) showSnackbar(l10n.noVisibleComments);
-
             setState(() {});
           }
 

--- a/lib/post/pages/post_page.dart
+++ b/lib/post/pages/post_page.dart
@@ -263,6 +263,12 @@ class _PostPageState extends State<PostPage> {
             if (!userChanged) {
               widget.onPostUpdated?.call(state.postView!);
             }
+
+            // Check if the post's community is blocked by the user. If so, show a message.
+            final blockedCommunities = context.read<AuthBloc>().state.getSiteResponse?.myUser?.communityBlocks;
+            final isCommunityBlocked = blockedCommunities?.any((community) => community.community.id == state.postView?.postView.post.communityId) ?? false;
+            if (isCommunityBlocked) showSnackbar(l10n.noVisibleComments);
+
             setState(() {});
           }
 


### PR DESCRIPTION
## Pull Request Description

This PR adds a helpful message when a user navigates to a post whose community was previously blocked.

<!--- Please describe what was changed -->

## Issue Being Fixed

<!-- Please describe the problem that is being fixed and, if applicable, reference a GitHub issue -->

Issue Number: https://lemmy.world/post/27560444

## Screenshots / Recordings

https://github.com/user-attachments/assets/d2b3ab70-3de6-4b18-8f27-acda050858f1

<!-- This section is optional but highly recommended to show off your changes! -->

## Checklist

- [ ] If a new package was added, did you ensure it uses an appropriate license and is actively maintained?
- [ ] Did you use localized strings (and added appropriate descriptions) where applicable?
- [ ] Did you add `semanticLabel`s where applicable for accessibility?
