### PR TITLE
Fix issue with non-image link previews

### DIFF
--- a/lib/shared/media/media_view.dart
+++ b/lib/shared/media/media_view.dart
@@ -311,7 +311,7 @@ class _MediaViewState extends State<MediaView> with TickerProviderStateMixin {
           constraints: BoxConstraints(
               maxHeight: switch (widget.viewMode) {
                 ViewMode.compact => ViewMode.compact.height,
-                ViewMode.comfortable => getMaxHeight() ?? double.infinity,
+                ViewMode.comfortable => getMaxHeight(),
               },
               minHeight: switch (widget.viewMode) {
                 ViewMode.compact => ViewMode.compact.height,

--- a/lib/shared/media/media_view.dart
+++ b/lib/shared/media/media_view.dart
@@ -15,6 +15,7 @@ import 'package:thunder/core/enums/media_type.dart';
 import 'package:thunder/post/enums/post_action.dart';
 import 'package:thunder/thunder/bloc/thunder_bloc.dart';
 import 'package:thunder/utils/links.dart';
+import 'package:thunder/utils/media/image.dart';
 import 'package:thunder/utils/media/video.dart';
 
 class MediaView extends StatefulWidget {
@@ -159,9 +160,11 @@ class _MediaViewState extends State<MediaView> with TickerProviderStateMixin {
 
   @override
   Widget build(BuildContext context) {
+    bool isImage = isImageUrl(widget.media.imageUrl ?? widget.media.mediaUrl ?? widget.media.originalUrl!);
+
     // If hiding thumbnails is enabled or if the media has no image URL (e.g., text or links with no images), we should display a link preview instead
     // This only applies for [ViewMode.comfortable]
-    if (widget.viewMode == ViewMode.comfortable && (widget.hideThumbnails || widget.media.imageUrl == null)) {
+    if (widget.viewMode == ViewMode.comfortable && (widget.hideThumbnails || !isImage)) {
       return LinkInformation(
         viewMode: widget.viewMode,
         originURL: widget.media.originalUrl,
@@ -308,7 +311,7 @@ class _MediaViewState extends State<MediaView> with TickerProviderStateMixin {
           constraints: BoxConstraints(
               maxHeight: switch (widget.viewMode) {
                 ViewMode.compact => ViewMode.compact.height,
-                ViewMode.comfortable => getMaxHeight(),
+                ViewMode.comfortable => getMaxHeight() ?? double.infinity,
               },
               minHeight: switch (widget.viewMode) {
                 ViewMode.compact => ViewMode.compact.height,


### PR DESCRIPTION
## Pull Request Description

This PR fixes an issue where links with no image previews were not being displayed properly.

<!--- Please describe what was changed -->

## Issue Being Fixed

<!-- Please describe the problem that is being fixed and, if applicable, reference a GitHub issue -->

Issue Number: #1840

## Screenshots / Recordings

| Before | After |
|-|-|
|![Screenshot_1746396237](https://github.com/user-attachments/assets/02b26c0b-8be5-4baf-ab40-7943d31e66f3)|![Screenshot_1746396180](https://github.com/user-attachments/assets/b2144ed1-4a68-4547-8e86-2006459355cd)|

<!-- This section is optional but highly recommended to show off your changes! -->

## Checklist

- [ ] If a new package was added, did you ensure it uses an appropriate license and is actively maintained?
- [ ] Did you use localized strings (and added appropriate descriptions) where applicable?
- [ ] Did you add `semanticLabel`s where applicable for accessibility?
