### PR TITLE
Fix issue with app crashing when using custom post metadata items

### DIFF
--- a/lib/thunder/bloc/thunder_bloc.dart
+++ b/lib/thunder/bloc/thunder_bloc.dart
@@ -161,9 +161,9 @@ class ThunderBloc extends Bloc<ThunderEvent, ThunderState> {
           FeedCardDividerThickness.values.byName(UserPreferences.getLocalSetting(LocalSettings.feedCardDividerThickness) ?? FeedCardDividerThickness.compact.name);
       Color feedCardDividerColor = Color(UserPreferences.getLocalSetting(LocalSettings.feedCardDividerColor) ?? Colors.transparent.value);
       List<PostCardMetadataItem> compactPostCardMetadataItems =
-          UserPreferences.getLocalSetting(LocalSettings.compactPostCardMetadataItems)?.map((e) => PostCardMetadataItem.values.byName(e)).toList() ?? DEFAULT_COMPACT_POST_CARD_METADATA;
+          UserPreferences.getLocalSetting<List<String>>(LocalSettings.compactPostCardMetadataItems)?.map((e) => PostCardMetadataItem.values.byName(e)).toList() ?? DEFAULT_COMPACT_POST_CARD_METADATA;
       List<PostCardMetadataItem> cardPostCardMetadataItems =
-          UserPreferences.getLocalSetting(LocalSettings.cardPostCardMetadataItems)?.map((e) => PostCardMetadataItem.values.byName(e)).toList() ?? DEFAULT_CARD_POST_CARD_METADATA;
+          UserPreferences.getLocalSetting<List<String>>(LocalSettings.cardPostCardMetadataItems)?.map((e) => PostCardMetadataItem.values.byName(e)).toList() ?? DEFAULT_CARD_POST_CARD_METADATA;
 
       // Post body settings
       bool showCrossPosts = UserPreferences.getLocalSetting(LocalSettings.showCrossPosts) ?? true;

--- a/lib/thunder/bloc/thunder_state.dart
+++ b/lib/thunder/bloc/thunder_state.dart
@@ -74,8 +74,8 @@ class ThunderState extends Equatable {
     this.dateFormat,
     this.feedCardDividerThickness = FeedCardDividerThickness.compact,
     this.feedCardDividerColor = Colors.transparent,
-    this.compactPostCardMetadataItems = const [],
-    this.cardPostCardMetadataItems = const [],
+    this.compactPostCardMetadataItems = const <PostCardMetadataItem>[],
+    this.cardPostCardMetadataItems = const <PostCardMetadataItem>[],
     this.keywordFilters = const [],
     this.appLanguageCode = 'en',
 


### PR DESCRIPTION
## Pull Request Description

This PR fixes an issue where Thunder crashes if a user has a custom list of post metadata items set. 

<!--- Please describe what was changed -->

## Issue Being Fixed

<!-- Please describe the problem that is being fixed and, if applicable, reference a GitHub issue -->

Issue Number: #1854

## Screenshots / Recordings

<!-- This section is optional but highly recommended to show off your changes! -->

## Checklist

- [ ] If a new package was added, did you ensure it uses an appropriate license and is actively maintained?
- [ ] Did you use localized strings (and added appropriate descriptions) where applicable?
- [ ] Did you add `semanticLabel`s where applicable for accessibility?
