### PR TITLE
Fix issue with thick comment depth indicator indentation

### DIFF
--- a/lib/comment/widgets/comment_card.dart
+++ b/lib/comment/widgets/comment_card.dart
@@ -7,6 +7,7 @@ import 'package:lemmy_api_client/v3.dart';
 
 import 'package:thunder/comment/enums/comment_action.dart';
 import 'package:thunder/comment/widgets/comment_depth_indicator.dart';
+import 'package:thunder/core/enums/nested_comment_indicator.dart';
 import 'package:thunder/utils/navigation.dart';
 import 'package:thunder/comment/widgets/comment_action_bottom_sheet.dart';
 import 'package:thunder/core/auth/bloc/auth_bloc.dart';
@@ -404,7 +405,7 @@ class _AdditionalCommentCardState extends State<AdditionalCommentCard> {
     return Container(
       decoration: CommentDepthIndicatorDecoration(context, level: widget.depth + 1, style: style, scheme: scheme),
       child: Container(
-        margin: EdgeInsets.only(left: widget.depth * 4.0),
+        margin: EdgeInsets.only(left: (style == NestedCommentIndicatorStyle.thick ? widget.depth + 1 : widget.depth) * 4.0),
         child: InkWell(
           onTap: () {
             setState(() => isLoading = true);

--- a/lib/comment/widgets/comment_depth_indicator.dart
+++ b/lib/comment/widgets/comment_depth_indicator.dart
@@ -68,7 +68,7 @@ class _BoxDecorationPainter extends BoxPainter {
   final CommentDepthIndicatorDecoration _decoration;
 
   static const double _spacing = 4.0;
-  static const double _offset = 2.0;
+  static const double _offset = 4.0;
 
   /// Paint the box decoration into the given location on the given canvas.
   @override
@@ -108,8 +108,8 @@ class _BoxDecorationPainter extends BoxPainter {
 
       // Draw only the current level of the comment indicator
       canvas.drawLine(
-        rect.translate(_decoration.level * _spacing - _offset, 0).topLeft,
-        rect.translate(_decoration.level * _spacing - _offset, 0).bottomLeft,
+        rect.translate(_decoration.level * _spacing + _offset, 0).topLeft,
+        rect.translate(_decoration.level * _spacing + _offset, 0).bottomLeft,
         paint,
       );
     }

--- a/lib/shared/comment_content.dart
+++ b/lib/shared/comment_content.dart
@@ -91,8 +91,8 @@ class _CommentContentState extends State<CommentContent> with SingleTickerProvid
     bool collapseParentCommentOnGesture = state.collapseParentCommentOnGesture;
     final ThemeData theme = Theme.of(context);
 
-    NestedCommentIndicatorStyle nestedCommentIndicatorStyle = state.nestedCommentIndicatorStyle;
-    NestedCommentIndicatorColor nestedCommentIndicatorColor = state.nestedCommentIndicatorColor;
+    final style = state.nestedCommentIndicatorStyle;
+    final scheme = state.nestedCommentIndicatorColor;
 
     return Container(
       decoration: widget.dragged
@@ -100,13 +100,13 @@ class _CommentContentState extends State<CommentContent> with SingleTickerProvid
           : CommentDepthIndicatorDecoration(
               context,
               level: widget.level,
-              style: nestedCommentIndicatorStyle,
-              scheme: nestedCommentIndicatorColor,
+              style: style,
+              scheme: scheme,
             ),
       child: ExcludeSemantics(
         excluding: widget.excludeSemantics,
         child: Container(
-          padding: widget.level > 0 ? EdgeInsets.only(left: (widget.level) * 4.0) : null,
+          padding: widget.level > 0 ? EdgeInsets.only(left: (style == NestedCommentIndicatorStyle.thick ? widget.level + 1 : widget.level) * 4.0) : null,
           child: AnimatedSize(
             duration: const Duration(milliseconds: 250),
             curve: Curves.easeInOutCubicEmphasized,


### PR DESCRIPTION
## Pull Request Description

This PR fixes an issue mentioned here: https://github.com/thunder-app/thunder/pull/1788#issuecomment-2763071492 where the thick comment indicator indentation was offset by one!

<!--- Please describe what was changed -->

## Issue Being Fixed

<!-- Please describe the problem that is being fixed and, if applicable, reference a GitHub issue -->

Issue Number: N/A

## Screenshots / Recordings

| Thin | Thick |
|-|-|
|![Screenshot_1743443531](https://github.com/user-attachments/assets/d605a5b5-9d23-4c45-bed6-0ae5816f93d2)|![Screenshot_1743443487](https://github.com/user-attachments/assets/171134a9-2ff5-4ee7-bbfb-12ab4bd29932)|
|![Screenshot_1743443450](https://github.com/user-attachments/assets/69ead795-ce20-4b4d-b6eb-c2bf39b8b097)|![Screenshot_1743443501](https://github.com/user-attachments/assets/70b2ab81-6486-4441-8bb3-aafd0a9b9f4c)|


<!-- This section is optional but highly recommended to show off your changes! -->

## Checklist

- [ ] If a new package was added, did you ensure it uses an appropriate license and is actively maintained?
- [ ] Did you use localized strings (and added appropriate descriptions) where applicable?
- [ ] Did you add `semanticLabel`s where applicable for accessibility?
