### PR TITLE
Refactor account bloc to use ThunderUser and ThunderCommunity

### DIFF
--- a/lib/account/account.dart
+++ b/lib/account/account.dart
@@ -1,1 +1,2 @@
+export 'bloc/account_bloc.dart';
 export 'pages/account_page.dart';

--- a/lib/account/bloc/account_bloc.dart
+++ b/lib/account/bloc/account_bloc.dart
@@ -3,21 +3,14 @@ import 'package:bloc_concurrency/bloc_concurrency.dart';
 import 'package:equatable/equatable.dart';
 import 'package:lemmy_api_client/v3.dart';
 
-import 'package:stream_transform/stream_transform.dart';
-
 import 'package:thunder/account/models/favourite.dart';
 import 'package:thunder/core/auth/helpers/fetch_account.dart';
 import 'package:thunder/core/models/models.dart';
 import 'package:thunder/core/singletons/lemmy_client.dart';
+import 'package:thunder/utils/error_messages.dart';
 
 part 'account_event.dart';
 part 'account_state.dart';
-
-const throttleDuration = Duration(seconds: 1);
-
-EventTransformer<E> throttleDroppable<E>(Duration duration) {
-  return (events, mapper) => droppable<E>().call(events.throttle(duration), mapper);
-}
 
 class AccountBloc extends Bloc<AccountEvent, AccountState> {
   AccountBloc() : super(const AccountState()) {
@@ -48,12 +41,12 @@ class AccountBloc extends Bloc<AccountEvent, AccountState> {
     await _getAccountSubscriptions(GetAccountSubscriptions(reload: event.reload), emit);
   }
 
-  /// Fetches the current account's information. This updates [personView] which holds moderated community information.
+  /// Fetches the current account's information.
   Future<void> _getAccountInformation(GetAccountInformation event, Emitter<AccountState> emit) async {
     final account = await fetchActiveProfileAccount();
 
     if (account == null || account.jwt == null) {
-      return emit(state.copyWith(status: AccountStatus.success, personView: null, moderates: [], reload: event.reload));
+      return emit(state.copyWith(status: AccountStatus.success, user: null, moderates: [], reload: event.reload));
     }
 
     try {
@@ -65,12 +58,19 @@ class AccountBloc extends Bloc<AccountEvent, AccountState> {
       // This eliminates an issue which has plagued me a lot which is that there's a race condition
       // with so many calls to GetAccountInformation, we can return success for the new and old account.
       if (response.personView.person.id == account.userId) {
-        return emit(state.copyWith(status: AccountStatus.success, personView: response.personView, moderates: response.moderates, reload: event.reload));
+        return emit(
+          state.copyWith(
+            status: AccountStatus.success,
+            user: ThunderUser(response.personView.person, userView: response.personView),
+            moderates: response.moderates.map((cmv) => ThunderCommunity(cmv.community)).toList(),
+            reload: event.reload,
+          ),
+        );
       } else {
-        return emit(state.copyWith(status: AccountStatus.success, personView: null, reload: event.reload));
+        return emit(state.copyWith(status: AccountStatus.success, user: null, reload: event.reload));
       }
     } catch (e) {
-      emit(state.copyWith(status: AccountStatus.failure, errorMessage: e.toString(), reload: event.reload));
+      emit(state.copyWith(status: AccountStatus.failure, error: getExceptionErrorMessage(e), reload: event.reload));
     }
   }
 
@@ -79,7 +79,7 @@ class AccountBloc extends Bloc<AccountEvent, AccountState> {
     final account = await fetchActiveProfileAccount();
 
     if (account == null || account.jwt == null) {
-      return emit(state.copyWith(status: AccountStatus.success, subscriptions: [], personView: null, reload: event.reload));
+      return emit(state.copyWith(status: AccountStatus.success, subscriptions: [], user: null, reload: event.reload));
     }
 
     try {
@@ -103,7 +103,7 @@ class AccountBloc extends Bloc<AccountEvent, AccountState> {
       subscriptions.sort((a, b) => a.title.toLowerCase().compareTo(b.title.toLowerCase()));
       return emit(state.copyWith(status: AccountStatus.success, subscriptions: subscriptions, reload: event.reload));
     } catch (e) {
-      emit(state.copyWith(status: AccountStatus.failure, errorMessage: e.toString(), reload: event.reload));
+      emit(state.copyWith(status: AccountStatus.failure, error: getExceptionErrorMessage(e), reload: event.reload));
     }
   }
 

--- a/lib/account/bloc/account_event.dart
+++ b/lib/account/bloc/account_event.dart
@@ -1,6 +1,7 @@
 part of 'account_bloc.dart';
 
 abstract class AccountEvent extends Equatable {
+  /// Whether to force a reload of the account information
   final bool reload;
 
   const AccountEvent({this.reload = true});

--- a/lib/account/bloc/account_state.dart
+++ b/lib/account/bloc/account_state.dart
@@ -8,16 +8,16 @@ class AccountState extends Equatable {
     this.subscriptions = const [],
     this.favorites = const [],
     this.moderates = const [],
-    this.personView,
-    this.errorMessage,
+    this.user,
+    this.error,
     this.reload = true,
   });
 
   /// The current status of the account
   final AccountStatus status;
 
-  /// The error message if the account failed to load
-  final String? errorMessage;
+  /// The user's information
+  final ThunderUser? user;
 
   /// The user's subscriptions if logged in
   final List<ThunderCommunity> subscriptions;
@@ -26,21 +26,21 @@ class AccountState extends Equatable {
   final List<ThunderCommunity> favorites;
 
   /// The user's moderated communities
-  final List<CommunityModeratorView> moderates;
-
-  /// The user's information
-  final PersonView? personView;
+  final List<ThunderCommunity> moderates;
 
   /// Whether changes to the account state should force a reload in certain parts of the app
   final bool reload;
+
+  /// The error message if the account failed to load
+  final String? error;
 
   AccountState copyWith({
     AccountStatus? status,
     List<ThunderCommunity>? subscriptions,
     List<ThunderCommunity>? favorites,
-    List<CommunityModeratorView>? moderates,
-    PersonView? personView,
-    String? errorMessage,
+    List<ThunderCommunity>? moderates,
+    ThunderUser? user,
+    String? error,
     bool? reload,
   }) {
     return AccountState(
@@ -48,12 +48,12 @@ class AccountState extends Equatable {
       subscriptions: subscriptions ?? this.subscriptions,
       favorites: favorites ?? this.favorites,
       moderates: moderates ?? this.moderates,
-      personView: personView ?? this.personView,
-      errorMessage: errorMessage ?? this.errorMessage,
+      user: user ?? this.user,
+      error: error ?? this.error,
       reload: reload ?? this.reload,
     );
   }
 
   @override
-  List<Object?> get props => [status, subscriptions, favorites, moderates, personView, errorMessage, reload];
+  List<Object?> get props => [status, subscriptions, favorites, moderates, user, error, reload];
 }

--- a/lib/account/widgets/account_placeholder.dart
+++ b/lib/account/widgets/account_placeholder.dart
@@ -1,16 +1,22 @@
 import 'package:flutter/material.dart';
+
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+
 import 'package:thunder/account/utils/profiles.dart';
 import 'package:thunder/thunder/bloc/thunder_bloc.dart';
 
+/// A widget that displays a placeholder when no user account is logged in.
+///
+/// The widget is used in the Account page to prompt the user to login to an account.
 class AccountPlaceholder extends StatelessWidget {
   const AccountPlaceholder({super.key});
 
   @override
   Widget build(BuildContext context) {
-    final ThemeData theme = Theme.of(context);
-    String anonymousInstance = context.watch<ThunderBloc>().state.currentAnonymousInstance ?? '';
+    final theme = Theme.of(context);
+    final l10n = AppLocalizations.of(context)!;
+    final instance = context.watch<ThunderBloc>().state.currentAnonymousInstance ?? '';
 
     return Center(
       child: Padding(
@@ -19,14 +25,14 @@ class AccountPlaceholder extends StatelessWidget {
           crossAxisAlignment: CrossAxisAlignment.center,
           mainAxisAlignment: MainAxisAlignment.center,
           children: [
-            Icon(Icons.people_rounded, size: 100, color: theme.dividerColor),
-            const SizedBox(height: 16),
-            Text(AppLocalizations.of(context)!.browsingAnonymously(anonymousInstance), textAlign: TextAlign.center),
-            Text(AppLocalizations.of(context)!.addAccountToSeeProfile, textAlign: TextAlign.center),
+            Icon(Icons.people_rounded, size: 100.0, color: theme.dividerColor),
+            const SizedBox(height: 16.0),
+            Text(l10n.browsingAnonymously(instance), textAlign: TextAlign.center),
+            Text(l10n.addAccountToSeeProfile, textAlign: TextAlign.center),
             const SizedBox(height: 24.0),
             ElevatedButton(
               style: ElevatedButton.styleFrom(minimumSize: const Size.fromHeight(60)),
-              child: Text(AppLocalizations.of(context)!.manageAccounts),
+              child: Text(l10n.manageAccounts),
               onPressed: () => showProfileModalSheet(context),
             )
           ],

--- a/lib/comment/widgets/comment_card_header/comment_card_header.dart
+++ b/lib/comment/widgets/comment_card_header/comment_card_header.dart
@@ -50,7 +50,7 @@ class CommentCardHeader extends StatelessWidget {
 
     final theme = Theme.of(context);
 
-    final accountId = context.select((AccountBloc bloc) => bloc.state.personView?.person.id);
+    final accountId = context.select((AccountBloc bloc) => bloc.state.user?.id);
     final collapseParentCommentOnGesture = context.select((ThunderBloc bloc) => bloc.state.collapseParentCommentOnGesture);
     final commentShowUserInstance = context.select((ThunderBloc bloc) => bloc.state.commentShowUserInstance);
     final saveColor = context.select((ThunderBloc bloc) => bloc.state.saveColor);

--- a/lib/community/widgets/community_drawer.dart
+++ b/lib/community/widgets/community_drawer.dart
@@ -61,7 +61,7 @@ class _CommunityDrawerState extends State<CommunityDrawer> {
 
     if (isLoggedIn) {
       final favoriteCommunityIds = accountState.favorites.map((community) => community.id).toSet();
-      final moderatedCommunityIds = accountState.moderates.map((cmv) => cmv.community.id).toSet();
+      final moderatedCommunityIds = accountState.moderates.map((community) => community.id).toSet();
       final filteredSubscriptions = accountState.subscriptions.where((community) => !favoriteCommunityIds.contains(community.id) && !moderatedCommunityIds.contains(community.id)).toList();
 
       subscriptions = filteredSubscriptions;
@@ -160,11 +160,7 @@ class UserDrawerItem extends StatelessWidget {
         onPressed: () => navigateToAccount?.call(),
         child: Row(
           children: [
-            if (accountState.personView?.person != null)
-              UserAvatar(
-                user: ThunderUser(accountState.personView!.person),
-                radius: 16.0,
-              ),
+            if (accountState.user != null) UserAvatar(user: accountState.user!, radius: 16.0),
             const SizedBox(width: 16.0),
             Column(
               crossAxisAlignment: CrossAxisAlignment.start,
@@ -180,7 +176,7 @@ class UserDrawerItem extends StatelessWidget {
                       const SizedBox(width: 5),
                     ],
                     Text(
-                      isLoggedIn ? accountState.personView?.person.name ?? '' : l10n.anonymous,
+                      isLoggedIn ? accountState.user?.username ?? '' : l10n.anonymous,
                       style: theme.textTheme.bodyMedium?.copyWith(fontWeight: FontWeight.w500),
                       maxLines: 1,
                       overflow: TextOverflow.ellipsis,
@@ -248,7 +244,7 @@ class FeedDrawerItems extends StatelessWidget {
             },
           ).toList(),
         ),
-        if (accountState.moderates.isNotEmpty || accountState.personView?.isAdmin == true)
+        if (accountState.moderates.isNotEmpty || accountState.user?.admin == true)
           DrawerItem(
             label: l10n.report(2),
             onTap: () {
@@ -340,7 +336,7 @@ class ModeratedCommunities extends StatelessWidget {
     AccountState accountState = context.watch<AccountBloc>().state;
     ThunderState thunderState = context.read<ThunderBloc>().state;
 
-    List<CommunityModeratorView> moderatedCommunities = accountState.moderates;
+    List<ThunderCommunity> moderatedCommunities = accountState.moderates;
 
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
@@ -357,10 +353,8 @@ class ModeratedCommunities extends StatelessWidget {
               physics: const NeverScrollableScrollPhysics(),
               itemCount: moderatedCommunities.length,
               itemBuilder: (context, index) {
-                final c = moderatedCommunities[index].community;
-                final community = ThunderCommunity(c);
-
-                final bool isCommunitySelected = feedState.communityId == community.id;
+                final community = moderatedCommunities[index];
+                final isCommunitySelected = feedState.communityId == community.id;
 
                 return TextButton(
                   style: TextButton.styleFrom(

--- a/lib/feed/widgets/feed_fab.dart
+++ b/lib/feed/widgets/feed_fab.dart
@@ -5,7 +5,6 @@ import 'package:flutter/services.dart';
 
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
-import 'package:lemmy_api_client/v3.dart';
 
 import 'package:thunder/account/bloc/account_bloc.dart';
 import 'package:thunder/core/auth/bloc/auth_bloc.dart';
@@ -62,7 +61,7 @@ class FeedFAB extends StatelessWidget {
     if (authState.isLoggedIn && isCommunityFeed) {
       final community = feedState.community;
 
-      if (community!.locked && !accountState.moderates.any((CommunityModeratorView cmv) => cmv.community.id == community.id)) {
+      if (community!.locked && !accountState.moderates.any((c) => c.id == community.id)) {
         isPostLocked = true;
       }
     }

--- a/lib/feed/widgets/feed_page_app_bar.dart
+++ b/lib/feed/widgets/feed_page_app_bar.dart
@@ -45,7 +45,7 @@ class FeedPageAppBar extends StatefulWidget {
 }
 
 class _FeedPageAppBarState extends State<FeedPageAppBar> {
-  Person? person;
+  ThunderUser? user;
 
   @override
   Widget build(BuildContext context) {
@@ -54,7 +54,7 @@ class _FeedPageAppBarState extends State<FeedPageAppBar> {
     final AuthState authState = context.read<AuthBloc>().state;
     final AccountState accountState = context.read<AccountBloc>().state;
 
-    person = accountState.reload ? accountState.personView?.person : person;
+    user = accountState.reload ? accountState.user : user;
 
     return SliverAppBar(
       pinned: !thunderBloc.state.hideTopBarOnScroll,
@@ -73,10 +73,10 @@ class _FeedPageAppBarState extends State<FeedPageAppBar> {
                     label: MaterialLocalizations.of(context).openAppDrawerTooltip,
                     child: Stack(
                       children: [
-                        if (person != null)
+                        if (user != null)
                           Align(
                             alignment: Alignment.center,
-                            child: UserAvatar(user: ThunderUser(person!)),
+                            child: UserAvatar(user: user!),
                           ),
                         Material(
                           color: Colors.transparent,

--- a/lib/moderator/view/report_page.dart
+++ b/lib/moderator/view/report_page.dart
@@ -335,7 +335,7 @@ class _ReportFeedViewState extends State<ReportFeedView> {
                                       children: [
                                         CommentReference(
                                           comment: commentView,
-                                          isOwnComment: commentView.creator.id == context.read<AccountBloc>().state.personView?.person.id,
+                                          isOwnComment: commentView.creator.id == context.read<AccountBloc>().state.user?.id,
                                           disableActions: true,
                                         ),
                                         Padding(

--- a/lib/search/pages/search_page.dart
+++ b/lib/search/pages/search_page.dart
@@ -190,8 +190,7 @@ class _SearchPageState extends State<SearchPage> with AutomaticKeepAliveClientMi
             final Account? activeProfile = await fetchActiveProfileAccount();
 
             // When account changes, that means our instance most likely changed, so reset search.
-            if (state.status == AccountStatus.success &&
-                    ((activeProfile?.userId == null && _previousUserId != null) || state.personView?.person.id == activeProfile?.userId && _previousUserId != state.personView?.person.id) ||
+            if (state.status == AccountStatus.success && ((activeProfile?.userId == null && _previousUserId != null) || state.user?.id == activeProfile?.userId && _previousUserId != state.user?.id) ||
                 (state.favorites.length != _previousFavoritesCount && _controller.text.isEmpty)) {
               _controller.clear();
               if (context.mounted) context.read<SearchBloc>().add(ResetSearch());

--- a/lib/settings/pages/filter_settings_page.dart
+++ b/lib/settings/pages/filter_settings_page.dart
@@ -197,7 +197,7 @@ class _FilterSettingsPageState extends State<FilterSettingsPage> with SingleTick
               ),
               onTap: () {
                 // Can only set discussion language if user is logged in
-                if (authState.isLoggedIn && accountState.status == AccountStatus.success && accountState.personView != null) {
+                if (authState.isLoggedIn && accountState.status == AccountStatus.success && accountState.user != null) {
                   navigateToSettingPage(context, LocalSettings.settingsPageAccountLanguages);
                 } else {
                   showThunderDialog(

--- a/lib/user/widgets/user_indicator.dart
+++ b/lib/user/widgets/user_indicator.dart
@@ -27,10 +27,10 @@ class _UserIndicatorState extends State<UserIndicator> {
   void initState() {
     super.initState();
 
-    final person = context.read<AccountBloc>().state.personView?.person;
+    final state = context.read<AccountBloc>().state;
 
-    if (person != null) {
-      setState(() => user = ThunderUser(person));
+    if (state.user != null) {
+      setState(() => user = state.user);
     } else {
       context.read<AccountBloc>().add(const GetAccountInformation());
     }
@@ -44,7 +44,7 @@ class _UserIndicatorState extends State<UserIndicator> {
       listenWhen: (previous, current) => previous.status != current.status,
       listener: (listenerContext, state) {
         if (state.status == AccountStatus.success) {
-          if (state.personView?.person != null) setState(() => user = ThunderUser(state.personView!.person));
+          if (state.user != null) setState(() => user = state.user);
         } else if (state.status != AccountStatus.loading) {
           setState(() => error = true);
         }


### PR DESCRIPTION
## Pull Request Description

This PR migrates some more of our logic over to internal models - this time focusing on the `AccountBloc`. In particular:
- `PersonView personView` -> `ThunderUser user`
- `CommunityModeratorView moderates` -> `ThunderCommunity moderates`

This PR also includes some minor cleanup and documentation for some widgets!

<!--- Please describe what was changed -->

## Issue Being Fixed

<!-- Please describe the problem that is being fixed and, if applicable, reference a GitHub issue -->

Issue Number: N/A

## Screenshots / Recordings

<!-- This section is optional but highly recommended to show off your changes! -->

## Checklist

- [ ] If a new package was added, did you ensure it uses an appropriate license and is actively maintained?
- [ ] Did you use localized strings (and added appropriate descriptions) where applicable?
- [ ] Did you add `semanticLabel`s where applicable for accessibility?
