### PR TITLE
Chore: Improve UserPreferences singleton usage

### DIFF
--- a/lib/account/bloc/profile_bloc.dart
+++ b/lib/account/bloc/profile_bloc.dart
@@ -147,7 +147,7 @@ class ProfileBloc extends Bloc<ProfileEvent, ProfileState> {
       if (account == null) return emit(state.copyWith(status: ProfileStatus.failure));
 
       // Set this account as the active account
-      final prefs = (await UserPreferences.instance).sharedPreferences;
+      final prefs = UserPreferences.instance.preferences;
       prefs.setString('active_profile_id', account.id);
 
       // Run the CheckAuth event to reset everything
@@ -169,7 +169,7 @@ class ProfileBloc extends Bloc<ProfileEvent, ProfileState> {
     emit(state.copyWith(status: ProfileStatus.loading, reload: event.reload));
 
     Account? account = await Account.fetchAccount(event.accountId);
-    final prefs = (await UserPreferences.instance).sharedPreferences;
+    final prefs = UserPreferences.instance.preferences;
 
     if (account != null) {
       // Set this account as the active account
@@ -193,7 +193,7 @@ class ProfileBloc extends Bloc<ProfileEvent, ProfileState> {
   Future<void> _removeProfile(RemoveProfile event, Emitter<ProfileState> emit) async {
     emit(state.copyWith(status: ProfileStatus.loading));
 
-    final prefs = (await UserPreferences.instance).sharedPreferences;
+    final prefs = UserPreferences.instance.preferences;
 
     final account = await fetchActiveProfile();
     await Account.deleteAccount(event.accountId);

--- a/lib/account/utils/profiles.dart
+++ b/lib/account/utils/profiles.dart
@@ -13,7 +13,7 @@ import 'package:thunder/account/account.dart';
 /// It will first try to find an active account. If that fails, then it will check for an anonymous account.
 /// If no anonymous account is found, it will create a new default anonymous account.
 Future<Account> fetchActiveProfile() async {
-  final prefs = (await UserPreferences.instance).sharedPreferences;
+  final prefs = UserPreferences.instance.preferences;
   final accountId = prefs.getString('active_profile_id');
 
   Account? account = await Account.fetchAccount(accountId ?? '');

--- a/lib/core/database/migrations.dart
+++ b/lib/core/database/migrations.dart
@@ -41,7 +41,7 @@ Future<bool> migrateToSQLite(AppDatabase database, {Database? originalDB, bool d
       // Check if there's an active user, and switch the account if so
       SharedPreferences? prefs;
 
-      if (Platform.isAndroid || Platform.isIOS) prefs = (await UserPreferences.instance).sharedPreferences;
+      if (Platform.isAndroid || Platform.isIOS) prefs = UserPreferences.instance.preferences;
 
       for (Map<String, dynamic> record in data['accounts']) {
         int accountId = await database.into(database.accounts).insert(AccountsCompanion.insert(

--- a/lib/core/singletons/preferences.dart
+++ b/lib/core/singletons/preferences.dart
@@ -5,80 +5,164 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter_file_dialog/flutter_file_dialog.dart';
 import 'package:path_provider/path_provider.dart';
 import 'package:shared_preferences/shared_preferences.dart';
+
 import 'package:thunder/core/enums/local_settings.dart';
 
+/// A singleton class to manage user preferences using SharedPreferences.
+///
+/// This class provides methods to fetch, update, export, and import user settings.
 class UserPreferences {
-  late SharedPreferences sharedPreferences;
+  /// The instance of SharedPreferences used internally.
+  late SharedPreferences preferences;
 
-  static Future<UserPreferences> fetchPreferences() async {
-    _preferences ??= UserPreferences()..sharedPreferences = await SharedPreferences.getInstance();
-    return _preferences!;
+  // Private constructor that can only be used within this class
+  UserPreferences._();
+
+  // Single instance of the class
+  static final UserPreferences _instance = UserPreferences._();
+
+  // Public getter to access the singleton instance
+  static UserPreferences get instance => _instance;
+
+  // Initialize the SharedPreferences instance
+  Future<void> initialize() async {
+    preferences = await SharedPreferences.getInstance();
   }
 
-  static UserPreferences? _preferences;
-
-  static Future<UserPreferences> get instance => fetchPreferences();
-
+  /// Returns the file path for the JSON file used for exporting preferences.
   static Future<String> _getJsonFilePath() async {
     final directory = await getApplicationDocumentsDirectory();
     return '${directory.path}/thunder_prefs.json';
   }
 
-  // Export SharedPreferences data to selected JSON file
+  /// Exports SharedPreferences data to a JSON file and filters out settings that are excluded from import/export.
+  ///
+  /// Returns the file path of the exported JSON file or null if the operation is canceled.
+  /// Throws exceptions if file operations fail.
   static Future<String?> exportToJson() async {
-    SharedPreferences prefs = await SharedPreferences.getInstance();
-    Map<String, dynamic> data = prefs.getKeys().where((key) => !LocalSettings.importExportExcludedSettings.any((excluded) => key.startsWith(excluded.name))).fold({}, (prev, key) {
-      prev[key] = prefs.get(key);
-      return prev;
-    });
+    try {
+      final prefs = instance.preferences;
 
-    String jsonData = json.encode(data);
-    String filePath = await _getJsonFilePath();
-
-    final file = File(filePath);
-    await file.writeAsString(jsonData);
-
-    return await FlutterFileDialog.saveFile(
-      params: SaveFileDialogParams(
-        mimeTypesFilter: ['application/json'],
-        sourceFilePath: filePath,
-        fileName: 'thunder_prefs.json',
-      ),
-    );
-  }
-
-  // Import JSON data from selected file to SharedPreferences
-  static Future<bool> importFromJson() async {
-    final filePath = await FlutterFileDialog.pickFile(
-      params: const OpenFileDialogParams(
-        fileExtensionsFilter: ['json'],
-      ),
-    );
-
-    if (filePath != null) {
-      final file = File(filePath);
-      String jsonData = await file.readAsString();
-      Map<String, dynamic> data = json.decode(jsonData);
-
-      SharedPreferences prefs = await SharedPreferences.getInstance();
-
-      data.forEach((key, value) {
-        if (value is int) {
-          prefs.setInt(key, value);
-        } else if (value is double) {
-          prefs.setDouble(key, value);
-        } else if (value is bool) {
-          prefs.setBool(key, value);
-        } else if (value is String) {
-          prefs.setString(key, value);
-        }
+      Map<String, dynamic> data = prefs.getKeys().where((key) => !LocalSettings.importExportExcludedSettings.any((excluded) => key.startsWith(excluded.name))).fold({}, (prev, key) {
+        prev[key] = prefs.get(key);
+        return prev;
       });
 
-      return true;
-    } else {
-      debugPrint("Import operation cancelled by user.");
+      String jsonData = json.encode(data);
+      String filePath = await _getJsonFilePath();
+
+      final file = File(filePath);
+      await file.writeAsString(jsonData);
+
+      return await FlutterFileDialog.saveFile(
+        params: SaveFileDialogParams(
+          mimeTypesFilter: ['application/json'],
+          sourceFilePath: filePath,
+          fileName: 'thunder_prefs.json',
+        ),
+      );
+    } catch (e) {
+      debugPrint('Error exporting preferences: $e');
+      return null;
+    }
+  }
+
+  /// Imports JSON data from a selected file into SharedPreferences.
+  ///
+  /// Returns true if the import is successful, false otherwise.
+  static Future<bool> importFromJson() async {
+    try {
+      final filePath = await FlutterFileDialog.pickFile(
+        params: const OpenFileDialogParams(
+          fileExtensionsFilter: ['json'],
+        ),
+      );
+
+      if (filePath != null) {
+        final file = File(filePath);
+        String jsonData = await file.readAsString();
+        Map<String, dynamic> data = json.decode(jsonData);
+
+        final prefs = instance.preferences;
+
+        data.forEach((key, value) {
+          _setValue(prefs, key, value);
+        });
+
+        return true;
+      } else {
+        debugPrint("Import operation cancelled by user.");
+      }
+    } catch (e) {
+      debugPrint('Error importing preferences: $e');
+    }
+    return false;
+  }
+
+  /// Helper method to set a value in SharedPreferences based on its type
+  static void _setValue(SharedPreferences prefs, String key, dynamic value) {
+    if (value is int) {
+      prefs.setInt(key, value);
+    } else if (value is double) {
+      prefs.setDouble(key, value);
+    } else if (value is bool) {
+      prefs.setBool(key, value);
+    } else if (value is String) {
+      prefs.setString(key, value);
+    } else if (value is List<String>) {
+      prefs.setStringList(key, value);
+    }
+  }
+
+  /// Fetches the value of a specific LocalSetting.
+  ///
+  /// Returns the value of the setting or null if not found.
+  /// Type parameter T should match the expected type of the setting.
+  static T? getLocalSetting<T>(LocalSettings setting) {
+    final prefs = instance.preferences;
+    final value = prefs.get(setting.name);
+
+    if (value != null && value is T) {
+      return value as T;
     }
 
-    return false;
+    return null;
+  }
+
+  /// Updates or sets the value of a specific LocalSetting.
+  ///
+  /// Throws an [ArgumentError] if the value type is unsupported.
+  static Future<void> setSetting<T>(LocalSettings setting, T value) async {
+    final prefs = instance.preferences;
+
+    if (value is int) {
+      await prefs.setInt(setting.name, value);
+    } else if (value is double) {
+      await prefs.setDouble(setting.name, value);
+    } else if (value is bool) {
+      await prefs.setBool(setting.name, value);
+    } else if (value is String) {
+      await prefs.setString(setting.name, value);
+    } else if (value is List<String>) {
+      await prefs.setStringList(setting.name, value);
+    } else {
+      throw ArgumentError('Unsupported value type: ${value.runtimeType}');
+    }
+  }
+
+  /// Removes a specific LocalSetting.
+  ///
+  /// Returns true if the setting was successfully removed, false otherwise.
+  static Future<bool> removeSetting(LocalSettings setting) async {
+    final prefs = instance.preferences;
+    return await prefs.remove(setting.name);
+  }
+
+  /// Clears all preferences.
+  ///
+  /// Returns true if preferences were successfully cleared, false otherwise.
+  static Future<bool> clearAllPreferences() async {
+    final prefs = instance.preferences;
+    return await prefs.clear();
   }
 }

--- a/lib/core/theme/bloc/theme_bloc.dart
+++ b/lib/core/theme/bloc/theme_bloc.dart
@@ -5,7 +5,6 @@ import 'package:bloc/bloc.dart';
 import 'package:equatable/equatable.dart';
 import 'package:bloc_concurrency/bloc_concurrency.dart';
 
-import 'package:shared_preferences/shared_preferences.dart';
 import 'package:stream_transform/stream_transform.dart';
 import 'package:thunder/core/enums/custom_theme_type.dart';
 import 'package:thunder/core/enums/local_settings.dart';
@@ -33,24 +32,22 @@ class ThemeBloc extends Bloc<ThemeEvent, ThemeState> {
     try {
       emit(state.copyWith(status: ThemeStatus.loading));
 
-      SharedPreferences prefs = (await UserPreferences.instance).sharedPreferences;
-
       // Fetch the ThemeType from preferences (system, light, dark)
-      ThemeType themeType = ThemeType.values[prefs.getInt(LocalSettings.appTheme.name) ?? ThemeType.system.index];
+      ThemeType themeType = ThemeType.values[UserPreferences.getLocalSetting(LocalSettings.appTheme) ?? ThemeType.system.index];
       Brightness brightness = SchedulerBinding.instance.platformDispatcher.platformBrightness;
 
       // Check if the user has selected to use a pure black theme, if so override the themeType to pureBlack
-      bool usePureBlackTheme = prefs.getBool(LocalSettings.usePureBlackTheme.name) ?? false;
+      bool usePureBlackTheme = UserPreferences.getLocalSetting(LocalSettings.usePureBlackTheme) ?? false;
       if (usePureBlackTheme && (themeType == ThemeType.dark || (themeType == ThemeType.system && brightness == Brightness.dark))) themeType = ThemeType.pureBlack;
 
       bool useDarkTheme = themeType == ThemeType.dark || themeType == ThemeType.pureBlack || (themeType == ThemeType.system && brightness == Brightness.dark);
 
-      CustomThemeType selectedTheme = CustomThemeType.values.byName(prefs.getString(LocalSettings.appThemeAccentColor.name) ?? CustomThemeType.deepBlue.name);
+      CustomThemeType selectedTheme = CustomThemeType.values.byName(UserPreferences.getLocalSetting(LocalSettings.appThemeAccentColor) ?? CustomThemeType.deepBlue.name);
 
-      bool useMaterialYouTheme = prefs.getBool(LocalSettings.useMaterialYouTheme.name) ?? false;
+      bool useMaterialYouTheme = UserPreferences.getLocalSetting(LocalSettings.useMaterialYouTheme) ?? false;
 
       // Fetch reduce animations preferences to remove overscrolling effects
-      bool reduceAnimations = prefs.getBool(LocalSettings.reduceAnimations.name) ?? false;
+      bool reduceAnimations = UserPreferences.getLocalSetting(LocalSettings.reduceAnimations) ?? false;
 
       return emit(
         state.copyWith(

--- a/lib/feed/utils/post.dart
+++ b/lib/feed/utils/post.dart
@@ -1,6 +1,5 @@
 import 'package:flutter/foundation.dart';
 import 'package:lemmy_api_client/v3.dart';
-import 'package:shared_preferences/shared_preferences.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 
 import 'package:thunder/account/account.dart';
@@ -31,8 +30,7 @@ Future<Map<String, dynamic>> fetchFeedItems({
   final account = await fetchActiveProfile();
   LemmyApiV3 lemmy = LemmyClient.instance.lemmyApiV3;
 
-  SharedPreferences prefs = (await UserPreferences.instance).sharedPreferences;
-  List<String> keywordFilters = prefs.getStringList(LocalSettings.keywordFilters.name) ?? [];
+  List<String> keywordFilters = UserPreferences.getLocalSetting(LocalSettings.keywordFilters) ?? [];
 
   int desiredPosts = 20;
   bool hasReachedPostsEnd = false;

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -20,7 +20,6 @@ import 'package:l10n_esperanto/l10n_esperanto.dart';
 import 'package:overlay_support/overlay_support.dart';
 import 'package:path/path.dart';
 import 'package:path_provider/path_provider.dart';
-import 'package:shared_preferences/shared_preferences.dart';
 
 // Project imports
 import 'package:thunder/account/account.dart';
@@ -76,6 +75,9 @@ void main() async {
   WidgetsBinding widgetsBinding = WidgetsFlutterBinding.ensureInitialized();
   FlutterNativeSplash.preserve(widgetsBinding: widgetsBinding);
 
+  // Initializes the UserPreferences singleton
+  await UserPreferences.instance.initialize();
+
   try {
     ByteData data = await PlatformAssetBundle().load('assets/ca/isrgrootx1.pem');
     SecurityContext.defaultContext.setTrustedCertificatesBytes(data.buffer.asUint8List());
@@ -96,7 +98,7 @@ void main() async {
     DartPingIOS.register();
   }
 
-  final String initialInstance = (await UserPreferences.instance).sharedPreferences.getString(LocalSettings.currentAnonymousInstance.name) ?? 'lemmy.ml';
+  final String initialInstance = UserPreferences.getLocalSetting(LocalSettings.currentAnonymousInstance) ?? 'lemmy.ml';
   LemmyClient.instance.changeBaseUrl(initialInstance);
 
   // Perform preference migrations
@@ -128,8 +130,7 @@ class _ThunderAppState extends State<ThunderApp> {
     super.initState();
 
     WidgetsBinding.instance.addPostFrameCallback((_) async {
-      SharedPreferences prefs = (await UserPreferences.instance).sharedPreferences;
-      String? inboxNotificationType = prefs.getString(LocalSettings.inboxNotificationType.name);
+      String? inboxNotificationType = UserPreferences.getLocalSetting(LocalSettings.inboxNotificationType);
 
       // If notification type is null, then don't perform any logic
       if (inboxNotificationType == null) return;
@@ -144,7 +145,7 @@ class _ThunderAppState extends State<ThunderApp> {
         bool success = await deleteAccountFromNotificationServer();
 
         if (success) {
-          prefs.remove(LocalSettings.inboxNotificationType.name);
+          UserPreferences.removeSetting(LocalSettings.inboxNotificationType);
           debugPrint('Removed tokens from notification server');
         }
       }

--- a/lib/notification/notifications.dart
+++ b/lib/notification/notifications.dart
@@ -7,7 +7,6 @@ import 'package:flutter/foundation.dart';
 
 // Package imports
 import 'package:flutter_local_notifications/flutter_local_notifications.dart';
-import 'package:shared_preferences/shared_preferences.dart';
 
 // Project imports
 import 'package:thunder/core/enums/local_settings.dart';
@@ -22,8 +21,7 @@ import 'package:thunder/notification/utils/unified_push.dart';
 ///
 /// The [controller] is passed in so that we can react to push notifications.
 Future<void> initPushNotificationLogic({required StreamController<NotificationResponse> controller}) async {
-  SharedPreferences prefs = (await UserPreferences.instance).sharedPreferences;
-  NotificationType notificationType = NotificationType.values.byName(prefs.getString(LocalSettings.inboxNotificationType.name) ?? NotificationType.none.name);
+  NotificationType notificationType = NotificationType.values.byName(UserPreferences.getLocalSetting(LocalSettings.inboxNotificationType) ?? NotificationType.none.name);
 
   debugPrint("Initializing push notifications for type: ${notificationType.name}");
 

--- a/lib/notification/shared/android_notification.dart
+++ b/lib/notification/shared/android_notification.dart
@@ -2,7 +2,6 @@
 import 'dart:convert';
 
 import 'package:flutter_local_notifications/flutter_local_notifications.dart';
-import 'package:shared_preferences/shared_preferences.dart';
 
 // Project imports
 import 'package:thunder/account/account.dart';
@@ -27,9 +26,8 @@ const String _testChannelName = 'Troubleshooting';
 /// to help display a group of notifications on Android.
 void showNotificationGroups({required NotificationType type, required List<Account> accounts, required List<NotificationInboxType> inboxTypes}) async {
   final FlutterLocalNotificationsPlugin flutterLocalNotificationsPlugin = FlutterLocalNotificationsPlugin();
-  final SharedPreferences prefs = (await UserPreferences.instance).sharedPreferences;
-  final FullNameSeparator userSeparator = FullNameSeparator.values.byName(prefs.getString(LocalSettings.userFormat.name) ?? FullNameSeparator.at.name);
-  final bool useDisplayNamesForUsers = prefs.getBool(LocalSettings.useDisplayNamesForUsers.name) ?? false;
+  final FullNameSeparator userSeparator = FullNameSeparator.values.byName(UserPreferences.getLocalSetting(LocalSettings.userFormat) ?? FullNameSeparator.at.name);
+  final bool useDisplayNamesForUsers = UserPreferences.getLocalSetting(LocalSettings.useDisplayNamesForUsers) ?? false;
 
   for (Account account in accounts) {
     for (NotificationInboxType inboxType in inboxTypes) {

--- a/lib/notification/shared/notification_server.dart
+++ b/lib/notification/shared/notification_server.dart
@@ -27,7 +27,7 @@ Future<bool> sendAuthTokenToNotificationServer({
   required String instance,
 }) async {
   try {
-    final prefs = (await UserPreferences.instance).sharedPreferences;
+    final prefs = UserPreferences.instance.preferences;
     String pushNotificationServer = prefs.getString(LocalSettings.pushNotificationServer.name) ?? THUNDER_SERVER_URL;
 
     // Send POST request to notification server
@@ -56,7 +56,7 @@ Future<bool> sendAuthTokenToNotificationServer({
 /// This is generally called when the user changes push notification types, or disables all push notifications.
 Future<bool> deleteAccountFromNotificationServer() async {
   try {
-    final prefs = (await UserPreferences.instance).sharedPreferences;
+    final prefs = UserPreferences.instance.preferences;
     String pushNotificationServer = prefs.getString(LocalSettings.pushNotificationServer.name) ?? THUNDER_SERVER_URL;
 
     List<Account> accounts = await Account.accounts();
@@ -79,7 +79,7 @@ Future<bool> deleteAccountFromNotificationServer() async {
 
 Future<bool> requestTestNotification() async {
   try {
-    final prefs = (await UserPreferences.instance).sharedPreferences;
+    final prefs = UserPreferences.instance.preferences;
     String pushNotificationServer = prefs.getString(LocalSettings.pushNotificationServer.name) ?? THUNDER_SERVER_URL;
 
     final l10n = AppLocalizations.of(GlobalContext.context)!;

--- a/lib/notification/utils/local_notifications.dart
+++ b/lib/notification/utils/local_notifications.dart
@@ -11,7 +11,6 @@ import 'package:flutter_local_notifications/flutter_local_notifications.dart';
 import 'package:html/parser.dart';
 import 'package:lemmy_api_client/v3.dart';
 import 'package:markdown/markdown.dart';
-import 'package:shared_preferences/shared_preferences.dart';
 
 // Project imports
 import 'package:thunder/account/account.dart';
@@ -50,11 +49,12 @@ Future<void> pollRepliesAndShowNotifications() async {
   // If we see this line outputted when notifications are disabled, then something is wrong with our configuration of background_fetch.
   debugPrint('Thunder - Background fetch - Running notification poll');
 
-  final SharedPreferences prefs = (await UserPreferences.instance).sharedPreferences;
-  final FullNameSeparator userSeparator = FullNameSeparator.values.byName(prefs.getString(LocalSettings.userFormat.name) ?? FullNameSeparator.at.name);
-  final FullNameSeparator communitySeparator = FullNameSeparator.values.byName(prefs.getString(LocalSettings.communityFormat.name) ?? FullNameSeparator.dot.name);
-  final bool useDisplayNamesForUsers = prefs.getBool(LocalSettings.useDisplayNamesForUsers.name) ?? false;
-  final bool useDisplayNamesForCommunities = prefs.getBool(LocalSettings.useDisplayNamesForCommunities.name) ?? false;
+  final FullNameSeparator userSeparator = FullNameSeparator.values.byName(UserPreferences.getLocalSetting(LocalSettings.userFormat) ?? FullNameSeparator.at.name);
+  final FullNameSeparator communitySeparator = FullNameSeparator.values.byName(UserPreferences.getLocalSetting(LocalSettings.communityFormat) ?? FullNameSeparator.dot.name);
+  final bool useDisplayNamesForUsers = UserPreferences.getLocalSetting(LocalSettings.useDisplayNamesForUsers) ?? false;
+  final bool useDisplayNamesForCommunities = UserPreferences.getLocalSetting(LocalSettings.useDisplayNamesForCommunities) ?? false;
+
+  final prefs = UserPreferences.instance.preferences;
 
   // Ensure that the db is initialized before attempting to access below.
   await initializeDatabase();

--- a/lib/notification/utils/notification_settings.dart
+++ b/lib/notification/utils/notification_settings.dart
@@ -28,7 +28,7 @@ Future<bool> updateNotificationSettings(
   Function? onUpdate,
 }) async {
   final l10n = AppLocalizations.of(context)!;
-  final prefs = (await UserPreferences.instance).sharedPreferences;
+  final prefs = UserPreferences.instance.preferences;
 
   // Disable background fetch and unregister unified push. This is only applied to Android. For iOS, simply deleting the token is enough.
   // The user should be aware that restarting the app is required to update their push notification settings

--- a/lib/notification/utils/unified_push.dart
+++ b/lib/notification/utils/unified_push.dart
@@ -10,7 +10,6 @@ import 'package:flutter/material.dart';
 import 'package:flutter_local_notifications/flutter_local_notifications.dart';
 import 'package:html/parser.dart';
 import 'package:lemmy_api_client/v3.dart';
-import 'package:shared_preferences/shared_preferences.dart';
 import 'package:thunder/comment/utils/comment.dart';
 import 'package:thunder/main.dart';
 import 'package:thunder/notification/shared/notification_payload.dart';
@@ -34,12 +33,13 @@ import 'package:thunder/utils/instance.dart';
 ///
 /// The [controller] is passed in so that we can react to push notifications when the user taps on the notification.
 void initUnifiedPushNotifications({required StreamController<NotificationResponse> controller}) async {
+  final prefs = UserPreferences.instance.preferences;
+
   UnifiedPush.initialize(
     onNewEndpoint: (String endpoint, String instance) async {
       debugPrint("Connected to new UnifiedPush endpoint: $instance @ $endpoint");
 
       // Save the endpoint to preferences so we can retrieve it later for troubleshooting
-      final SharedPreferences prefs = (await UserPreferences.instance).sharedPreferences;
       prefs.setString('unified_push_endpoint', endpoint);
 
       List<Account> accounts = await Account.accounts();
@@ -58,7 +58,6 @@ void initUnifiedPushNotifications({required StreamController<NotificationRespons
       debugPrint("UnifiedPush registration failed for $instance");
 
       // Clear the endpoint from preferences
-      final SharedPreferences prefs = (await UserPreferences.instance).sharedPreferences;
       prefs.remove('unified_push_endpoint');
 
       // We should remove any previously sent tokens, and send them again
@@ -69,7 +68,6 @@ void initUnifiedPushNotifications({required StreamController<NotificationRespons
       debugPrint("UnifiedPush unregistered from $instance");
 
       // Clear the endpoint from preferences
-      final SharedPreferences prefs = (await UserPreferences.instance).sharedPreferences;
       prefs.remove('unified_push_endpoint');
 
       // We should remove any previously sent tokens, and send them again
@@ -80,11 +78,10 @@ void initUnifiedPushNotifications({required StreamController<NotificationRespons
       // Ensure that the db is initialized before attempting to access below.
       await initializeDatabase();
 
-      final SharedPreferences prefs = (await UserPreferences.instance).sharedPreferences;
-      final FullNameSeparator userSeparator = FullNameSeparator.values.byName(prefs.getString(LocalSettings.userFormat.name) ?? FullNameSeparator.at.name);
-      final FullNameSeparator communitySeparator = FullNameSeparator.values.byName(prefs.getString(LocalSettings.communityFormat.name) ?? FullNameSeparator.dot.name);
-      final bool useDisplayNamesForUsers = prefs.getBool(LocalSettings.useDisplayNamesForUsers.name) ?? false;
-      final bool useDisplayNamesForCommunities = prefs.getBool(LocalSettings.useDisplayNamesForCommunities.name) ?? false;
+      final FullNameSeparator userSeparator = FullNameSeparator.values.byName(UserPreferences.getLocalSetting(LocalSettings.userFormat) ?? FullNameSeparator.at.name);
+      final FullNameSeparator communitySeparator = FullNameSeparator.values.byName(UserPreferences.getLocalSetting(LocalSettings.communityFormat) ?? FullNameSeparator.dot.name);
+      final bool useDisplayNamesForUsers = UserPreferences.getLocalSetting(LocalSettings.useDisplayNamesForUsers) ?? false;
+      final bool useDisplayNamesForCommunities = UserPreferences.getLocalSetting(LocalSettings.useDisplayNamesForCommunities) ?? false;
 
       final String decodedMessage = utf8.decode(message);
 

--- a/lib/post/bloc/post_bloc.dart
+++ b/lib/post/bloc/post_bloc.dart
@@ -6,7 +6,6 @@ import 'package:bloc_concurrency/bloc_concurrency.dart';
 import 'package:collection/collection.dart';
 import 'package:equatable/equatable.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
-import 'package:shared_preferences/shared_preferences.dart';
 import 'package:stream_transform/stream_transform.dart';
 import 'package:lemmy_api_client/v3.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
@@ -19,6 +18,7 @@ import 'package:thunder/core/models/models.dart';
 import 'package:thunder/comment/utils/comment.dart';
 import 'package:thunder/core/models/comment_view_tree.dart';
 import 'package:thunder/core/singletons/lemmy_client.dart';
+import 'package:thunder/core/singletons/preferences.dart';
 import 'package:thunder/utils/constants.dart';
 import 'package:thunder/utils/error_messages.dart';
 import 'package:thunder/utils/global_context.dart';
@@ -70,8 +70,7 @@ class PostBloc extends Bloc<PostEvent, PostState> {
     try {
       Object? exception;
 
-      SharedPreferences prefs = await SharedPreferences.getInstance();
-      CommentSortType defaultSortType = CommentSortType.values.byName(prefs.getString(LocalSettings.defaultCommentSortType.name)?.toLowerCase() ?? DEFAULT_COMMENT_SORT_TYPE.name);
+      CommentSortType defaultSortType = CommentSortType.values.byName(UserPreferences.getLocalSetting(LocalSettings.defaultCommentSortType)?.toLowerCase() ?? DEFAULT_COMMENT_SORT_TYPE.name);
       defaultSortType = LemmyClient.instance.supportsCommentSortType(defaultSortType) ? defaultSortType : DEFAULT_COMMENT_SORT_TYPE;
 
       final account = await fetchActiveProfile();
@@ -261,8 +260,7 @@ class PostBloc extends Bloc<PostEvent, PostState> {
 
     int attemptCount = 0;
 
-    SharedPreferences prefs = await SharedPreferences.getInstance();
-    CommentSortType defaultSortType = CommentSortType.values.byName(prefs.getString(LocalSettings.defaultCommentSortType.name)?.toLowerCase() ?? DEFAULT_COMMENT_SORT_TYPE.name);
+    CommentSortType defaultSortType = CommentSortType.values.byName(UserPreferences.getLocalSetting(LocalSettings.defaultCommentSortType)?.toLowerCase() ?? DEFAULT_COMMENT_SORT_TYPE.name);
     defaultSortType = LemmyClient.instance.supportsCommentSortType(defaultSortType) ? defaultSortType : DEFAULT_COMMENT_SORT_TYPE;
 
     CommentSortType sortType = event.sortType ?? (state.sortType ?? defaultSortType);

--- a/lib/post/utils/post.dart
+++ b/lib/post/utils/post.dart
@@ -1,7 +1,6 @@
 import 'package:flutter/material.dart';
 
 import 'package:lemmy_api_client/v3.dart';
-import 'package:shared_preferences/shared_preferences.dart';
 
 import 'package:thunder/account/account.dart';
 import 'package:thunder/core/enums/local_settings.dart';
@@ -234,7 +233,7 @@ Future<ThunderPost> savePost(ThunderPost post, bool save) async {
 
 /// Parse a post with media
 Future<List<ThunderPost>> parsePosts(List<PostView> postViews, {String? resolutionInstance}) async {
-  final prefs = (await UserPreferences.instance).sharedPreferences;
+  final prefs = UserPreferences.instance.preferences;
   final fetchImageDimensions = prefs.getBool(LocalSettings.showPostFullHeightImages.name) == true && prefs.getBool(LocalSettings.useCompactView.name) != true;
   final edgeToEdgeImages = prefs.getBool(LocalSettings.showPostEdgeToEdgeImages.name) ?? false;
   final tabletMode = prefs.getBool(LocalSettings.useTabletMode.name) ?? false;
@@ -324,8 +323,7 @@ Future<ThunderPost> parsePost(PostView postView, bool fetchImageDimensions, bool
   if (fetchImageDimensions && media.thumbnailUrl != null) {
     // If the instance does not contain image metadata, we'll do some additional checks
     try {
-      SharedPreferences prefs = (await UserPreferences.instance).sharedPreferences;
-      int imageDimensionTimeout = prefs.getInt(LocalSettings.imageDimensionTimeout.name) ?? 2;
+      int imageDimensionTimeout = UserPreferences.getLocalSetting(LocalSettings.imageDimensionTimeout) ?? 2;
 
       size = await retrieveImageDimensions(imageUrl: media.thumbnailUrl ?? media.mediaUrl).timeout(Duration(seconds: imageDimensionTimeout));
     } catch (e) {

--- a/lib/post/utils/post.dart
+++ b/lib/post/utils/post.dart
@@ -234,7 +234,7 @@ Future<ThunderPost> savePost(ThunderPost post, bool save) async {
 /// Parse a post with media
 Future<List<ThunderPost>> parsePosts(List<PostView> postViews, {String? resolutionInstance}) async {
   final prefs = UserPreferences.instance.preferences;
-  final fetchImageDimensions = prefs.getBool(LocalSettings.showPostFullHeightImages.name) == true && prefs.getBool(LocalSettings.useCompactView.name) != true;
+  final fetchImageDimensions = prefs.getBool(LocalSettings.showPostFullHeightImages.name) != false && prefs.getBool(LocalSettings.useCompactView.name) != true;
   final edgeToEdgeImages = prefs.getBool(LocalSettings.showPostEdgeToEdgeImages.name) ?? false;
   final tabletMode = prefs.getBool(LocalSettings.useTabletMode.name) ?? false;
   final hideNsfwPosts = prefs.getBool(LocalSettings.hideNsfwPosts.name) ?? false;

--- a/lib/search/pages/search_page.dart
+++ b/lib/search/pages/search_page.dart
@@ -11,7 +11,6 @@ import 'package:fading_edge_scrollview/fading_edge_scrollview.dart';
 import 'package:flex_color_scheme/flex_color_scheme.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:lemmy_api_client/v3.dart';
-import 'package:shared_preferences/shared_preferences.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 
 import 'package:thunder/account/account.dart';
@@ -63,7 +62,6 @@ class _SearchPageState extends State<SearchPage> with AutomaticKeepAliveClientMi
   final _scrollController = ScrollController(initialScrollOffset: 0);
   // This exists only because it is required by FadingEdgeScrollView
   final ScrollController _searchFiltersScrollController = ScrollController();
-  SharedPreferences? prefs;
   SortType sortType = SortType.active;
   IconData? sortTypeIcon;
   String? sortTypeLabel;
@@ -102,9 +100,8 @@ class _SearchPageState extends State<SearchPage> with AutomaticKeepAliveClientMi
   }
 
   Future<void> initPrefs() async {
-    prefs = (await UserPreferences.instance).sharedPreferences;
     setState(() {
-      sortType = SortType.values.byName(prefs!.getString("search_default_sort_type") ?? DEFAULT_SEARCH_SORT_TYPE.name);
+      sortType = SortType.values.byName(UserPreferences.instance.preferences.getString("search_default_sort_type") ?? DEFAULT_SEARCH_SORT_TYPE.name);
       final sortTypeItem = allSortTypeItems.firstWhere((sortTypeItem) => sortTypeItem.payload == sortType);
       sortTypeIcon = sortTypeItem.icon;
       sortTypeLabel = sortTypeItem.label;
@@ -849,7 +846,7 @@ class _SearchPageState extends State<SearchPage> with AutomaticKeepAliveClientMi
             sortTypeLabel = selected.label;
           });
 
-          prefs!.setString("search_default_sort_type", selected.payload.name);
+          UserPreferences.instance.preferences.setString("search_default_sort_type", selected.payload.name);
 
           _doSearch();
         },

--- a/lib/settings/pages/accessibility_settings_page.dart
+++ b/lib/settings/pages/accessibility_settings_page.dart
@@ -30,7 +30,7 @@ class _AccessibilitySettingsPageState extends State<AccessibilitySettingsPage> w
   LocalSettings? settingToHighlight;
 
   void setPreferences(attribute, value) async {
-    final prefs = (await UserPreferences.instance).sharedPreferences;
+    final prefs = UserPreferences.instance.preferences;
 
     switch (attribute) {
       case LocalSettings.reduceAnimations:
@@ -46,7 +46,7 @@ class _AccessibilitySettingsPageState extends State<AccessibilitySettingsPage> w
   }
 
   void _initPreferences() async {
-    final prefs = (await UserPreferences.instance).sharedPreferences;
+    final prefs = UserPreferences.instance.preferences;
 
     setState(() {
       reduceAnimations = prefs.getBool(LocalSettings.reduceAnimations.name) ?? false;

--- a/lib/settings/pages/comment_appearance_settings_page.dart
+++ b/lib/settings/pages/comment_appearance_settings_page.dart
@@ -62,7 +62,7 @@ class _CommentAppearanceSettingsPageState extends State<CommentAppearanceSetting
 
   /// Initialize the settings from the user's shared preferences
   Future<void> initPreferences() async {
-    final prefs = (await UserPreferences.instance).sharedPreferences;
+    final prefs = UserPreferences.instance.preferences;
 
     setState(() {
       showCommentButtonActions = prefs.getBool(LocalSettings.showCommentActionButtons.name) ?? false;
@@ -78,7 +78,7 @@ class _CommentAppearanceSettingsPageState extends State<CommentAppearanceSetting
 
   /// Given an attribute and the associated value, update the setting in the shared preferences
   void setPreferences(attribute, value) async {
-    final prefs = (await UserPreferences.instance).sharedPreferences;
+    final prefs = UserPreferences.instance.preferences;
 
     switch (attribute) {
       case LocalSettings.showCommentActionButtons:
@@ -112,7 +112,7 @@ class _CommentAppearanceSettingsPageState extends State<CommentAppearanceSetting
 
   /// Reset the comment preferences to their defaults
   void resetCommentPreferences() async {
-    final prefs = (await UserPreferences.instance).sharedPreferences;
+    final prefs = UserPreferences.instance.preferences;
 
     await prefs.remove(LocalSettings.showCommentActionButtons.name);
     await prefs.remove(LocalSettings.combineCommentScores.name);

--- a/lib/settings/pages/debug_settings_page.dart
+++ b/lib/settings/pages/debug_settings_page.dart
@@ -12,7 +12,6 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:extended_image/extended_image.dart';
 import 'package:path_provider/path_provider.dart';
 import 'package:sqflite/sqflite.dart';
-import 'package:shared_preferences/shared_preferences.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:thunder/core/enums/local_settings.dart';
 import 'package:thunder/core/singletons/preferences.dart';
@@ -67,7 +66,7 @@ class _DebugSettingsPageState extends State<DebugSettingsPage> {
   List<int> imageDimensionTimeouts = List.generate(10, (index) => index + 1);
 
   Future<void> setPreferences(attribute, value) async {
-    final prefs = (await UserPreferences.instance).sharedPreferences;
+    final prefs = UserPreferences.instance.preferences;
 
     switch (attribute) {
       case LocalSettings.enableExperimentalFeatures:
@@ -86,7 +85,7 @@ class _DebugSettingsPageState extends State<DebugSettingsPage> {
     super.initState();
 
     WidgetsBinding.instance.addPostFrameCallback((_) async {
-      final SharedPreferences prefs = (await UserPreferences.instance).sharedPreferences;
+      final prefs = UserPreferences.instance.preferences;
       inboxNotificationType = NotificationType.values.byName(prefs.getString(LocalSettings.inboxNotificationType.name) ?? NotificationType.none.name);
 
       if (!kIsWeb && Platform.isAndroid) {
@@ -208,15 +207,15 @@ class _DebugSettingsPageState extends State<DebugSettingsPage> {
                   contentText: l10n.deleteLocalPreferencesDescription,
                   onSecondaryButtonPressed: (dialogContext) => Navigator.of(dialogContext).pop(),
                   secondaryButtonText: l10n.cancel,
-                  onPrimaryButtonPressed: (dialogContext, _) {
-                    SharedPreferences.getInstance().then((prefs) async {
-                      await prefs.clear();
+                  onPrimaryButtonPressed: (dialogContext, _) async {
+                    final cleared = await UserPreferences.clearAllPreferences();
 
-                      if (context.mounted) {
-                        context.read<ThunderBloc>().add(UserPreferencesChangeEvent());
-                        showSnackbar(AppLocalizations.of(context)!.clearedUserPreferences);
-                      }
-                    });
+                    if (cleared) {
+                      context.read<ThunderBloc>().add(UserPreferencesChangeEvent());
+                      showSnackbar(AppLocalizations.of(context)!.clearedUserPreferences);
+                    } else {
+                      showSnackbar(AppLocalizations.of(context)!.failedToPerformAction);
+                    }
 
                     Navigator.of(dialogContext).pop();
                   },

--- a/lib/settings/pages/fab_settings_page.dart
+++ b/lib/settings/pages/fab_settings_page.dart
@@ -82,7 +82,7 @@ class _FabSettingsPage extends State<FabSettingsPage> with TickerProviderStateMi
   LocalSettings? settingToHighlight;
 
   void setPreferences(attribute, value) async {
-    final prefs = (await UserPreferences.instance).sharedPreferences;
+    final prefs = UserPreferences.instance.preferences;
 
     switch (attribute) {
       case LocalSettings.enableFeedsFab:
@@ -164,7 +164,7 @@ class _FabSettingsPage extends State<FabSettingsPage> with TickerProviderStateMi
   }
 
   void _initPreferences() async {
-    final prefs = (await UserPreferences.instance).sharedPreferences;
+    final prefs = UserPreferences.instance.preferences;
 
     setState(() {
       enableFeedsFab = prefs.getBool(LocalSettings.enableFeedsFab.name) ?? true;

--- a/lib/settings/pages/filter_settings_page.dart
+++ b/lib/settings/pages/filter_settings_page.dart
@@ -32,7 +32,7 @@ class _FilterSettingsPageState extends State<FilterSettingsPage> with SingleTick
   LocalSettings? settingToHighlight;
 
   void setPreferences(attribute, value) async {
-    final prefs = (await UserPreferences.instance).sharedPreferences;
+    final prefs = UserPreferences.instance.preferences;
 
     switch (attribute) {
       case LocalSettings.keywordFilters:
@@ -47,7 +47,7 @@ class _FilterSettingsPageState extends State<FilterSettingsPage> with SingleTick
   }
 
   void _initPreferences() async {
-    final prefs = (await UserPreferences.instance).sharedPreferences;
+    final prefs = UserPreferences.instance.preferences;
 
     setState(() {
       keywordFilters = prefs.getStringList(LocalSettings.keywordFilters.name) ?? [];

--- a/lib/settings/pages/general_settings_page.dart
+++ b/lib/settings/pages/general_settings_page.dart
@@ -150,7 +150,7 @@ class _GeneralSettingsPageState extends State<GeneralSettingsPage> with SingleTi
   bool enableExperimentalFeatures = false;
 
   Future<void> setPreferences(attribute, value) async {
-    final prefs = (await UserPreferences.instance).sharedPreferences;
+    final prefs = UserPreferences.instance.preferences;
 
     switch (attribute) {
       case LocalSettings.defaultFeedListType:
@@ -266,7 +266,7 @@ class _GeneralSettingsPageState extends State<GeneralSettingsPage> with SingleTi
   }
 
   void _initPreferences() async {
-    final prefs = (await UserPreferences.instance).sharedPreferences;
+    final prefs = UserPreferences.instance.preferences;
 
     // Get all currently active accounts
     List<Account> accountList = await Account.accounts();

--- a/lib/settings/pages/gesture_settings_page.dart
+++ b/lib/settings/pages/gesture_settings_page.dart
@@ -68,7 +68,7 @@ class _GestureSettingsPageState extends State<GestureSettingsPage> with TickerPr
   LocalSettings? settingToHighlight;
 
   void setPreferences(attribute, value) async {
-    final prefs = (await UserPreferences.instance).sharedPreferences;
+    final prefs = UserPreferences.instance.preferences;
 
     switch (attribute) {
       /// -------------------------- Gesture Related Settings --------------------------
@@ -136,7 +136,7 @@ class _GestureSettingsPageState extends State<GestureSettingsPage> with TickerPr
   }
 
   void _initPreferences() async {
-    final prefs = (await UserPreferences.instance).sharedPreferences;
+    final prefs = UserPreferences.instance.preferences;
 
     setState(() {
       /// -------------------------- Gesture Related Settings --------------------------

--- a/lib/settings/pages/post_appearance_settings_page.dart
+++ b/lib/settings/pages/post_appearance_settings_page.dart
@@ -133,7 +133,7 @@ class _PostAppearanceSettingsPageState extends State<PostAppearanceSettingsPage>
 
   /// Initialize the settings from the user's shared preferences
   Future<void> initPreferences() async {
-    final prefs = (await UserPreferences.instance).sharedPreferences;
+    final prefs = UserPreferences.instance.preferences;
 
     setState(() {
       // General Settings
@@ -175,7 +175,7 @@ class _PostAppearanceSettingsPageState extends State<PostAppearanceSettingsPage>
 
   /// Given an attribute and the associated value, update the setting in the shared preferences
   void setPreferences(attribute, value) async {
-    final prefs = (await UserPreferences.instance).sharedPreferences;
+    final prefs = UserPreferences.instance.preferences;
 
     switch (attribute) {
       case LocalSettings.useCompactView:
@@ -291,7 +291,7 @@ class _PostAppearanceSettingsPageState extends State<PostAppearanceSettingsPage>
 
   /// Reset the posts preferences to their defaults
   void resetPostPreferences() async {
-    final prefs = (await UserPreferences.instance).sharedPreferences;
+    final prefs = UserPreferences.instance.preferences;
 
     await prefs.remove(LocalSettings.useCompactView.name);
     await prefs.remove(LocalSettings.hideNsfwPreviews.name);

--- a/lib/settings/pages/theme_settings_page.dart
+++ b/lib/settings/pages/theme_settings_page.dart
@@ -105,7 +105,7 @@ class _ThemeSettingsPageState extends State<ThemeSettingsPage> {
   LocalSettings? settingToHighlight;
 
   Future<void> setPreferences(attribute, value) async {
-    final prefs = (await UserPreferences.instance).sharedPreferences;
+    final prefs = UserPreferences.instance.preferences;
 
     switch (attribute) {
       /// -------------------------- Theme Related Settings --------------------------
@@ -237,7 +237,7 @@ class _ThemeSettingsPageState extends State<ThemeSettingsPage> {
   }
 
   void _initPreferences() async {
-    final prefs = (await UserPreferences.instance).sharedPreferences;
+    final prefs = UserPreferences.instance.preferences;
 
     setState(() {
       /// -------------------------- Theme Related Settings --------------------------

--- a/lib/settings/pages/video_player_settings.dart
+++ b/lib/settings/pages/video_player_settings.dart
@@ -80,7 +80,7 @@ class _VideoPlayerSettingsPageState extends State<VideoPlayerSettingsPage> {
   }
 
   Future<void> setPreferences(attribute, value) async {
-    final prefs = (await UserPreferences.instance).sharedPreferences;
+    final prefs = UserPreferences.instance.preferences;
     switch (attribute) {
       case LocalSettings.videoAutoMute:
         await prefs.setBool(LocalSettings.videoAutoMute.name, value);
@@ -115,7 +115,7 @@ class _VideoPlayerSettingsPageState extends State<VideoPlayerSettingsPage> {
   }
 
   void _initPreferences() async {
-    final prefs = (await UserPreferences.instance).sharedPreferences;
+    final prefs = UserPreferences.instance.preferences;
     setState(() {
       videoAutoMute = prefs.getBool(LocalSettings.videoAutoMute.name) ?? true;
       videoAutoFullscreen = prefs.getBool(LocalSettings.videoAutoFullscreen.name) ?? false;

--- a/lib/settings/widgets/accessibility_profile.dart
+++ b/lib/settings/widgets/accessibility_profile.dart
@@ -2,7 +2,6 @@ import 'dart:async';
 
 import 'package:dynamic_color/dynamic_color.dart';
 import 'package:flutter/material.dart';
-import 'package:shared_preferences/shared_preferences.dart';
 import 'package:thunder/core/enums/local_settings.dart';
 import 'package:thunder/core/singletons/preferences.dart';
 import 'package:thunder/settings/widgets/expandable_option.dart';
@@ -58,11 +57,10 @@ class SettingProfile extends StatelessWidget {
                   ? null
                   : () async {
                       bool success = true;
-                      final SharedPreferences prefs = (await UserPreferences.instance).sharedPreferences;
 
                       for (MapEntry<LocalSettings, Object> entry in settingsToChange.entries) {
                         if (entry.value is bool) {
-                          await prefs.setBool(entry.key.name, entry.value as bool);
+                          await UserPreferences.instance.preferences.setBool(entry.key.name, entry.value as bool);
                         } else {
                           // This should never happen in production, since we should add support for any unsupported types
                           // before adding a profile containing those types.

--- a/lib/shared/share/advanced_share_sheet.dart
+++ b/lib/shared/share/advanced_share_sheet.dart
@@ -8,7 +8,6 @@ import 'package:flutter_cache_manager/flutter_cache_manager.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:screenshot/screenshot.dart';
 import 'package:share_plus/share_plus.dart';
-import 'package:shared_preferences/shared_preferences.dart';
 import 'package:thunder/core/enums/local_settings.dart';
 import 'package:thunder/core/enums/media_type.dart';
 import 'package:thunder/core/models/models.dart';
@@ -142,9 +141,8 @@ Future<Uint8List> generateShareImage(BuildContext context, AdvancedShareSheetOpt
 
 void showAdvancedShareSheet(BuildContext context, ThunderPost post) async {
   final ThemeData theme = Theme.of(context);
-  final SharedPreferences prefs = (await UserPreferences.instance).sharedPreferences;
 
-  String? optionsJson = prefs.getString(LocalSettings.advancedShareOptions.name);
+  String? optionsJson = UserPreferences.getLocalSetting(LocalSettings.advancedShareOptions);
   AdvancedShareSheetOptions options = optionsJson != null ? AdvancedShareSheetOptions.fromJson(jsonDecode(optionsJson)) : AdvancedShareSheetOptions();
 
   bool isDownloading = false;
@@ -326,7 +324,7 @@ void showAdvancedShareSheet(BuildContext context, ThunderPost post) async {
                                 onPressed: _canShare(options, post) && !isGeneratingImage
                                     ? () async {
                                         // Save the share settings
-                                        prefs.setString(LocalSettings.advancedShareOptions.name, jsonEncode(options.toJson()));
+                                        UserPreferences.setSetting(LocalSettings.advancedShareOptions, jsonEncode(options.toJson()));
 
                                         // Generate the text to share
                                         String? text;

--- a/lib/thunder/bloc/thunder_bloc.dart
+++ b/lib/thunder/bloc/thunder_bloc.dart
@@ -5,7 +5,6 @@ import 'package:flutter/material.dart';
 import 'package:intl/intl.dart';
 import 'package:lemmy_api_client/v3.dart';
 
-import 'package:shared_preferences/shared_preferences.dart';
 import 'package:stream_transform/stream_transform.dart';
 import 'package:thunder/core/enums/action_color.dart';
 import 'package:thunder/core/enums/browser_mode.dart';
@@ -85,186 +84,187 @@ class ThunderBloc extends Bloc<ThunderEvent, ThunderState> {
     try {
       emit(state.copyWith(status: ThunderStatus.refreshing));
 
-      SharedPreferences prefs = (await UserPreferences.instance).sharedPreferences;
-
       /// -------------------------- Feed Related Settings --------------------------
       // Default Listing/Sort Settings
       FeedListType defaultFeedListType = DEFAULT_LISTING_TYPE;
       SortType defaultSortType = DEFAULT_SORT_TYPE;
       try {
-        defaultFeedListType = FeedListType.values.byName(prefs.getString(LocalSettings.defaultFeedListType.name) ?? DEFAULT_LISTING_TYPE.name);
-        defaultSortType = SortType.values.byName(prefs.getString(LocalSettings.defaultFeedSortType.name) ?? DEFAULT_SORT_TYPE.name);
+        defaultFeedListType = FeedListType.values.byName(UserPreferences.getLocalSetting(LocalSettings.defaultFeedListType) ?? DEFAULT_LISTING_TYPE.name);
+        defaultSortType = SortType.values.byName(UserPreferences.getLocalSetting(LocalSettings.defaultFeedSortType) ?? DEFAULT_SORT_TYPE.name);
       } catch (e) {
         defaultFeedListType = FeedListType.values.byName(DEFAULT_LISTING_TYPE.name);
         defaultSortType = SortType.values.byName(DEFAULT_SORT_TYPE.name);
       }
 
-      bool useProfilePictureForDrawer = prefs.getBool(LocalSettings.useProfilePictureForDrawer.name) ?? false;
+      bool useProfilePictureForDrawer = UserPreferences.getLocalSetting(LocalSettings.useProfilePictureForDrawer) ?? false;
 
       // NSFW Settings
-      bool hideNsfwPosts = prefs.getBool(LocalSettings.hideNsfwPosts.name) ?? false;
-      bool hideNsfwPreviews = prefs.getBool(LocalSettings.hideNsfwPreviews.name) ?? true;
+      bool hideNsfwPosts = UserPreferences.getLocalSetting(LocalSettings.hideNsfwPosts) ?? false;
+      bool hideNsfwPreviews = UserPreferences.getLocalSetting(LocalSettings.hideNsfwPreviews) ?? true;
 
       // Tablet Settings
-      bool tabletMode = prefs.getBool(LocalSettings.useTabletMode.name) ?? false;
+      bool tabletMode = UserPreferences.getLocalSetting(LocalSettings.useTabletMode) ?? false;
 
       // General Settings
-      bool openInReaderMode = prefs.getBool(LocalSettings.openLinksInReaderMode.name) ?? false;
-      bool useDisplayNamesForUsers = prefs.getBool(LocalSettings.useDisplayNamesForUsers.name) ?? false;
-      bool useDisplayNamesForCommunities = prefs.getBool(LocalSettings.useDisplayNamesForCommunities.name) ?? false;
-      bool markPostReadOnMediaView = prefs.getBool(LocalSettings.markPostAsReadOnMediaView.name) ?? false;
-      bool markPostReadOnScroll = prefs.getBool(LocalSettings.markPostAsReadOnScroll.name) ?? false;
-      bool showInAppUpdateNotification = prefs.getBool(LocalSettings.showInAppUpdateNotification.name) ?? false;
-      bool showUpdateChangelogs = prefs.getBool(LocalSettings.showUpdateChangelogs.name) ?? true;
-      NotificationType inboxNotificationType = NotificationType.values.byName(prefs.getString(LocalSettings.inboxNotificationType.name) ?? NotificationType.none.name);
-      String? appLanguageCode = prefs.getString(LocalSettings.appLanguageCode.name) ?? 'en';
-      FullNameSeparator userSeparator = FullNameSeparator.values.byName(prefs.getString(LocalSettings.userFormat.name) ?? FullNameSeparator.at.name);
-      NameThickness userFullNameUserNameThickness = NameThickness.values.byName(prefs.getString(LocalSettings.userFullNameUserNameThickness.name) ?? NameThickness.normal.name);
-      NameColor userFullNameUserNameColor = NameColor.fromString(color: prefs.getString(LocalSettings.userFullNameUserNameColor.name) ?? NameColor.defaultColor);
-      NameThickness userFullNameInstanceNameThickness = NameThickness.values.byName(prefs.getString(LocalSettings.userFullNameInstanceNameThickness.name) ?? NameThickness.light.name);
-      NameColor userFullNameInstanceNameColor = NameColor.fromString(color: prefs.getString(LocalSettings.userFullNameInstanceNameColor.name) ?? NameColor.defaultColor);
-      FullNameSeparator communitySeparator = FullNameSeparator.values.byName(prefs.getString(LocalSettings.communityFormat.name) ?? FullNameSeparator.dot.name);
-      NameThickness communityFullNameCommunityNameThickness = NameThickness.values.byName(prefs.getString(LocalSettings.communityFullNameCommunityNameThickness.name) ?? NameThickness.normal.name);
-      NameColor communityFullNameCommunityNameColor = NameColor.fromString(color: prefs.getString(LocalSettings.communityFullNameCommunityNameColor.name) ?? NameColor.defaultColor);
-      NameThickness communityFullNameInstanceNameThickness = NameThickness.values.byName(prefs.getString(LocalSettings.communityFullNameInstanceNameThickness.name) ?? NameThickness.light.name);
-      NameColor communityFullNameInstanceNameColor = NameColor.fromString(color: prefs.getString(LocalSettings.communityFullNameInstanceNameColor.name) ?? NameColor.defaultColor);
-      ImageCachingMode imageCachingMode = ImageCachingMode.values.byName(prefs.getString(LocalSettings.imageCachingMode.name) ?? ImageCachingMode.relaxed.name);
-      bool showNavigationLabels = prefs.getBool(LocalSettings.showNavigationLabels.name) ?? true;
-      bool hideTopBarOnScroll = prefs.getBool(LocalSettings.hideTopBarOnScroll.name) ?? false;
-      bool showHiddenPosts = prefs.getBool(LocalSettings.showHiddenPosts.name) ?? false;
-      bool showExpandedTaglines = prefs.getBool(LocalSettings.showExpandedTaglines.name) ?? false;
+      bool openInReaderMode = UserPreferences.getLocalSetting(LocalSettings.openLinksInReaderMode) ?? false;
+      bool useDisplayNamesForUsers = UserPreferences.getLocalSetting(LocalSettings.useDisplayNamesForUsers) ?? false;
+      bool useDisplayNamesForCommunities = UserPreferences.getLocalSetting(LocalSettings.useDisplayNamesForCommunities) ?? false;
+      bool markPostReadOnMediaView = UserPreferences.getLocalSetting(LocalSettings.markPostAsReadOnMediaView) ?? false;
+      bool markPostReadOnScroll = UserPreferences.getLocalSetting(LocalSettings.markPostAsReadOnScroll) ?? false;
+      bool showInAppUpdateNotification = UserPreferences.getLocalSetting(LocalSettings.showInAppUpdateNotification) ?? false;
+      bool showUpdateChangelogs = UserPreferences.getLocalSetting(LocalSettings.showUpdateChangelogs) ?? true;
+      NotificationType inboxNotificationType = NotificationType.values.byName(UserPreferences.getLocalSetting(LocalSettings.inboxNotificationType) ?? NotificationType.none.name);
+      String? appLanguageCode = UserPreferences.getLocalSetting(LocalSettings.appLanguageCode) ?? 'en';
+      FullNameSeparator userSeparator = FullNameSeparator.values.byName(UserPreferences.getLocalSetting(LocalSettings.userFormat) ?? FullNameSeparator.at.name);
+      NameThickness userFullNameUserNameThickness = NameThickness.values.byName(UserPreferences.getLocalSetting(LocalSettings.userFullNameUserNameThickness) ?? NameThickness.normal.name);
+      NameColor userFullNameUserNameColor = NameColor.fromString(color: UserPreferences.getLocalSetting(LocalSettings.userFullNameUserNameColor) ?? NameColor.defaultColor);
+      NameThickness userFullNameInstanceNameThickness = NameThickness.values.byName(UserPreferences.getLocalSetting(LocalSettings.userFullNameInstanceNameThickness) ?? NameThickness.light.name);
+      NameColor userFullNameInstanceNameColor = NameColor.fromString(color: UserPreferences.getLocalSetting(LocalSettings.userFullNameInstanceNameColor) ?? NameColor.defaultColor);
+      FullNameSeparator communitySeparator = FullNameSeparator.values.byName(UserPreferences.getLocalSetting(LocalSettings.communityFormat) ?? FullNameSeparator.dot.name);
+      NameThickness communityFullNameCommunityNameThickness =
+          NameThickness.values.byName(UserPreferences.getLocalSetting(LocalSettings.communityFullNameCommunityNameThickness) ?? NameThickness.normal.name);
+      NameColor communityFullNameCommunityNameColor = NameColor.fromString(color: UserPreferences.getLocalSetting(LocalSettings.communityFullNameCommunityNameColor) ?? NameColor.defaultColor);
+      NameThickness communityFullNameInstanceNameThickness =
+          NameThickness.values.byName(UserPreferences.getLocalSetting(LocalSettings.communityFullNameInstanceNameThickness) ?? NameThickness.light.name);
+      NameColor communityFullNameInstanceNameColor = NameColor.fromString(color: UserPreferences.getLocalSetting(LocalSettings.communityFullNameInstanceNameColor) ?? NameColor.defaultColor);
+      ImageCachingMode imageCachingMode = ImageCachingMode.values.byName(UserPreferences.getLocalSetting(LocalSettings.imageCachingMode) ?? ImageCachingMode.relaxed.name);
+      bool showNavigationLabels = UserPreferences.getLocalSetting(LocalSettings.showNavigationLabels) ?? true;
+      bool hideTopBarOnScroll = UserPreferences.getLocalSetting(LocalSettings.hideTopBarOnScroll) ?? false;
+      bool showHiddenPosts = UserPreferences.getLocalSetting(LocalSettings.showHiddenPosts) ?? false;
+      bool showExpandedTaglines = UserPreferences.getLocalSetting(LocalSettings.showExpandedTaglines) ?? false;
 
-      BrowserMode browserMode = BrowserMode.values.byName(prefs.getString(LocalSettings.browserMode.name) ?? BrowserMode.customTabs.name);
+      BrowserMode browserMode = BrowserMode.values.byName(UserPreferences.getLocalSetting(LocalSettings.browserMode) ?? BrowserMode.customTabs.name);
 
       /// -------------------------- Feed Post Related Settings --------------------------
       // Compact Related Settings
-      bool useCompactView = prefs.getBool(LocalSettings.useCompactView.name) ?? false;
-      bool showTitleFirst = prefs.getBool(LocalSettings.showPostTitleFirst.name) ?? false;
-      bool hideThumbnails = prefs.getBool(LocalSettings.hideThumbnails.name) ?? false;
-      bool showThumbnailPreviewOnRight = prefs.getBool(LocalSettings.showThumbnailPreviewOnRight.name) ?? false;
-      bool showTextPostIndicator = prefs.getBool(LocalSettings.showTextPostIndicator.name) ?? false;
-      bool tappableAuthorCommunity = prefs.getBool(LocalSettings.tappableAuthorCommunity.name) ?? false;
+      bool useCompactView = UserPreferences.getLocalSetting(LocalSettings.useCompactView) ?? false;
+      bool showTitleFirst = UserPreferences.getLocalSetting(LocalSettings.showPostTitleFirst) ?? false;
+      bool hideThumbnails = UserPreferences.getLocalSetting(LocalSettings.hideThumbnails) ?? false;
+      bool showThumbnailPreviewOnRight = UserPreferences.getLocalSetting(LocalSettings.showThumbnailPreviewOnRight) ?? false;
+      bool showTextPostIndicator = UserPreferences.getLocalSetting(LocalSettings.showTextPostIndicator) ?? false;
+      bool tappableAuthorCommunity = UserPreferences.getLocalSetting(LocalSettings.tappableAuthorCommunity) ?? false;
 
       // General Settings
-      bool showVoteActions = prefs.getBool(LocalSettings.showPostVoteActions.name) ?? true;
-      bool showSaveAction = prefs.getBool(LocalSettings.showPostSaveAction.name) ?? true;
-      bool showCommunityIcons = prefs.getBool(LocalSettings.showPostCommunityIcons.name) ?? false;
-      bool showFullHeightImages = prefs.getBool(LocalSettings.showPostFullHeightImages.name) ?? true;
-      bool showEdgeToEdgeImages = prefs.getBool(LocalSettings.showPostEdgeToEdgeImages.name) ?? false;
-      bool showTextContent = prefs.getBool(LocalSettings.showPostTextContentPreview.name) ?? false;
-      bool showPostAuthor = prefs.getBool(LocalSettings.showPostAuthor.name) ?? false;
-      bool postShowUserInstance = prefs.getBool(LocalSettings.postShowUserInstance.name) ?? false;
-      bool scoreCounters = prefs.getBool(LocalSettings.scoreCounters.name) ?? false;
-      bool dimReadPosts = prefs.getBool(LocalSettings.dimReadPosts.name) ?? true;
-      bool showFullPostDate = prefs.getBool(LocalSettings.showFullPostDate.name) ?? false;
-      DateFormat dateFormat = DateFormat(prefs.getString(LocalSettings.dateFormat.name) ?? DateFormat.yMMMMd(Intl.systemLocale).add_jm().pattern);
-      FeedCardDividerThickness feedCardDividerThickness = FeedCardDividerThickness.values.byName(prefs.getString(LocalSettings.feedCardDividerThickness.name) ?? FeedCardDividerThickness.compact.name);
-      Color feedCardDividerColor = Color(prefs.getInt(LocalSettings.feedCardDividerColor.name) ?? Colors.transparent.value);
+      bool showVoteActions = UserPreferences.getLocalSetting(LocalSettings.showPostVoteActions) ?? true;
+      bool showSaveAction = UserPreferences.getLocalSetting(LocalSettings.showPostSaveAction) ?? true;
+      bool showCommunityIcons = UserPreferences.getLocalSetting(LocalSettings.showPostCommunityIcons) ?? false;
+      bool showFullHeightImages = UserPreferences.getLocalSetting(LocalSettings.showPostFullHeightImages) ?? true;
+      bool showEdgeToEdgeImages = UserPreferences.getLocalSetting(LocalSettings.showPostEdgeToEdgeImages) ?? false;
+      bool showTextContent = UserPreferences.getLocalSetting(LocalSettings.showPostTextContentPreview) ?? false;
+      bool showPostAuthor = UserPreferences.getLocalSetting(LocalSettings.showPostAuthor) ?? false;
+      bool postShowUserInstance = UserPreferences.getLocalSetting(LocalSettings.postShowUserInstance) ?? false;
+      bool scoreCounters = UserPreferences.getLocalSetting(LocalSettings.scoreCounters) ?? false;
+      bool dimReadPosts = UserPreferences.getLocalSetting(LocalSettings.dimReadPosts) ?? true;
+      bool showFullPostDate = UserPreferences.getLocalSetting(LocalSettings.showFullPostDate) ?? false;
+      DateFormat dateFormat = DateFormat(UserPreferences.getLocalSetting(LocalSettings.dateFormat) ?? DateFormat.yMMMMd(Intl.systemLocale).add_jm().pattern);
+      FeedCardDividerThickness feedCardDividerThickness =
+          FeedCardDividerThickness.values.byName(UserPreferences.getLocalSetting(LocalSettings.feedCardDividerThickness) ?? FeedCardDividerThickness.compact.name);
+      Color feedCardDividerColor = Color(UserPreferences.getLocalSetting(LocalSettings.feedCardDividerColor) ?? Colors.transparent.value);
       List<PostCardMetadataItem> compactPostCardMetadataItems =
-          prefs.getStringList(LocalSettings.compactPostCardMetadataItems.name)?.map((e) => PostCardMetadataItem.values.byName(e)).toList() ?? DEFAULT_COMPACT_POST_CARD_METADATA;
+          UserPreferences.getLocalSetting(LocalSettings.compactPostCardMetadataItems)?.map((e) => PostCardMetadataItem.values.byName(e)).toList() ?? DEFAULT_COMPACT_POST_CARD_METADATA;
       List<PostCardMetadataItem> cardPostCardMetadataItems =
-          prefs.getStringList(LocalSettings.cardPostCardMetadataItems.name)?.map((e) => PostCardMetadataItem.values.byName(e)).toList() ?? DEFAULT_CARD_POST_CARD_METADATA;
+          UserPreferences.getLocalSetting(LocalSettings.cardPostCardMetadataItems)?.map((e) => PostCardMetadataItem.values.byName(e)).toList() ?? DEFAULT_CARD_POST_CARD_METADATA;
 
       // Post body settings
-      bool showCrossPosts = prefs.getBool(LocalSettings.showCrossPosts.name) ?? true;
-      PostBodyViewType postBodyViewType = PostBodyViewType.values.byName(prefs.getString(LocalSettings.postBodyViewType.name) ?? PostBodyViewType.expanded.name);
-      bool postBodyShowUserInstance = prefs.getBool(LocalSettings.postBodyShowUserInstance.name) ?? false;
-      bool postBodyShowCommunityInstance = prefs.getBool(LocalSettings.postBodyShowCommunityInstance.name) ?? false;
-      bool postBodyShowCommunityAvatar = prefs.getBool(LocalSettings.postBodyShowCommunityAvatar.name) ?? false;
+      bool showCrossPosts = UserPreferences.getLocalSetting(LocalSettings.showCrossPosts) ?? true;
+      PostBodyViewType postBodyViewType = PostBodyViewType.values.byName(UserPreferences.getLocalSetting(LocalSettings.postBodyViewType) ?? PostBodyViewType.expanded.name);
+      bool postBodyShowUserInstance = UserPreferences.getLocalSetting(LocalSettings.postBodyShowUserInstance) ?? false;
+      bool postBodyShowCommunityInstance = UserPreferences.getLocalSetting(LocalSettings.postBodyShowCommunityInstance) ?? false;
+      bool postBodyShowCommunityAvatar = UserPreferences.getLocalSetting(LocalSettings.postBodyShowCommunityAvatar) ?? false;
 
-      List<String> keywordFilters = prefs.getStringList(LocalSettings.keywordFilters.name) ?? [];
+      List<String> keywordFilters = UserPreferences.getLocalSetting(LocalSettings.keywordFilters) ?? [];
 
       /// -------------------------- Post Page Related Settings --------------------------
       // Comment Related Settings
-      CommentSortType defaultCommentSortType = CommentSortType.values.byName(prefs.getString(LocalSettings.defaultCommentSortType.name) ?? DEFAULT_COMMENT_SORT_TYPE.name);
-      bool collapseParentCommentOnGesture = prefs.getBool(LocalSettings.collapseParentCommentBodyOnGesture.name) ?? true;
-      bool showCommentButtonActions = prefs.getBool(LocalSettings.showCommentActionButtons.name) ?? false;
-      bool commentShowUserInstance = prefs.getBool(LocalSettings.commentShowUserInstance.name) ?? false;
-      bool commentShowUserAvatar = prefs.getBool(LocalSettings.commentShowUserAvatar.name) ?? false;
-      bool combineCommentScores = prefs.getBool(LocalSettings.combineCommentScores.name) ?? false;
+      CommentSortType defaultCommentSortType = CommentSortType.values.byName(UserPreferences.getLocalSetting(LocalSettings.defaultCommentSortType) ?? DEFAULT_COMMENT_SORT_TYPE.name);
+      bool collapseParentCommentOnGesture = UserPreferences.getLocalSetting(LocalSettings.collapseParentCommentBodyOnGesture) ?? true;
+      bool showCommentButtonActions = UserPreferences.getLocalSetting(LocalSettings.showCommentActionButtons) ?? false;
+      bool commentShowUserInstance = UserPreferences.getLocalSetting(LocalSettings.commentShowUserInstance) ?? false;
+      bool commentShowUserAvatar = UserPreferences.getLocalSetting(LocalSettings.commentShowUserAvatar) ?? false;
+      bool combineCommentScores = UserPreferences.getLocalSetting(LocalSettings.combineCommentScores) ?? false;
       NestedCommentIndicatorStyle nestedCommentIndicatorStyle =
-          NestedCommentIndicatorStyle.values.byName(prefs.getString(LocalSettings.nestedCommentIndicatorStyle.name) ?? DEFAULT_NESTED_COMMENT_INDICATOR_STYLE.name);
+          NestedCommentIndicatorStyle.values.byName(UserPreferences.getLocalSetting(LocalSettings.nestedCommentIndicatorStyle) ?? DEFAULT_NESTED_COMMENT_INDICATOR_STYLE.name);
       NestedCommentIndicatorColor nestedCommentIndicatorColor =
-          NestedCommentIndicatorColor.values.byName(prefs.getString(LocalSettings.nestedCommentIndicatorColor.name) ?? DEFAULT_NESTED_COMMENT_INDICATOR_COLOR.name);
+          NestedCommentIndicatorColor.values.byName(UserPreferences.getLocalSetting(LocalSettings.nestedCommentIndicatorColor) ?? DEFAULT_NESTED_COMMENT_INDICATOR_COLOR.name);
 
       /// -------------------------- Theme Related Settings --------------------------
       // Theme Settings
-      ThemeType themeType = ThemeType.values[prefs.getInt(LocalSettings.appTheme.name) ?? ThemeType.system.index];
-      CustomThemeType selectedTheme = CustomThemeType.values.byName(prefs.getString(LocalSettings.appThemeAccentColor.name) ?? CustomThemeType.deepBlue.name);
-      bool useMaterialYouTheme = prefs.getBool(LocalSettings.useMaterialYouTheme.name) ?? false;
+      ThemeType themeType = ThemeType.values[UserPreferences.getLocalSetting(LocalSettings.appTheme) ?? ThemeType.system.index];
+      CustomThemeType selectedTheme = CustomThemeType.values.byName(UserPreferences.getLocalSetting(LocalSettings.appThemeAccentColor) ?? CustomThemeType.deepBlue.name);
+      bool useMaterialYouTheme = UserPreferences.getLocalSetting(LocalSettings.useMaterialYouTheme) ?? false;
 
       // Color Settings
-      ActionColor upvoteColor = ActionColor.fromString(colorRaw: prefs.getString(LocalSettings.upvoteColor.name) ?? ActionColor.orange);
-      ActionColor downvoteColor = ActionColor.fromString(colorRaw: prefs.getString(LocalSettings.downvoteColor.name) ?? ActionColor.blue);
-      ActionColor saveColor = ActionColor.fromString(colorRaw: prefs.getString(LocalSettings.saveColor.name) ?? ActionColor.purple);
-      ActionColor markReadColor = ActionColor.fromString(colorRaw: prefs.getString(LocalSettings.markReadColor.name) ?? ActionColor.teal);
-      ActionColor replyColor = ActionColor.fromString(colorRaw: prefs.getString(LocalSettings.replyColor.name) ?? ActionColor.green);
-      ActionColor hideColor = ActionColor.fromString(colorRaw: prefs.getString(LocalSettings.hideColor.name) ?? ActionColor.red);
+      ActionColor upvoteColor = ActionColor.fromString(colorRaw: UserPreferences.getLocalSetting(LocalSettings.upvoteColor) ?? ActionColor.orange);
+      ActionColor downvoteColor = ActionColor.fromString(colorRaw: UserPreferences.getLocalSetting(LocalSettings.downvoteColor) ?? ActionColor.blue);
+      ActionColor saveColor = ActionColor.fromString(colorRaw: UserPreferences.getLocalSetting(LocalSettings.saveColor) ?? ActionColor.purple);
+      ActionColor markReadColor = ActionColor.fromString(colorRaw: UserPreferences.getLocalSetting(LocalSettings.markReadColor) ?? ActionColor.teal);
+      ActionColor replyColor = ActionColor.fromString(colorRaw: UserPreferences.getLocalSetting(LocalSettings.replyColor) ?? ActionColor.green);
+      ActionColor hideColor = ActionColor.fromString(colorRaw: UserPreferences.getLocalSetting(LocalSettings.hideColor) ?? ActionColor.red);
 
       // Font Settings
-      FontScale titleFontSizeScale = FontScale.values.byName(prefs.getString(LocalSettings.titleFontSizeScale.name) ?? FontScale.base.name);
-      FontScale contentFontSizeScale = FontScale.values.byName(prefs.getString(LocalSettings.contentFontSizeScale.name) ?? FontScale.base.name);
-      FontScale commentFontSizeScale = FontScale.values.byName(prefs.getString(LocalSettings.commentFontSizeScale.name) ?? FontScale.base.name);
-      FontScale metadataFontSizeScale = FontScale.values.byName(prefs.getString(LocalSettings.metadataFontSizeScale.name) ?? FontScale.base.name);
+      FontScale titleFontSizeScale = FontScale.values.byName(UserPreferences.getLocalSetting(LocalSettings.titleFontSizeScale) ?? FontScale.base.name);
+      FontScale contentFontSizeScale = FontScale.values.byName(UserPreferences.getLocalSetting(LocalSettings.contentFontSizeScale) ?? FontScale.base.name);
+      FontScale commentFontSizeScale = FontScale.values.byName(UserPreferences.getLocalSetting(LocalSettings.commentFontSizeScale) ?? FontScale.base.name);
+      FontScale metadataFontSizeScale = FontScale.values.byName(UserPreferences.getLocalSetting(LocalSettings.metadataFontSizeScale) ?? FontScale.base.name);
 
       /// -------------------------- Gesture Related Settings --------------------------
       // Sidebar Gesture Settings
-      bool bottomNavBarSwipeGestures = prefs.getBool(LocalSettings.sidebarBottomNavBarSwipeGesture.name) ?? true;
-      bool bottomNavBarDoubleTapGestures = prefs.getBool(LocalSettings.sidebarBottomNavBarDoubleTapGesture.name) ?? false;
+      bool bottomNavBarSwipeGestures = UserPreferences.getLocalSetting(LocalSettings.sidebarBottomNavBarSwipeGesture) ?? true;
+      bool bottomNavBarDoubleTapGestures = UserPreferences.getLocalSetting(LocalSettings.sidebarBottomNavBarDoubleTapGesture) ?? false;
 
       // Post Gestures
-      bool enablePostGestures = prefs.getBool(LocalSettings.enablePostGestures.name) ?? true;
-      SwipeAction leftPrimaryPostGesture = SwipeAction.values.byName(prefs.getString(LocalSettings.postGestureLeftPrimary.name) ?? SwipeAction.upvote.name);
-      SwipeAction leftSecondaryPostGesture = SwipeAction.values.byName(prefs.getString(LocalSettings.postGestureLeftSecondary.name) ?? SwipeAction.downvote.name);
-      SwipeAction rightPrimaryPostGesture = SwipeAction.values.byName(prefs.getString(LocalSettings.postGestureRightPrimary.name) ?? SwipeAction.save.name);
-      SwipeAction rightSecondaryPostGesture = SwipeAction.values.byName(prefs.getString(LocalSettings.postGestureRightSecondary.name) ?? SwipeAction.toggleRead.name);
+      bool enablePostGestures = UserPreferences.getLocalSetting(LocalSettings.enablePostGestures) ?? true;
+      SwipeAction leftPrimaryPostGesture = SwipeAction.values.byName(UserPreferences.getLocalSetting(LocalSettings.postGestureLeftPrimary) ?? SwipeAction.upvote.name);
+      SwipeAction leftSecondaryPostGesture = SwipeAction.values.byName(UserPreferences.getLocalSetting(LocalSettings.postGestureLeftSecondary) ?? SwipeAction.downvote.name);
+      SwipeAction rightPrimaryPostGesture = SwipeAction.values.byName(UserPreferences.getLocalSetting(LocalSettings.postGestureRightPrimary) ?? SwipeAction.save.name);
+      SwipeAction rightSecondaryPostGesture = SwipeAction.values.byName(UserPreferences.getLocalSetting(LocalSettings.postGestureRightSecondary) ?? SwipeAction.toggleRead.name);
 
       // Comment Gestures
-      bool enableCommentGestures = prefs.getBool(LocalSettings.enableCommentGestures.name) ?? true;
-      SwipeAction leftPrimaryCommentGesture = SwipeAction.values.byName(prefs.getString(LocalSettings.commentGestureLeftPrimary.name) ?? SwipeAction.upvote.name);
-      SwipeAction leftSecondaryCommentGesture = SwipeAction.values.byName(prefs.getString(LocalSettings.commentGestureLeftSecondary.name) ?? SwipeAction.downvote.name);
-      SwipeAction rightPrimaryCommentGesture = SwipeAction.values.byName(prefs.getString(LocalSettings.commentGestureRightPrimary.name) ?? SwipeAction.reply.name);
-      SwipeAction rightSecondaryCommentGesture = SwipeAction.values.byName(prefs.getString(LocalSettings.commentGestureRightSecondary.name) ?? SwipeAction.save.name);
+      bool enableCommentGestures = UserPreferences.getLocalSetting(LocalSettings.enableCommentGestures) ?? true;
+      SwipeAction leftPrimaryCommentGesture = SwipeAction.values.byName(UserPreferences.getLocalSetting(LocalSettings.commentGestureLeftPrimary) ?? SwipeAction.upvote.name);
+      SwipeAction leftSecondaryCommentGesture = SwipeAction.values.byName(UserPreferences.getLocalSetting(LocalSettings.commentGestureLeftSecondary) ?? SwipeAction.downvote.name);
+      SwipeAction rightPrimaryCommentGesture = SwipeAction.values.byName(UserPreferences.getLocalSetting(LocalSettings.commentGestureRightPrimary) ?? SwipeAction.reply.name);
+      SwipeAction rightSecondaryCommentGesture = SwipeAction.values.byName(UserPreferences.getLocalSetting(LocalSettings.commentGestureRightSecondary) ?? SwipeAction.save.name);
 
-      bool enableFullScreenSwipeNavigationGesture = prefs.getBool(LocalSettings.enableFullScreenSwipeNavigationGesture.name) ?? true;
+      bool enableFullScreenSwipeNavigationGesture = UserPreferences.getLocalSetting(LocalSettings.enableFullScreenSwipeNavigationGesture) ?? true;
 
       /// -------------------------- FAB Related Settings --------------------------
-      bool enableFeedsFab = prefs.getBool(LocalSettings.enableFeedsFab.name) ?? true;
-      bool enablePostsFab = prefs.getBool(LocalSettings.enablePostsFab.name) ?? true;
+      bool enableFeedsFab = UserPreferences.getLocalSetting(LocalSettings.enableFeedsFab) ?? true;
+      bool enablePostsFab = UserPreferences.getLocalSetting(LocalSettings.enablePostsFab) ?? true;
 
-      bool enableBackToTop = prefs.getBool(LocalSettings.enableBackToTop.name) ?? true;
-      bool enableSubscriptions = prefs.getBool(LocalSettings.enableSubscriptions.name) ?? true;
-      bool enableRefresh = prefs.getBool(LocalSettings.enableRefresh.name) ?? true;
-      bool enableDismissRead = prefs.getBool(LocalSettings.enableDismissRead.name) ?? true;
-      bool enableChangeSort = prefs.getBool(LocalSettings.enableChangeSort.name) ?? true;
-      bool enableNewPost = prefs.getBool(LocalSettings.enableNewPost.name) ?? true;
+      bool enableBackToTop = UserPreferences.getLocalSetting(LocalSettings.enableBackToTop) ?? true;
+      bool enableSubscriptions = UserPreferences.getLocalSetting(LocalSettings.enableSubscriptions) ?? true;
+      bool enableRefresh = UserPreferences.getLocalSetting(LocalSettings.enableRefresh) ?? true;
+      bool enableDismissRead = UserPreferences.getLocalSetting(LocalSettings.enableDismissRead) ?? true;
+      bool enableChangeSort = UserPreferences.getLocalSetting(LocalSettings.enableChangeSort) ?? true;
+      bool enableNewPost = UserPreferences.getLocalSetting(LocalSettings.enableNewPost) ?? true;
 
-      bool postFabEnableBackToTop = prefs.getBool(LocalSettings.postFabEnableBackToTop.name) ?? true;
-      bool postFabEnableChangeSort = prefs.getBool(LocalSettings.postFabEnableChangeSort.name) ?? true;
-      bool postFabEnableReplyToPost = prefs.getBool(LocalSettings.postFabEnableReplyToPost.name) ?? true;
-      bool postFabEnableRefresh = prefs.getBool(LocalSettings.postFabEnableRefresh.name) ?? true;
-      bool postFabEnableSearch = prefs.getBool(LocalSettings.postFabEnableSearch.name) ?? true;
+      bool postFabEnableBackToTop = UserPreferences.getLocalSetting(LocalSettings.postFabEnableBackToTop) ?? true;
+      bool postFabEnableChangeSort = UserPreferences.getLocalSetting(LocalSettings.postFabEnableChangeSort) ?? true;
+      bool postFabEnableReplyToPost = UserPreferences.getLocalSetting(LocalSettings.postFabEnableReplyToPost) ?? true;
+      bool postFabEnableRefresh = UserPreferences.getLocalSetting(LocalSettings.postFabEnableRefresh) ?? true;
+      bool postFabEnableSearch = UserPreferences.getLocalSetting(LocalSettings.postFabEnableSearch) ?? true;
 
-      FeedFabAction feedFabSinglePressAction = FeedFabAction.values.byName(prefs.getString(LocalSettings.feedFabSinglePressAction.name) ?? FeedFabAction.newPost.name);
-      FeedFabAction feedFabLongPressAction = FeedFabAction.values.byName(prefs.getString(LocalSettings.feedFabLongPressAction.name) ?? FeedFabAction.openFab.name);
-      PostFabAction postFabSinglePressAction = PostFabAction.values.byName(prefs.getString(LocalSettings.postFabSinglePressAction.name) ?? PostFabAction.replyToPost.name);
-      PostFabAction postFabLongPressAction = PostFabAction.values.byName(prefs.getString(LocalSettings.postFabLongPressAction.name) ?? PostFabAction.openFab.name);
+      FeedFabAction feedFabSinglePressAction = FeedFabAction.values.byName(UserPreferences.getLocalSetting(LocalSettings.feedFabSinglePressAction) ?? FeedFabAction.newPost.name);
+      FeedFabAction feedFabLongPressAction = FeedFabAction.values.byName(UserPreferences.getLocalSetting(LocalSettings.feedFabLongPressAction) ?? FeedFabAction.openFab.name);
+      PostFabAction postFabSinglePressAction = PostFabAction.values.byName(UserPreferences.getLocalSetting(LocalSettings.postFabSinglePressAction) ?? PostFabAction.replyToPost.name);
+      PostFabAction postFabLongPressAction = PostFabAction.values.byName(UserPreferences.getLocalSetting(LocalSettings.postFabLongPressAction) ?? PostFabAction.openFab.name);
 
-      bool enableCommentNavigation = prefs.getBool(LocalSettings.enableCommentNavigation.name) ?? true;
-      bool combineNavAndFab = prefs.getBool(LocalSettings.combineNavAndFab.name) ?? true;
+      bool enableCommentNavigation = UserPreferences.getLocalSetting(LocalSettings.enableCommentNavigation) ?? true;
+      bool combineNavAndFab = UserPreferences.getLocalSetting(LocalSettings.combineNavAndFab) ?? true;
 
       /// -------------------------- Accessibility Related Settings --------------------------
-      bool reduceAnimations = prefs.getBool(LocalSettings.reduceAnimations.name) ?? false;
+      bool reduceAnimations = UserPreferences.getLocalSetting(LocalSettings.reduceAnimations) ?? false;
 
       /// ------------------ VIDEO PLAYER SETTINGS -----------------------------------------
-      bool videoAutoFullscreen = prefs.getBool(LocalSettings.videoAutoFullscreen.name) ?? false;
-      bool videoAutoLoop = prefs.getBool(LocalSettings.videoAutoLoop.name) ?? false;
-      bool videoAutoMute = prefs.getBool(LocalSettings.videoAutoMute.name) ?? true;
-      VideoAutoPlay videoAutoPlay = VideoAutoPlay.values.byName(prefs.getString(LocalSettings.videoAutoPlay.name) ?? VideoAutoPlay.never.name);
-      VideoPlayBackSpeed videoDefaultPlaybackSpeed = VideoPlayBackSpeed.values.byName(prefs.getString(LocalSettings.videoDefaultPlaybackSpeed.name) ?? VideoPlayBackSpeed.normal.name);
-      VideoPlayerMode videoPlayerMode = VideoPlayerMode.values.byName(prefs.getString(LocalSettings.videoPlayerMode.name) ?? VideoPlayerMode.inApp.name);
+      bool videoAutoFullscreen = UserPreferences.getLocalSetting(LocalSettings.videoAutoFullscreen) ?? false;
+      bool videoAutoLoop = UserPreferences.getLocalSetting(LocalSettings.videoAutoLoop) ?? false;
+      bool videoAutoMute = UserPreferences.getLocalSetting(LocalSettings.videoAutoMute) ?? true;
+      VideoAutoPlay videoAutoPlay = VideoAutoPlay.values.byName(UserPreferences.getLocalSetting(LocalSettings.videoAutoPlay) ?? VideoAutoPlay.never.name);
+      VideoPlayBackSpeed videoDefaultPlaybackSpeed = VideoPlayBackSpeed.values.byName(UserPreferences.getLocalSetting(LocalSettings.videoDefaultPlaybackSpeed) ?? VideoPlayBackSpeed.normal.name);
+      VideoPlayerMode videoPlayerMode = VideoPlayerMode.values.byName(UserPreferences.getLocalSetting(LocalSettings.videoPlayerMode) ?? VideoPlayerMode.inApp.name);
 
-      String currentAnonymousInstance = prefs.getString(LocalSettings.currentAnonymousInstance.name) ?? 'lemmy.ml';
+      String currentAnonymousInstance = UserPreferences.getLocalSetting(LocalSettings.currentAnonymousInstance) ?? 'lemmy.ml';
 
       return emit(state.copyWith(
         status: ThunderStatus.success,
@@ -448,13 +448,11 @@ class ThunderBloc extends Bloc<ThunderEvent, ThunderState> {
   }
 
   void _onSetCurrentAnonymousInstance(OnSetCurrentAnonymousInstance event, Emitter<ThunderState> emit) async {
-    final SharedPreferences prefs = (await UserPreferences.instance).sharedPreferences;
-
     if (event.instance != null) {
       LemmyClient.instance.changeBaseUrl(event.instance!);
-      prefs.setString(LocalSettings.currentAnonymousInstance.name, event.instance!);
+      UserPreferences.setSetting(LocalSettings.currentAnonymousInstance, event.instance!);
     } else {
-      prefs.remove(LocalSettings.currentAnonymousInstance.name);
+      UserPreferences.removeSetting(LocalSettings.currentAnonymousInstance);
     }
 
     emit(state.copyWith(currentAnonymousInstance: event.instance));

--- a/lib/thunder/pages/thunder_page.dart
+++ b/lib/thunder/pages/thunder_page.dart
@@ -12,7 +12,6 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_native_splash/flutter_native_splash.dart';
 import 'package:overlay_support/overlay_support.dart';
 import 'package:back_button_interceptor/back_button_interceptor.dart';
-import 'package:shared_preferences/shared_preferences.dart';
 import 'package:fading_edge_scrollview/fading_edge_scrollview.dart';
 
 // Internal
@@ -306,7 +305,7 @@ class _ThunderState extends State<Thunder> {
                             // If the last known version is not null (meaning we've run before)
                             // and the current version is different (meaning we've updated)
                             // show the changelog (if we are configured to do so).
-                            SharedPreferences prefs = (await UserPreferences.instance).sharedPreferences;
+                            final prefs = UserPreferences.instance.preferences;
                             String? lastKnownVersion = prefs.getString('current_version');
                             String currentVersion = getCurrentVersion(removeInternalBuildNumber: true, trimV: true);
 

--- a/lib/thunder/widgets/bottom_nav_bar.dart
+++ b/lib/thunder/widgets/bottom_nav_bar.dart
@@ -2,7 +2,6 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 
 import 'package:flutter_bloc/flutter_bloc.dart';
-import 'package:shared_preferences/shared_preferences.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 
 import 'package:thunder/account/account.dart';
@@ -46,8 +45,7 @@ class _CustomBottomNavigationBarState extends State<CustomBottomNavigationBar> {
   void _handleDragEnd(DragEndDetails details, BuildContext context) async {
     if (widget.selectedPageIndex != 0) return;
 
-    SharedPreferences prefs = (await UserPreferences.instance).sharedPreferences;
-    bool bottomNavBarSwipeGestures = prefs.getBool(LocalSettings.sidebarBottomNavBarSwipeGesture.name) ?? true;
+    bool bottomNavBarSwipeGestures = UserPreferences.getLocalSetting(LocalSettings.sidebarBottomNavBarSwipeGesture) ?? true;
     if (bottomNavBarSwipeGestures == false) return;
 
     double delta = _dragEndX - _dragStartX;
@@ -66,8 +64,7 @@ class _CustomBottomNavigationBarState extends State<CustomBottomNavigationBar> {
   void _handleDoubleTap(BuildContext context) async {
     if (widget.selectedPageIndex != 0) return;
 
-    SharedPreferences prefs = (await UserPreferences.instance).sharedPreferences;
-    bool bottomNavBarDoubleTapGestures = prefs.getBool(LocalSettings.sidebarBottomNavBarDoubleTapGesture.name) ?? false;
+    bool bottomNavBarDoubleTapGestures = UserPreferences.getLocalSetting(LocalSettings.sidebarBottomNavBarDoubleTapGesture) ?? false;
     if (bottomNavBarDoubleTapGestures == false) return;
 
     bool isDrawerOpen = context.mounted ? Scaffold.of(context).isDrawerOpen : false;

--- a/lib/utils/preferences.dart
+++ b/lib/utils/preferences.dart
@@ -1,7 +1,6 @@
 import 'dart:convert';
 
 import 'package:flutter/foundation.dart';
-import 'package:shared_preferences/shared_preferences.dart';
 import 'package:thunder/account/account.dart';
 import 'package:thunder/core/enums/enums.dart';
 import 'package:thunder/drafts/models/draft.dart';
@@ -17,7 +16,7 @@ import 'package:thunder/core/singletons/preferences.dart';
 import 'package:thunder/utils/constants.dart';
 
 Future<void> performSharedPreferencesMigration() async {
-  final SharedPreferences prefs = (await UserPreferences.instance).sharedPreferences;
+  final prefs = UserPreferences.instance.preferences;
 
   // Migrate the openInExternalBrowser setting, if found.
   bool? legacyOpenInExternalBrowser = prefs.getBool(LocalSettings.openLinksInExternalBrowser.name);


### PR DESCRIPTION
## Pull Request Description

This PR improves our usage of `UserPreferences` singleton by adding methods to get, set, and remove settings based on a given `LocalSetting`. I've also gone ahead and looked through the codebase to improve our consistency when it comes to using this singleton!

Note: Since there are some internal preferences that are not defined in `LocalSettings`, I've decided to keep those as is, but we could clean things up there by adding them as `LocalSettings` (with some way to indicate that they are internal fields to exclude them from search, etc.)

Usage:

To fetch the preferences instance (useful for internal settings not exposed by LocalSettings): `final prefs = UserPreferences.instance.preferences;`

<!--- Please describe what was changed -->

## Issue Being Fixed

<!-- Please describe the problem that is being fixed and, if applicable, reference a GitHub issue -->

Issue Number: N/A

## Screenshots / Recordings

<!-- This section is optional but highly recommended to show off your changes! -->

## Checklist

- [ ] If a new package was added, did you ensure it uses an appropriate license and is actively maintained?
- [ ] Did you use localized strings (and added appropriate descriptions) where applicable?
- [ ] Did you add `semanticLabel`s where applicable for accessibility?
