### PR TITLE
Refactor instance list entry and instance info response

### DIFF
--- a/lib/account/widgets/profile_modal_body.dart
+++ b/lib/account/widgets/profile_modal_body.dart
@@ -11,6 +11,7 @@ import 'package:swipeable_page_route/swipeable_page_route.dart';
 import 'package:thunder/account/models/account.dart';
 import 'package:thunder/account/pages/login_page.dart';
 import 'package:thunder/core/auth/bloc/auth_bloc.dart';
+import 'package:thunder/core/models/models.dart';
 import 'package:thunder/core/singletons/lemmy_client.dart';
 import 'package:thunder/core/theme/bloc/theme_bloc.dart';
 import 'package:thunder/thunder/bloc/thunder_bloc.dart';
@@ -743,14 +744,15 @@ class _ProfileSelectState extends State<ProfileSelect> {
 
   Future<void> fetchInstanceInfo(List<AccountExtended> accountsExtended) async {
     for (final account in accountsExtended) {
-      final GetInstanceInfoResponse instanceinfoResponse = await getInstanceInfo(account.instance).timeout(
+      final instanceInfo = await getInstanceInfo(account.instance).timeout(
         const Duration(seconds: 5),
-        onTimeout: () => const GetInstanceInfoResponse(success: false),
+        onTimeout: () => const ThunderInstanceInfo(success: false),
       );
+
       setState(() {
-        account.instanceIcon = instanceinfoResponse.icon;
-        account.version = instanceinfoResponse.version;
-        account.alive = instanceinfoResponse.success;
+        account.instanceIcon = instanceInfo.icon;
+        account.version = instanceInfo.version;
+        account.alive = instanceInfo.success;
       });
     }
   }
@@ -793,14 +795,15 @@ class _ProfileSelectState extends State<ProfileSelect> {
 
   Future<void> fetchAnonymousInstanceInfo(List<AnonymousInstanceExtended> anonymousInstancesExtended) async {
     for (final anonymousInstanceExtended in anonymousInstancesExtended) {
-      final GetInstanceInfoResponse instanceInfoResponse = await getInstanceInfo(anonymousInstanceExtended.anonymousInstance.instance).timeout(
+      final instanceInfo = await getInstanceInfo(anonymousInstanceExtended.anonymousInstance.instance).timeout(
         const Duration(seconds: 5),
-        onTimeout: () => const GetInstanceInfoResponse(success: false),
+        onTimeout: () => const ThunderInstanceInfo(success: false),
       );
+
       setState(() {
-        anonymousInstanceExtended.instanceIcon = instanceInfoResponse.icon;
-        anonymousInstanceExtended.version = instanceInfoResponse.version;
-        anonymousInstanceExtended.alive = instanceInfoResponse.success;
+        anonymousInstanceExtended.instanceIcon = instanceInfo.icon;
+        anonymousInstanceExtended.version = instanceInfo.version;
+        anonymousInstanceExtended.alive = instanceInfo.success;
       });
     }
   }

--- a/lib/core/models/models.dart
+++ b/lib/core/models/models.dart
@@ -3,3 +3,4 @@ export 'thunder_user.dart';
 export 'thunder_instance.dart';
 export 'thunder_post.dart';
 export 'thunder_comment.dart';
+export 'thunder_instance_info.dart';

--- a/lib/core/models/thunder_instance.dart
+++ b/lib/core/models/thunder_instance.dart
@@ -4,13 +4,28 @@ class ThunderInstance {
   /// The Lemmy API model for the site.
   final Site _instance;
 
-  ThunderInstance(Site instance) : _instance = instance;
+  /// The Lemmy API model for the site view.
+  final SiteView? _instanceView;
 
+  ThunderInstance(Site instance, {SiteView? instanceView})
+      : _instance = instance,
+        _instanceView = instanceView;
+
+  /// The instance's icon.
   String? get icon => _instance.icon;
 
+  /// The name of the instance.
   String get name => _instance.name;
 
+  /// The description of the instance.
   String? get description => _instance.description;
 
+  /// The instance's sidebar information.
   String? get sidebar => _instance.sidebar;
+
+  /// The total number of users on the instance.
+  int? get users => _instanceView?.counts.users;
+
+  /// The URL to the instance. This is generally associated with the ActivityPub actor URL.
+  String get url => _instance.actorId;
 }

--- a/lib/core/models/thunder_instance_info.dart
+++ b/lib/core/models/thunder_instance_info.dart
@@ -1,0 +1,34 @@
+class ThunderInstanceInfo {
+  const ThunderInstanceInfo({
+    this.id,
+    this.domain,
+    this.version,
+    this.name,
+    this.icon,
+    this.users,
+    this.success = false,
+  });
+
+  bool isMetadataPopulated() => icon != null || version != null || name != null || users != null;
+
+  /// The ID of the instance.
+  final int? id;
+
+  /// The domain of the instance.
+  final String? domain;
+
+  /// The Lemmy version of the instance.
+  final String? version;
+
+  /// The name of the instance.
+  final String? name;
+
+  /// The icon of the instance.
+  final String? icon;
+
+  /// The number of users on the instance.
+  final int? users;
+
+  /// Whether the instance was successfully fetched.
+  final bool success;
+}

--- a/lib/feed/widgets/tagline.dart
+++ b/lib/feed/widgets/tagline.dart
@@ -6,7 +6,6 @@ import 'package:expandable/expandable.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 
-import 'package:thunder/core/auth/bloc/auth_bloc.dart';
 import 'package:thunder/core/singletons/lemmy_client.dart';
 import 'package:thunder/shared/common_markdown_body.dart';
 import 'package:thunder/thunder/bloc/thunder_bloc.dart';

--- a/lib/instance/widgets/instance_list_entry.dart
+++ b/lib/instance/widgets/instance_list_entry.dart
@@ -1,16 +1,18 @@
 import 'package:flutter/material.dart';
+
+import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+import 'package:thunder/core/models/models.dart';
+
 import 'package:thunder/utils/navigation.dart';
 import 'package:thunder/shared/avatars/instance_avatar.dart';
-import 'package:thunder/utils/instance.dart';
 import 'package:thunder/utils/numbers.dart';
-import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 
 /// Creates a widget which can display a summary of an instance for a list.
 /// Note that this is only Stateful so that it can be useful within an AnimatedContainer.
 class InstanceListEntry extends StatefulWidget {
-  final GetInstanceInfoResponse instance;
+  final ThunderInstanceInfo instanceInfo;
 
-  const InstanceListEntry({super.key, required this.instance});
+  const InstanceListEntry({super.key, required this.instanceInfo});
 
   @override
   State<InstanceListEntry> createState() => _InstanceListEntryState();
@@ -19,42 +21,37 @@ class InstanceListEntry extends StatefulWidget {
 class _InstanceListEntryState extends State<InstanceListEntry> {
   @override
   Widget build(BuildContext context) {
-    final AppLocalizations l10n = AppLocalizations.of(context)!;
+    final l10n = AppLocalizations.of(context)!;
+    final instanceInfo = widget.instanceInfo;
+
+    final name = instanceInfo.name;
+    final domain = instanceInfo.domain ?? '';
+    final users = instanceInfo.users ?? 0;
+    final version = instanceInfo.version;
+
+    if (!instanceInfo.success) {
+      return ListTile(
+        leading: InstanceAvatar(instance: instanceInfo),
+        title: Text(name ?? domain, overflow: TextOverflow.ellipsis),
+        subtitle: Wrap(children: [
+          Text(domain, overflow: TextOverflow.ellipsis),
+          Text(' · ${l10n.unreachable}'),
+        ]),
+        onTap: null,
+      );
+    }
 
     return ListTile(
-      leading: InstanceAvatar(instance: widget.instance),
-      title: Text(
-        widget.instance.name ?? widget.instance.domain ?? '',
-        overflow: TextOverflow.ellipsis,
-      ),
+      leading: InstanceAvatar(instance: instanceInfo),
+      title: Text(name ?? domain, overflow: TextOverflow.ellipsis),
       subtitle: Wrap(
         children: [
-          Text(
-            widget.instance.domain ?? '',
-            overflow: TextOverflow.ellipsis,
-          ),
-          if (widget.instance.users != null)
-            Text(
-              ' · ${l10n.countUsers(formatLongNumber(widget.instance.users ?? 0))}',
-              semanticsLabel: l10n.countUsers(widget.instance.users ?? 0),
-            ),
-          if (widget.instance.version?.isNotEmpty == true)
-            Text(
-              ' · v${widget.instance.version}',
-              semanticsLabel: 'v${widget.instance.version}',
-            ),
-          if (!widget.instance.success) Text(' · ${l10n.unreachable}'),
+          Text(domain, overflow: TextOverflow.ellipsis),
+          if (instanceInfo.users != null) Text(' · ${l10n.countUsers(formatLongNumber(users))}', semanticsLabel: l10n.countUsers(users)),
+          if (version?.isNotEmpty == true) Text(' · v$version', semanticsLabel: 'v$version'),
         ],
       ),
-      onTap: widget.instance.success
-          ? () {
-              navigateToInstancePage(
-                context,
-                instanceHost: widget.instance.domain ?? '',
-                instanceId: widget.instance.id,
-              );
-            }
-          : null,
+      onTap: () => navigateToInstancePage(context, instanceHost: domain, instanceId: instanceInfo.id),
     );
   }
 }

--- a/lib/search/bloc/search_bloc.dart
+++ b/lib/search/bloc/search_bloc.dart
@@ -84,7 +84,8 @@ class SearchBloc extends Bloc<SearchEvent, SearchState> {
       LemmyApiV3 lemmy = LemmyClient.instance.lemmyApiV3;
 
       SearchResponse? searchResponse;
-      List<GetInstanceInfoResponse> instances = [];
+      List<ThunderInstanceInfo> instances = [];
+
       if (event.searchType == MetaSearchType.instances) {
         // Retrieve all the federated instances from this instance.
         GetFederatedInstancesResponse getFederatedInstancesResponse = await LemmyClient.instance.lemmyApiV3.run(GetFederatedInstances(auth: account?.jwt));
@@ -99,16 +100,16 @@ class SearchBloc extends Bloc<SearchEvent, SearchState> {
                   instance.domain.contains(event.query),
             ) ??
             []) {
-          instances.add(GetInstanceInfoResponse(success: true, domain: instance.domain, id: instance.id));
+          instances.add(ThunderInstanceInfo(success: true, domain: instance.domain, id: instance.id));
         }
 
         // Put the initial, full list in the UI now
         emit(state.copyWith(status: SearchStatus.success, instances: instances, viewingAll: event.query.isEmpty));
 
         // Now go through and fill the rest of the information about the instances. Periodically update the UI with this info.
-        for (final MapEntry<int, GetInstanceInfoResponse> entry in instances.asMap().entries) {
+        for (final MapEntry<int, ThunderInstanceInfo> entry in instances.asMap().entries) {
           // Use a lower timeout so we're not waiting forever.
-          final GetInstanceInfoResponse newInstanceInfo = await getInstanceInfo(
+          final newInstanceInfo = await getInstanceInfo(
             entry.value.domain,
             id: entry.value.id,
             timeout: const Duration(seconds: 1),
@@ -117,7 +118,7 @@ class SearchBloc extends Bloc<SearchEvent, SearchState> {
           if (newInstanceInfo.success) {
             instances[entry.key] = newInstanceInfo;
           } else {
-            instances[entry.key] = GetInstanceInfoResponse(success: false, domain: entry.value.domain, id: entry.value.id);
+            instances[entry.key] = ThunderInstanceInfo(success: false, domain: entry.value.domain, id: entry.value.id);
           }
 
           // To avoid rebuilding too often, we'll invoke a rebuild for every 10 instances we process or when we reach the end.

--- a/lib/search/bloc/search_state.dart
+++ b/lib/search/bloc/search_state.dart
@@ -24,7 +24,7 @@ class SearchState extends Equatable {
   List<PersonView>? users;
   List<CommentView>? comments;
   List<PostViewMedia>? posts;
-  List<GetInstanceInfoResponse>? instances;
+  List<ThunderInstanceInfo>? instances;
 
   final String? errorMessage;
 
@@ -41,7 +41,7 @@ class SearchState extends Equatable {
     List<PersonView>? users,
     List<CommentView>? comments,
     List<PostViewMedia>? posts,
-    List<GetInstanceInfoResponse>? instances,
+    List<ThunderInstanceInfo>? instances,
     String? errorMessage,
     int? page,
     SortType? sortType,

--- a/lib/search/pages/search_page.dart
+++ b/lib/search/pages/search_page.dart
@@ -799,14 +799,14 @@ class _SearchPageState extends State<SearchPage> with AutomaticKeepAliveClientMi
               controller: _scrollController,
               itemCount: state.instances!.length,
               itemBuilder: (BuildContext context, int index) {
-                final GetInstanceInfoResponse instance = state.instances![index];
+                final instanceInfo = state.instances![index];
                 return AnimatedCrossFade(
                   duration: const Duration(milliseconds: 250),
-                  firstChild: InstanceListEntry(instance: GetInstanceInfoResponse(success: instance.success, domain: instance.domain, id: instance.id)),
-                  secondChild: InstanceListEntry(instance: instance),
+                  firstChild: InstanceListEntry(instanceInfo: ThunderInstanceInfo(success: instanceInfo.success, domain: instanceInfo.domain, id: instanceInfo.id)),
+                  secondChild: InstanceListEntry(instanceInfo: instanceInfo),
                   // If the instance metadata is not fully populated, show one widget, otherwise show the other.
                   // This should allow the metadata to essentially "fade in".
-                  crossFadeState: instance.isMetadataPopulated() ? CrossFadeState.showSecond : CrossFadeState.showFirst,
+                  crossFadeState: instanceInfo.isMetadataPopulated() ? CrossFadeState.showSecond : CrossFadeState.showFirst,
                 );
               },
             ),

--- a/lib/search/utils/search_utils.dart
+++ b/lib/search/utils/search_utils.dart
@@ -3,7 +3,6 @@ import 'package:lemmy_api_client/v3.dart';
 import 'package:thunder/core/enums/meta_search_type.dart';
 import 'package:thunder/core/models/models.dart';
 import 'package:thunder/search/bloc/search_bloc.dart';
-import 'package:thunder/utils/instance.dart';
 
 /// Checks whether there are any results for the current given [searchType] in the [searchState] or the given [searchResponse].
 bool searchIsEmpty(MetaSearchType searchType, {SearchState? searchState, SearchResponse? searchResponse}) {
@@ -11,7 +10,7 @@ bool searchIsEmpty(MetaSearchType searchType, {SearchState? searchState, SearchR
   final List<PersonView>? users = searchState?.users ?? searchResponse?.users;
   final List<CommentView>? comments = searchState?.comments ?? searchResponse?.comments;
   final List<PostView>? posts = searchState?.posts?.map((pvm) => pvm.postView).toList() ?? searchResponse?.posts;
-  final List<GetInstanceInfoResponse>? instances = searchState?.instances;
+  final List<ThunderInstanceInfo>? instances = searchState?.instances;
 
   return switch (searchType) {
     MetaSearchType.communities => communities?.isNotEmpty != true,

--- a/lib/shared/avatars/community_avatar.dart
+++ b/lib/shared/avatars/community_avatar.dart
@@ -4,7 +4,6 @@ import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:cached_network_image/cached_network_image.dart';
 
 import 'package:thunder/core/models/models.dart';
-import 'package:thunder/utils/media/image.dart';
 
 /// A community avatar. Displays the associated community icon if available.
 ///

--- a/lib/shared/avatars/instance_avatar.dart
+++ b/lib/shared/avatars/instance_avatar.dart
@@ -1,12 +1,14 @@
-import 'package:cached_network_image/cached_network_image.dart';
 import 'package:flutter/material.dart';
-import 'package:thunder/utils/instance.dart';
+
+import 'package:cached_network_image/cached_network_image.dart';
+
+import 'package:thunder/core/models/models.dart';
 
 /// An instance avatar. Displays the associated instance icon if available.
 ///
 /// Otherwise, displays the first letter of the instance's name.
 class InstanceAvatar extends StatelessWidget {
-  final GetInstanceInfoResponse instance;
+  final ThunderInstanceInfo instance;
   final double radius;
 
   const InstanceAvatar({super.key, required this.instance, this.radius = 16.0});

--- a/lib/shared/avatars/user_avatar.dart
+++ b/lib/shared/avatars/user_avatar.dart
@@ -3,7 +3,6 @@ import 'package:flutter/material.dart';
 import 'package:cached_network_image/cached_network_image.dart';
 
 import 'package:thunder/core/models/models.dart';
-import 'package:thunder/utils/media/image.dart';
 
 /// A user avatar. Displays the associated user icon if available.
 ///

--- a/lib/utils/instance.dart
+++ b/lib/utils/instance.dart
@@ -2,6 +2,7 @@ import 'dart:collection';
 
 import 'package:flutter/material.dart';
 import 'package:lemmy_api_client/v3.dart';
+import 'package:thunder/core/models/models.dart';
 import 'package:thunder/core/singletons/lemmy_client.dart';
 import 'package:thunder/instances.dart';
 import 'package:thunder/shared/pages/loading_page.dart';
@@ -171,47 +172,29 @@ Future<int?> getLemmyCommentId(BuildContext context, String text) async {
   return null;
 }
 
-class GetInstanceInfoResponse {
-  final bool success;
-  final String? icon;
-  final String? version;
-  final String? name;
-  final String? domain;
-  final int? users;
-  final int? id;
-
-  const GetInstanceInfoResponse({
-    required this.success,
-    this.icon,
-    this.version,
-    this.name,
-    this.domain,
-    this.users,
-    this.id,
-  });
-
-  bool isMetadataPopulated() => icon != null || version != null || name != null || users != null;
-}
-
-Future<GetInstanceInfoResponse> getInstanceInfo(String? url, {int? id, Duration? timeout}) async {
-  if (url?.isEmpty ?? true) {
-    return const GetInstanceInfoResponse(success: false);
-  }
+/// Fetches the instance info for a given URL.
+///
+/// This includes the instance name, version, icon, and user count.
+/// If the URL is invalid or the instance is unreachable, it returns a default [ThunderInstanceInfo] with success set to false.
+Future<ThunderInstanceInfo> getInstanceInfo(String? url, {int? id, Duration? timeout}) async {
+  if (url?.isEmpty ?? true) return const ThunderInstanceInfo(success: false);
 
   try {
     final site = await LemmyApiV3(url!).run(const GetSite()).timeout(timeout ?? const Duration(seconds: 5));
-    return GetInstanceInfoResponse(
-      success: true,
-      icon: site.siteView.site.icon,
-      version: site.version,
-      name: site.siteView.site.name,
-      domain: fetchInstanceNameFromUrl(site.siteView.site.actorId),
-      users: site.siteView.counts.users,
+    final instance = ThunderInstance(site.siteView.site, instanceView: site.siteView);
+
+    return ThunderInstanceInfo(
       id: id,
+      domain: fetchInstanceNameFromUrl(instance.url),
+      version: site.version,
+      name: instance.name,
+      icon: instance.icon,
+      users: instance.users,
+      success: true,
     );
   } catch (e) {
     // Bad instances will throw an exception, so no icon
-    return const GetInstanceInfoResponse(success: false);
+    return const ThunderInstanceInfo(success: false);
   }
 }
 


### PR DESCRIPTION
## Pull Request Description

This PR moves the `GetInstanceInfoResponse` class into `ThunderInstanceInfo` and additionally, cleans up the `InstanceListEntry` widget!

<!--- Please describe what was changed -->

## Issue Being Fixed

<!-- Please describe the problem that is being fixed and, if applicable, reference a GitHub issue -->

Issue Number: N/A

## Screenshots / Recordings

<!-- This section is optional but highly recommended to show off your changes! -->

## Checklist

- [ ] If a new package was added, did you ensure it uses an appropriate license and is actively maintained?
- [ ] Did you use localized strings (and added appropriate descriptions) where applicable?
- [ ] Did you add `semanticLabel`s where applicable for accessibility?
