### PR TITLE
Show full username in private messages

### DIFF
--- a/lib/inbox/widgets/inbox_private_messages_view.dart
+++ b/lib/inbox/widgets/inbox_private_messages_view.dart
@@ -5,11 +5,14 @@ import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:lemmy_api_client/v3.dart';
 
 import 'package:thunder/comment/enums/comment_action.dart';
+import 'package:thunder/core/enums/font_scale.dart';
 import 'package:thunder/feed/view/feed_page.dart';
 import 'package:thunder/inbox/bloc/inbox_bloc.dart';
 import 'package:thunder/shared/common_markdown_body.dart';
 import 'package:thunder/shared/divider.dart';
+import 'package:thunder/shared/full_name_widgets.dart';
 import 'package:thunder/utils/date_time.dart';
+import 'package:thunder/utils/instance.dart';
 
 class InboxPrivateMessagesView extends StatefulWidget {
   final List<PrivateMessageView> privateMessages;
@@ -26,6 +29,7 @@ class _InboxPrivateMessagesViewState extends State<InboxPrivateMessagesView> {
     final l10n = AppLocalizations.of(context)!;
     final theme = Theme.of(context);
     final state = context.read<InboxBloc>().state;
+    final textStyle = theme.textTheme.bodyMedium;
 
     return Builder(builder: (context) {
       return CustomScrollView(
@@ -52,26 +56,37 @@ class _InboxPrivateMessagesViewState extends State<InboxPrivateMessagesView> {
                     crossAxisAlignment: CrossAxisAlignment.start,
                     children: [
                       Row(
-                        mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                        crossAxisAlignment: CrossAxisAlignment.start,
                         children: [
-                          Row(
-                            mainAxisSize: MainAxisSize.min,
-                            children: [
-                              Text(
-                                widget.privateMessages[index].creator.name,
-                                style: theme.textTheme.titleSmall?.copyWith(color: Colors.greenAccent),
-                              ),
-                              const Padding(
-                                padding: EdgeInsets.symmetric(horizontal: 8.0),
-                                child: Icon(Icons.arrow_forward_rounded, size: 14),
-                              ),
-                              Text(
-                                widget.privateMessages[index].recipient.name,
-                                style: theme.textTheme.titleSmall?.copyWith(color: Colors.greenAccent),
-                              ),
-                            ],
+                          Expanded(
+                            child: Wrap(
+                              crossAxisAlignment: WrapCrossAlignment.center,
+                              children: [
+                                UserFullNameWidget(
+                                  context,
+                                  widget.privateMessages[index].creator.name,
+                                  widget.privateMessages[index].creator.displayName,
+                                  fetchInstanceNameFromUrl(widget.privateMessages[index].creator.actorId),
+                                  includeInstance: true,
+                                ),
+                                const Padding(
+                                  padding: EdgeInsets.symmetric(horizontal: 8.0),
+                                  child: Icon(Icons.arrow_forward_rounded, size: 14),
+                                ),
+                                UserFullNameWidget(
+                                  context,
+                                  widget.privateMessages[index].recipient.name,
+                                  widget.privateMessages[index].recipient.displayName,
+                                  fetchInstanceNameFromUrl(widget.privateMessages[index].recipient.actorId),
+                                  includeInstance: true,
+                                ),
+                              ],
+                            ),
                           ),
-                          Text(formatTimeToString(dateTime: widget.privateMessages[index].privateMessage.published.toIso8601String()))
+                          Text(
+                            formatTimeToString(dateTime: widget.privateMessages[index].privateMessage.published.toIso8601String()),
+                            style: textStyle!.copyWith(fontSize: MediaQuery.textScalerOf(context).scale((textStyle.fontSize!) * (FontScale.base.textScaleFactor))),
+                          )
                         ],
                       ),
                       Padding(


### PR DESCRIPTION
## Pull Request Description

<!--- Please describe what was changed -->

This PR improves the private message widget to use our standard `UserFullNameWidget` so that we can see instance names, as well as respecting other settings related to color, weight, etc.

Notes:
- We know that our private message page could use an overhaul, but this was a nice easy change to knock out.
- I added wrapping in case the names are long. On a device with a normal DPI (i.e., not my emulator) or on an instance with a shorter name, everything should still be on one line as before.
- Please review without whitespace.

## Issue Being Fixed

<!-- Please describe the problem that is being fixed and, if applicable, reference a GitHub issue -->

Issue Number: #1818

## Screenshots / Recordings

<!-- This section is optional but highly recommended to show off your changes! -->

| Before | After |
|--------|--------|
| ![image](https://github.com/user-attachments/assets/518091f3-4a65-49f9-8840-7f209e4c61e7) | ![image](https://github.com/user-attachments/assets/5b5d083d-59fd-4d8a-b038-111f3ca01ace) | 

## Checklist

- [ ] If a new package was added, did you ensure it uses an appropriate license and is actively maintained?
- [ ] Did you use localized strings (and added appropriate descriptions) where applicable?
- [ ] Did you add `semanticLabel`s where applicable for accessibility?
