### PR TITLE
Fix community metadata subscription not applying properly

### DIFF
--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Mon Mar 25 08:39:25 PDT 2024
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.10.2-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/lib/community/widgets/post_card.dart
+++ b/lib/community/widgets/post_card.dart
@@ -171,7 +171,10 @@ class _PostCardState extends State<PostCard> {
         ? PostCardViewCompact(
             post: ThunderPost(widget.postViewMedia.postView.post, postView: widget.postViewMedia.postView, media: widget.postViewMedia.media),
             creator: ThunderUser(widget.postViewMedia.postView.creator),
-            community: ThunderCommunity(widget.postViewMedia.postView.community),
+            community: ThunderCommunity(
+              widget.postViewMedia.postView.community,
+              subscribed: widget.postViewMedia.postView.subscribed,
+            ),
             isUserLoggedIn: isUserLoggedIn,
             indicateRead: widget.indicateRead,
             isLastTapped: widget.isLastTapped,

--- a/lib/community/widgets/post_card_view_comfortable.dart
+++ b/lib/community/widgets/post_card_view_comfortable.dart
@@ -179,7 +179,10 @@ class PostCardViewComfortable extends StatelessWidget {
                     children: [
                       PostCommunityAndAuthor(
                         user: ThunderUser(postViewMedia.postView.creator),
-                        community: ThunderCommunity(postViewMedia.postView.community),
+                        community: ThunderCommunity(
+                          postViewMedia.postView.community,
+                          subscribed: postView.subscribed,
+                        ),
                         dim: dim,
                       ),
                       PostCardMetadata(

--- a/lib/core/models/thunder_community.dart
+++ b/lib/core/models/thunder_community.dart
@@ -5,9 +5,33 @@ class ThunderCommunity {
   final Community _community;
 
   /// The Lemmy API model for the community view.
-  final CommunityView? _communityView;
+  late CommunityView? _communityView;
 
-  ThunderCommunity(this._community, {CommunityView? communityView}) : _communityView = communityView;
+  ThunderCommunity(this._community, {CommunityView? communityView, SubscribedType? subscribed}) {
+    if (communityView == null && subscribed != null) {
+      // If the community view is not provided, create a new one with the provided subscription status.
+      _communityView = CommunityView(
+        community: _community,
+        subscribed: subscribed,
+        blocked: false,
+        counts: CommunityAggregates(
+          communityId: _community.id,
+          published: _community.published,
+          subscribers: -1,
+          subscribersLocal: -1,
+          usersActiveDay: -1,
+          usersActiveWeek: -1,
+          usersActiveMonth: -1,
+          usersActiveHalfYear: -1,
+          posts: -1,
+          comments: -1,
+        ),
+      );
+    } else {
+      // If the community view is provided, use it.
+      _communityView = communityView;
+    }
+  }
 
   /// The ID of the community.
   int get id => _community.id;

--- a/lib/shared/avatars/community_avatar.dart
+++ b/lib/shared/avatars/community_avatar.dart
@@ -61,7 +61,6 @@ class CommunityAvatar extends StatelessWidget {
     // Only set pictrs query parameters if the image URL is a pictrs URL and the image is not being proxied
     if (imageUri.path.contains('/pictrs/image/') && queryParameters.isNotEmpty) {
       imageUri = Uri.https(imageUri.host, imageUri.path, queryParameters);
-      debugPrint('imageUri with pictrs: $imageUri');
     }
 
     return CachedNetworkImage(


### PR DESCRIPTION
## Pull Request Description

This PR fixes an issue where the community metadata subscription indicator was not being applied properly. This was likely a regression from #1784 where I switched over to using `ThunderCommunity` for the `PostCommunityAndAuthor`.

The core issue was that I wasn't providing the `CommunityView`, which `ThunderCommunity` relies on to fetch the subscription status. To resolve this, I added a new `subscribed` parameter to `ThunderCommunity` which creates a stub `CommunityView` with the proper subscription status. This was done because `PostView` only includes `Community`, not `CommunityView`.

> Note: The stubbed `CommunityView` required me to enter some dummy data, but I did cross-check to ensure that the dummy data was not being used!

P.S. - I also upgraded our gradle distribution version from 8.7 to 8.10.2. I was having some issues when building (possibly due to some Android Studio changes). I'm not sure if this was also something you experienced @micahmo

<!--- Please describe what was changed -->

## Issue Being Fixed

<!-- Please describe the problem that is being fixed and, if applicable, reference a GitHub issue -->

Issue Number: N/A

## Screenshots / Recordings

<!-- This section is optional but highly recommended to show off your changes! -->

## Checklist

- [ ] If a new package was added, did you ensure it uses an appropriate license and is actively maintained?
- [ ] Did you use localized strings (and added appropriate descriptions) where applicable?
- [ ] Did you add `semanticLabel`s where applicable for accessibility?
