### PR TITLE
Fix issue where blocked user comments are attached to wrong comment tree

### DIFF
--- a/lib/comment/models/comment_node.dart
+++ b/lib/comment/models/comment_node.dart
@@ -46,11 +46,11 @@ class CommentNode {
   static void insertCommentNode(CommentNode root, String parentId, CommentNode commentNode) {
     CommentNode? parent = findCommentNode(root, parentId);
 
-    if (parent == null) {
+    if (parent == null && parentId == "0") {
       return root.addReply(commentNode);
     }
 
-    parent.addReply(commentNode);
+    parent?.addReply(commentNode);
   }
 
   /// A static helper method to find a comment node in the tree given its [id]. The [id] comes from [comment.path]


### PR DESCRIPTION
## Pull Request Description

This PR fixes an issue where comments are sometimes attached to the wrong parent comment. This primarily happens when a user is viewing a post containing comments for a blocked user.

Additional details:
Previously, we had logic to attach a comment to the root node if a parent comment was not found. This was to account for top-level comments that don't have a parent node.

```dart
if (parent == null) {
  return root.addReply(commentNode);
}
```

This logic doesn't work as expected in situations where there are blocked users. It turns out that blocking a user prevents the API from returning back their comments. However, any replies to the blocked user are returned back from the API. Due to this, the replies no longer have a parent node to attach to and is therefore attached to the root node.

To match parity with the web UI, I've added another condition to which requires the `parentId` to be `0` in order for us to attach the comment to the root node. Otherwise, the comment is disregarded if there is no parent node found.

I've verified this behaviour by blocking a user and comparing the results from Thunder to the one shown in the web UI and vice versa.

<!--- Please describe what was changed -->

## Issue Being Fixed

<!-- Please describe the problem that is being fixed and, if applicable, reference a GitHub issue -->

Issue Number: https://github.com/thunder-app/thunder/issues/1833

## Screenshots / Recordings

<!-- This section is optional but highly recommended to show off your changes! -->

## Checklist

- [ ] If a new package was added, did you ensure it uses an appropriate license and is actively maintained?
- [ ] Did you use localized strings (and added appropriate descriptions) where applicable?
- [ ] Did you add `semanticLabel`s where applicable for accessibility?
