### PR TITLE
Fix FAB Settings page navigation

### DIFF
--- a/lib/utils/navigation.dart
+++ b/lib/utils/navigation.dart
@@ -41,6 +41,7 @@ import 'package:thunder/settings/pages/accessibility_settings_page.dart';
 import 'package:thunder/settings/pages/appearance_settings_page.dart';
 import 'package:thunder/settings/pages/comment_appearance_settings_page.dart';
 import 'package:thunder/settings/pages/debug_settings_page.dart';
+import 'package:thunder/settings/pages/fab_settings_page.dart';
 import 'package:thunder/settings/pages/filter_settings_page.dart';
 import 'package:thunder/settings/pages/general_settings_page.dart';
 import 'package:thunder/settings/pages/gesture_settings_page.dart';
@@ -821,7 +822,7 @@ void navigateToSettingPage(BuildContext context, LocalSettings setting, {LocalSe
             SETTINGS_APPEARANCE_POSTS_PAGE => PostAppearanceSettingsPage(settingToHighlight: settingToHighlight ?? setting),
             SETTINGS_APPEARANCE_COMMENTS_PAGE => CommentAppearanceSettingsPage(settingToHighlight: settingToHighlight ?? setting),
             SETTINGS_GESTURES_PAGE => GestureSettingsPage(settingToHighlight: settingToHighlight ?? setting),
-            SETTINGS_FAB_PAGE => GestureSettingsPage(settingToHighlight: settingToHighlight ?? setting),
+            SETTINGS_FAB_PAGE => FabSettingsPage(settingToHighlight: settingToHighlight ?? setting),
             SETTINGS_FILTERS_PAGE => FilterSettingsPage(settingToHighlight: settingToHighlight ?? setting),
             SETTINGS_ACCOUNT_PAGE => UserSettingsPage(settingToHighlight: settingToHighlight ?? setting),
             SETTINGS_ACCOUNT_LANGUAGES_PAGE => DiscussionLanguageSelector(),


### PR DESCRIPTION
## Pull Request Description

<!--- Please describe what was changed -->

This PR fixes a problem where we couldn't navigate to the FAB settings page.

## Issue Being Fixed

<!-- Please describe the problem that is being fixed and, if applicable, reference a GitHub issue -->

Issue Number: #1804

## Screenshots / Recordings

<!-- This section is optional but highly recommended to show off your changes! -->

## Checklist

- [ ] If a new package was added, did you ensure it uses an appropriate license and is actively maintained?
- [ ] Did you use localized strings (and added appropriate descriptions) where applicable?
- [ ] Did you add `semanticLabel`s where applicable for accessibility?
