### PR TITLE
Fix comment fab

### DIFF
--- a/lib/post/pages/post_page.dart
+++ b/lib/post/pages/post_page.dart
@@ -319,22 +319,23 @@ class _PostPageState extends State<PostPage> {
             floatingActionButton: Stack(
               alignment: Alignment.center,
               children: [
-                Positioned.fill(
-                  child: Padding(
-                    padding: const EdgeInsets.only(bottom: 5),
-                    child: Align(
-                      alignment: Alignment.bottomCenter,
-                      child: CommentNavigatorFab(
-                        initialIndex: 0,
-                        maxIndex: listController.isAttached ? listController.numberOfItems - 1 : 0,
-                        scrollController: scrollController,
-                        listController: listController,
-                        comments: flattenedComments,
-                        statusBarHeight: thunderState.hideTopBarOnScroll ? statusBarHeight : 0,
+                if (thunderState.enableCommentNavigation)
+                  Positioned.fill(
+                    child: Padding(
+                      padding: const EdgeInsets.only(bottom: 5),
+                      child: Align(
+                        alignment: Alignment.bottomCenter,
+                        child: CommentNavigatorFab(
+                          initialIndex: 0,
+                          maxIndex: listController.isAttached ? listController.numberOfItems - 1 : 0,
+                          scrollController: scrollController,
+                          listController: listController,
+                          comments: flattenedComments,
+                          statusBarHeight: thunderState.hideTopBarOnScroll ? statusBarHeight : 0,
+                        ),
                       ),
                     ),
                   ),
-                ),
                 if (thunderState.enablePostsFab)
                   Padding(
                     padding: EdgeInsets.only(

--- a/lib/settings/pages/general_settings_page.dart
+++ b/lib/settings/pages/general_settings_page.dart
@@ -212,6 +212,11 @@ class _GeneralSettingsPageState extends State<GeneralSettingsPage> with SingleTi
       case LocalSettings.enableCommentNavigation:
         await prefs.setBool(LocalSettings.enableCommentNavigation.name, value);
         setState(() => enableCommentNavigation = value);
+        if (!value) {
+          // if the user has disabled comment navigation, we can't combine the nav and fab
+          await prefs.setBool(LocalSettings.combineNavAndFab.name, false);
+          setState(() => combineNavAndFab = false);
+        }
         break;
       case LocalSettings.combineNavAndFab:
         await prefs.setBool(LocalSettings.combineNavAndFab.name, value);


### PR DESCRIPTION
## Pull Request Description

<!--- Please describe what was changed -->

This PR fixes an issue where we were not respecting the option not to show the comment nav.

I also ensured that disabling comment nav disables the option to combine nav + FAB, since that option no longer makes sense in that context.

Please review without whitespace.

## Issue Being Fixed

<!-- Please describe the problem that is being fixed and, if applicable, reference a GitHub issue -->

Issue Number: #1803

## Screenshots / Recordings

<!-- This section is optional but highly recommended to show off your changes! -->

https://github.com/user-attachments/assets/9c59a29d-2576-43ab-a460-d553b4d72db6

## Checklist

- [ ] If a new package was added, did you ensure it uses an appropriate license and is actively maintained?
- [ ] Did you use localized strings (and added appropriate descriptions) where applicable?
- [ ] Did you add `semanticLabel`s where applicable for accessibility?
