### PR TITLE
Apply feedback for user/community headers

### DIFF
--- a/lib/account/widgets/account_page_app_bar.dart
+++ b/lib/account/widgets/account_page_app_bar.dart
@@ -7,12 +7,8 @@ import 'package:thunder/localizations/app_localizations.dart';
 import 'package:thunder/account/account.dart';
 import 'package:thunder/core/enums/full_name.dart';
 import 'package:thunder/core/enums/local_settings.dart';
-import 'package:thunder/core/singletons/lemmy_client.dart';
 import 'package:thunder/feed/bloc/feed_bloc.dart';
-import 'package:thunder/feed/utils/user_share.dart';
 import 'package:thunder/feed/utils/utils.dart';
-import 'package:thunder/shared/sort_picker.dart';
-import 'package:thunder/shared/thunder_popup_menu_item.dart';
 import 'package:thunder/thunder/bloc/thunder_bloc.dart';
 import 'package:thunder/utils/instance.dart';
 import 'package:thunder/utils/navigation.dart';
@@ -132,10 +128,17 @@ class AccountAppBarUserActions extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final l10n = AppLocalizations.of(context)!;
-    final feedBloc = context.read<FeedBloc>();
 
     return Row(
       children: [
+        IconButton(
+          icon: Icon(Icons.refresh_rounded, semanticLabel: l10n.refresh),
+          tooltip: l10n.refresh,
+          onPressed: () {
+            HapticFeedback.mediumImpact();
+            triggerRefresh(context);
+          },
+        ),
         IconButton(
           icon: Icon(showSaved ? Icons.bookmark_rounded : Icons.bookmark_border_rounded, semanticLabel: l10n.saved),
           tooltip: showSaved ? l10n.showOwnContent : l10n.showSavedContent,
@@ -151,41 +154,6 @@ class AccountAppBarUserActions extends StatelessWidget {
             HapticFeedback.mediumImpact();
             navigateToSettingPage(context, LocalSettings.settingsPageAccount);
           },
-        ),
-        Semantics(
-          label: l10n.menu,
-          child: PopupMenuButton(
-            onOpened: () => HapticFeedback.mediumImpact(),
-            itemBuilder: (context) => [
-              ThunderPopupMenuItem(
-                icon: Icons.sort,
-                title: l10n.sortBy,
-                onTap: () {
-                  showModalBottomSheet<void>(
-                    showDragHandle: true,
-                    context: context,
-                    isScrollControlled: true,
-                    builder: (builderContext) => SortPicker(
-                      title: l10n.sortOptions,
-                      onSelect: (selected) async => feedBloc.add(FeedChangeSortTypeEvent(selected.payload)),
-                      previouslySelected: feedBloc.state.sortType,
-                      minimumVersion: LemmyClient.instance.version,
-                    ),
-                  );
-                },
-              ),
-              ThunderPopupMenuItem(
-                icon: Icons.refresh_rounded,
-                title: l10n.refresh,
-                onTap: () => triggerRefresh(context),
-              ),
-              ThunderPopupMenuItem(
-                icon: Icons.share_rounded,
-                title: l10n.share,
-                onTap: () => showUserShareSheet(context, feedBloc.state.fullPersonView!.personView),
-              ),
-            ],
-          ),
         ),
       ],
     );

--- a/lib/account/widgets/account_page_app_bar.dart
+++ b/lib/account/widgets/account_page_app_bar.dart
@@ -14,39 +14,11 @@ import 'package:thunder/utils/instance.dart';
 import 'package:thunder/utils/navigation.dart';
 
 /// Holds the app bar for the account page
-class AccountPageAppBar extends StatefulWidget {
-  const AccountPageAppBar({
-    super.key,
-    this.showAppBarTitle = true,
-    this.showSaved = false,
-    this.onToggleSaved,
-  });
+class AccountPageAppBar extends StatelessWidget {
+  const AccountPageAppBar({super.key, this.showAppBarTitle = true});
 
   /// Whether to show the app bar title
   final bool showAppBarTitle;
-
-  /// Whether or not to show saved posts/comments
-  final bool showSaved;
-
-  /// Callback to show saved posts/comments
-  final Function(bool showSaved)? onToggleSaved;
-
-  @override
-  State<AccountPageAppBar> createState() => _AccountPageAppBarState();
-}
-
-class _AccountPageAppBarState extends State<AccountPageAppBar> {
-  /// Whether or not to show saved posts. We store a local variable here so that the icon can be optimistically updated
-  bool showSaved = false;
-
-  @override
-  void didUpdateWidget(covariant AccountPageAppBar oldWidget) {
-    super.didUpdateWidget(oldWidget);
-
-    if (showSaved != widget.showSaved && context.read<FeedBloc>().state.status == FeedStatus.success) {
-      setState(() => showSaved = widget.showSaved);
-    }
-  }
 
   @override
   Widget build(BuildContext context) {
@@ -59,7 +31,7 @@ class _AccountPageAppBarState extends State<AccountPageAppBar> {
       titleSpacing: 0.0,
       toolbarHeight: 70.0,
       surfaceTintColor: state.hideTopBarOnScroll ? Colors.transparent : null,
-      title: AccountAppBarTitle(visible: widget.showAppBarTitle),
+      title: AccountAppBarTitle(visible: showAppBarTitle),
       leading: IconButton(
         onPressed: () {
           HapticFeedback.mediumImpact();
@@ -68,15 +40,7 @@ class _AccountPageAppBarState extends State<AccountPageAppBar> {
         icon: Icon(Icons.people_alt_rounded, semanticLabel: l10n.profiles),
         tooltip: l10n.profiles,
       ),
-      actions: [
-        AccountAppBarUserActions(
-          showSaved: showSaved,
-          onToggleSaved: (showSaved) {
-            setState(() => this.showSaved = showSaved);
-            widget.onToggleSaved?.call(showSaved);
-          },
-        )
-      ],
+      actions: [AccountAppBarUserActions()],
     );
   }
 }
@@ -117,13 +81,7 @@ class AccountAppBarTitle extends StatelessWidget {
 
 /// The actions of the app bar for the account page
 class AccountAppBarUserActions extends StatelessWidget {
-  const AccountAppBarUserActions({super.key, this.showSaved = false, this.onToggleSaved});
-
-  /// Whether to show saved posts/comments
-  final bool showSaved;
-
-  /// Callback when the saved icon is tapped
-  final void Function(bool showSaved)? onToggleSaved;
+  const AccountAppBarUserActions({super.key});
 
   @override
   Widget build(BuildContext context) {
@@ -137,14 +95,6 @@ class AccountAppBarUserActions extends StatelessWidget {
           onPressed: () {
             HapticFeedback.mediumImpact();
             triggerRefresh(context);
-          },
-        ),
-        IconButton(
-          icon: Icon(showSaved ? Icons.bookmark_rounded : Icons.bookmark_border_rounded, semanticLabel: l10n.saved),
-          tooltip: showSaved ? l10n.showOwnContent : l10n.showSavedContent,
-          onPressed: () {
-            HapticFeedback.mediumImpact();
-            onToggleSaved?.call(!showSaved);
           },
         ),
         IconButton(

--- a/lib/community/widgets/community_header/community_header.dart
+++ b/lib/community/widgets/community_header/community_header.dart
@@ -3,6 +3,7 @@ import 'package:flutter/material.dart';
 import 'package:cached_network_image/cached_network_image.dart';
 
 import 'package:thunder/community/widgets/community_header/community_header_actions.dart';
+import 'package:thunder/community/widgets/community_information.dart';
 import 'package:thunder/core/enums/font_scale.dart';
 import 'package:thunder/core/models/models.dart';
 import 'package:thunder/shared/avatars/community_avatar.dart';
@@ -50,7 +51,22 @@ class _CommunityHeaderState extends State<CommunityHeader> {
       return content;
     }
 
-    content = _CommunityHeaderWithBanner(community: widget.community, child: content);
+    content = GestureDetector(
+      behavior: HitTestBehavior.opaque,
+      onTap: () => showModalBottomSheet(
+        context: context,
+        showDragHandle: true,
+        enableDrag: true,
+        useSafeArea: true,
+        scrollControlDisabledMaxHeightRatio: 0.90,
+        builder: (context) => CommunityInformation(
+          community: widget.community,
+          instance: widget.instance,
+          moderators: widget.moderators,
+        ),
+      ),
+      child: _CommunityHeaderWithBanner(community: widget.community, child: content),
+    );
 
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
@@ -132,7 +148,7 @@ class _CommunityStats extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    double iconSize = 16.0 * FontScale.small.textScaleFactor;
+    double iconSize = 16.0 * FontScale.base.textScaleFactor;
 
     return Row(
       spacing: 10.0,
@@ -140,12 +156,10 @@ class _CommunityStats extends StatelessWidget {
         IconText(
           icon: Icon(Icons.people_rounded, size: iconSize),
           text: formatNumberToK(community.subscribers ?? 0),
-          fontScale: FontScale.small,
         ),
         IconText(
           icon: Icon(Icons.library_books_rounded, size: iconSize),
           text: formatNumberToK(community.totalPosts ?? 0),
-          fontScale: FontScale.small,
         ),
       ],
     );
@@ -164,12 +178,29 @@ class _CommunityHeaderWithBanner extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+
     return Stack(
+      alignment: Alignment.center,
       children: [
         if (community.banner != null) ...[
           _BannerImage(url: community.banner!),
           _BannerGradient(),
         ],
+        Positioned(
+          right: 20.0,
+          child: Icon(
+            Icons.info_outline_rounded,
+            size: 24.0,
+            color: theme.colorScheme.onSurface.withValues(alpha: 0.8),
+            shadows: [
+              Shadow(
+                color: theme.colorScheme.onSurface.withValues(alpha: 0.1),
+                blurRadius: 16.0,
+              ),
+            ],
+          ),
+        ),
         child,
       ],
     );

--- a/lib/community/widgets/community_header/community_header_actions.dart
+++ b/lib/community/widgets/community_header/community_header_actions.dart
@@ -120,7 +120,6 @@ class _ActionChipsList extends StatelessWidget {
     return Row(
       spacing: 8.0,
       children: [
-        _InfoActionChip(community: community, instance: instance, moderators: moderators),
         _SortActionChip(),
         ..._getAuthenticatedActions(context),
         _SearchActionChip(),
@@ -144,46 +143,6 @@ class _ActionChipsList extends StatelessWidget {
       _CreatePostActionChip(community: community),
       _BlockActionChip(community: community),
     ];
-  }
-}
-
-/// Action chip for displaying community information.
-class _InfoActionChip extends StatelessWidget {
-  /// Community to display actions for
-  final ThunderCommunity community;
-
-  /// Instance of the community
-  final ThunderInstance instance;
-
-  /// List of moderators for the community
-  final List<ThunderUser> moderators;
-
-  const _InfoActionChip({
-    required this.community,
-    required this.instance,
-    required this.moderators,
-  });
-
-  @override
-  Widget build(BuildContext context) {
-    final l10n = GlobalContext.l10n;
-
-    return ThunderActionChip(
-      icon: Icons.info_outline_rounded,
-      label: l10n.about,
-      onPressed: () => showModalBottomSheet(
-        context: context,
-        showDragHandle: true,
-        enableDrag: true,
-        useSafeArea: true,
-        scrollControlDisabledMaxHeightRatio: 0.90,
-        builder: (context) => CommunityInformation(
-          community: community,
-          instance: instance,
-          moderators: moderators,
-        ),
-      ),
-    );
   }
 }
 
@@ -268,7 +227,7 @@ class _SubscriptionActionChip extends StatelessWidget {
 
     return switch (subscribed) {
       SubscribedType.notSubscribed => l10n.subscribe,
-      SubscribedType.pending => l10n.unsubscribePending,
+      SubscribedType.pending => l10n.pending,
       SubscribedType.subscribed => l10n.unsubscribe,
       _ => '',
     };
@@ -336,7 +295,7 @@ class _FavoritesActionChip extends StatelessWidget {
 
     return ThunderActionChip(
       icon: favorited ? Icons.star_rounded : Icons.star_border_rounded,
-      label: favorited ? l10n.removeFromFavorites : l10n.addToFavorites,
+      label: favorited ? l10n.unfavorite : l10n.favorite,
       onPressed: () => toggleFavoriteCommunity(context, community, favorited),
     );
   }
@@ -355,7 +314,7 @@ class _CreatePostActionChip extends StatelessWidget {
 
     return ThunderActionChip(
       icon: Icons.library_books_rounded,
-      label: l10n.createPost,
+      label: l10n.newPost,
       onPressed: () {
         HapticFeedback.mediumImpact();
         navigateToCreatePostPage(context, communityId: community.id, community: community);

--- a/lib/community/widgets/community_header/community_header_actions.dart
+++ b/lib/community/widgets/community_header/community_header_actions.dart
@@ -141,7 +141,7 @@ class _ActionChipsList extends StatelessWidget {
       _SubscriptionActionChip(community: community),
       if (community.subscribed != SubscribedType.notSubscribed) _FavoritesActionChip(community: community),
       _CreatePostActionChip(community: community),
-      _BlockActionChip(community: community),
+      if (community.subscribed == SubscribedType.notSubscribed) _BlockActionChip(community: community),
     ];
   }
 }

--- a/lib/community/widgets/community_header/community_header_actions.dart
+++ b/lib/community/widgets/community_header/community_header_actions.dart
@@ -8,7 +8,6 @@ import 'package:thunder/account/account.dart';
 import 'package:thunder/community/bloc/anonymous_subscriptions_bloc.dart';
 import 'package:thunder/community/bloc/community_bloc.dart';
 import 'package:thunder/community/enums/community_action.dart';
-import 'package:thunder/community/widgets/community_information.dart';
 import 'package:thunder/core/enums/full_name.dart';
 import 'package:thunder/core/models/models.dart';
 import 'package:thunder/core/singletons/lemmy_client.dart';

--- a/lib/feed/view/feed_page.dart
+++ b/lib/feed/view/feed_page.dart
@@ -361,26 +361,7 @@ class _FeedViewState extends State<FeedView> {
                       controller: _scrollController,
                       slivers: <Widget>[
                         widget.feedType == FeedType.account
-                            ? AccountPageAppBar(
-                                showAppBarTitle: showAppBarTitle,
-                                showSaved: state.showSaved,
-                                onToggleSaved: (showSaved) {
-                                  context.read<FeedBloc>().add(
-                                        FeedFetchedEvent(
-                                          feedType: FeedType.account,
-                                          feedListType: state.feedListType,
-                                          sortType: state.sortType,
-                                          communityId: state.communityId,
-                                          communityName: state.communityName,
-                                          userId: state.userId,
-                                          username: state.username,
-                                          reset: true,
-                                          showHidden: state.showHidden,
-                                          showSaved: showSaved,
-                                        ),
-                                      );
-                                },
-                              )
+                            ? AccountPageAppBar(showAppBarTitle: showAppBarTitle)
                             : FeedPageAppBar(
                                 showAppBarTitle: (state.feedType == FeedType.general && state.status != FeedStatus.initial) ? true : showAppBarTitle,
                                 scaffoldStateKey: widget.scaffoldStateKey,

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -991,6 +991,10 @@
   "@failedToUpdateNotificationSettings": {
     "description": "Error message when failed to update notification settings."
   },
+  "favorite": "Favorite",
+  "@favorite": {
+    "description": "Action for favoriting a community"
+  },
   "favorites": "Favorites",
   "@favorites": {
     "description": "The favorited communities on the drawer"
@@ -2816,6 +2820,10 @@
   "unexpectedError": "Unexpected Error",
   "@unexpectedError": {
     "description": "Error message for unexpected error"
+  },
+  "unfavorite": "Unfavorite",
+  "@unfavorite": {
+    "description": "Action for unfavoriting a community"
   },
   "unfeaturedPost": "Unfeatured Post",
   "@unfeaturedPost": {

--- a/lib/localizations/app_localizations.dart
+++ b/lib/localizations/app_localizations.dart
@@ -1874,6 +1874,12 @@ abstract class AppLocalizations {
   /// **'Failed to update notification settings'**
   String get failedToUpdateNotificationSettings;
 
+  /// Action for favoriting a community
+  ///
+  /// In en, this message translates to:
+  /// **'Favorite'**
+  String get favorite;
+
   /// The favorited communities on the drawer
   ///
   /// In en, this message translates to:
@@ -5137,6 +5143,12 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'Unexpected Error'**
   String get unexpectedError;
+
+  /// Action for unfavoriting a community
+  ///
+  /// In en, this message translates to:
+  /// **'Unfavorite'**
+  String get unfavorite;
 
   /// Short decription for moderator action to unfeature a post
   ///

--- a/lib/localizations/app_localizations_ar.dart
+++ b/lib/localizations/app_localizations_ar.dart
@@ -992,6 +992,9 @@ class AppLocalizationsAr extends AppLocalizations {
       'Failed to update notification settings';
 
   @override
+  String get favorite => 'Favorite';
+
+  @override
   String get favorites => 'Favorites';
 
   @override
@@ -2834,6 +2837,9 @@ class AppLocalizationsAr extends AppLocalizations {
 
   @override
   String get unexpectedError => 'Unexpected Error';
+
+  @override
+  String get unfavorite => 'Unfavorite';
 
   @override
   String get unfeaturedPost => 'Unfeatured Post';

--- a/lib/localizations/app_localizations_cs.dart
+++ b/lib/localizations/app_localizations_cs.dart
@@ -1008,6 +1008,9 @@ class AppLocalizationsCs extends AppLocalizations {
       'Failed to update notification settings';
 
   @override
+  String get favorite => 'Favorite';
+
+  @override
   String get favorites => 'Oblíbené';
 
   @override
@@ -2840,6 +2843,9 @@ class AppLocalizationsCs extends AppLocalizations {
 
   @override
   String get unexpectedError => 'Neočekávaná Chyba';
+
+  @override
+  String get unfavorite => 'Unfavorite';
 
   @override
   String get unfeaturedPost => 'Unfeatured Post';

--- a/lib/localizations/app_localizations_de.dart
+++ b/lib/localizations/app_localizations_de.dart
@@ -1016,6 +1016,9 @@ class AppLocalizationsDe extends AppLocalizations {
       'Benachrichtigungseinstellungen konnten nicht aktualisiert werden';
 
   @override
+  String get favorite => 'Favorite';
+
+  @override
   String get favorites => 'Favoriten';
 
   @override
@@ -2879,6 +2882,9 @@ class AppLocalizationsDe extends AppLocalizations {
 
   @override
   String get unexpectedError => 'Unerwarteter Fehler';
+
+  @override
+  String get unfavorite => 'Unfavorite';
 
   @override
   String get unfeaturedPost => 'Einfacher Post';

--- a/lib/localizations/app_localizations_en.dart
+++ b/lib/localizations/app_localizations_en.dart
@@ -1000,6 +1000,9 @@ class AppLocalizationsEn extends AppLocalizations {
       'Failed to update notification settings';
 
   @override
+  String get favorite => 'Favorite';
+
+  @override
   String get favorites => 'Favorites';
 
   @override
@@ -2842,6 +2845,9 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get unexpectedError => 'Unexpected Error';
+
+  @override
+  String get unfavorite => 'Unfavorite';
 
   @override
   String get unfeaturedPost => 'Unfeatured Post';

--- a/lib/localizations/app_localizations_eo.dart
+++ b/lib/localizations/app_localizations_eo.dart
@@ -997,6 +997,9 @@ class AppLocalizationsEo extends AppLocalizations {
       'Failed to update notification settings';
 
   @override
+  String get favorite => 'Favorite';
+
+  @override
   String get favorites => 'Plej ŝatataĵoj';
 
   @override
@@ -2823,6 +2826,9 @@ class AppLocalizationsEo extends AppLocalizations {
 
   @override
   String get unexpectedError => 'Neatendita Eraro';
+
+  @override
+  String get unfavorite => 'Unfavorite';
 
   @override
   String get unfeaturedPost => 'Unfeatured Post';

--- a/lib/localizations/app_localizations_es.dart
+++ b/lib/localizations/app_localizations_es.dart
@@ -1023,6 +1023,9 @@ class AppLocalizationsEs extends AppLocalizations {
       'Error al actualizar los ajustes de las notificaciones';
 
   @override
+  String get favorite => 'Favorite';
+
+  @override
   String get favorites => 'Favoritos';
 
   @override
@@ -2899,6 +2902,9 @@ class AppLocalizationsEs extends AppLocalizations {
 
   @override
   String get unexpectedError => 'Error inesperado';
+
+  @override
+  String get unfavorite => 'Unfavorite';
 
   @override
   String get unfeaturedPost => 'Tema sin categoría';

--- a/lib/localizations/app_localizations_fi.dart
+++ b/lib/localizations/app_localizations_fi.dart
@@ -997,6 +997,9 @@ class AppLocalizationsFi extends AppLocalizations {
       'Failed to update notification settings';
 
   @override
+  String get favorite => 'Favorite';
+
+  @override
   String get favorites => 'Suosikit';
 
   @override
@@ -2827,6 +2830,9 @@ class AppLocalizationsFi extends AppLocalizations {
 
   @override
   String get unexpectedError => 'Odottamaton virhe';
+
+  @override
+  String get unfavorite => 'Unfavorite';
 
   @override
   String get unfeaturedPost => 'Unfeatured Post';

--- a/lib/localizations/app_localizations_fr.dart
+++ b/lib/localizations/app_localizations_fr.dart
@@ -1010,6 +1010,9 @@ class AppLocalizationsFr extends AppLocalizations {
       'Failed to update notification settings';
 
   @override
+  String get favorite => 'Favorite';
+
+  @override
   String get favorites => 'Favoris';
 
   @override
@@ -2855,6 +2858,9 @@ class AppLocalizationsFr extends AppLocalizations {
 
   @override
   String get unexpectedError => 'Erreur inattendue';
+
+  @override
+  String get unfavorite => 'Unfavorite';
 
   @override
   String get unfeaturedPost => 'Unfeatured Post';

--- a/lib/localizations/app_localizations_hu.dart
+++ b/lib/localizations/app_localizations_hu.dart
@@ -1000,6 +1000,9 @@ class AppLocalizationsHu extends AppLocalizations {
       'Failed to update notification settings';
 
   @override
+  String get favorite => 'Favorite';
+
+  @override
   String get favorites => 'Favorites';
 
   @override
@@ -2842,6 +2845,9 @@ class AppLocalizationsHu extends AppLocalizations {
 
   @override
   String get unexpectedError => 'Unexpected Error';
+
+  @override
+  String get unfavorite => 'Unfavorite';
 
   @override
   String get unfeaturedPost => 'Unfeatured Post';

--- a/lib/localizations/app_localizations_it.dart
+++ b/lib/localizations/app_localizations_it.dart
@@ -1007,6 +1007,9 @@ class AppLocalizationsIt extends AppLocalizations {
       'Impossibile aggiornare le impostazioni di notifica';
 
   @override
+  String get favorite => 'Favorite';
+
+  @override
   String get favorites => 'Preferiti';
 
   @override
@@ -2839,6 +2842,9 @@ class AppLocalizationsIt extends AppLocalizations {
 
   @override
   String get unexpectedError => 'Errore Inaspettato';
+
+  @override
+  String get unfavorite => 'Unfavorite';
 
   @override
   String get unfeaturedPost => 'Post Rilasciato';

--- a/lib/localizations/app_localizations_nb.dart
+++ b/lib/localizations/app_localizations_nb.dart
@@ -995,6 +995,9 @@ class AppLocalizationsNb extends AppLocalizations {
       'Failed to update notification settings';
 
   @override
+  String get favorite => 'Favorite';
+
+  @override
   String get favorites => 'Favorites';
 
   @override
@@ -2824,6 +2827,9 @@ class AppLocalizationsNb extends AppLocalizations {
 
   @override
   String get unexpectedError => 'Uventet feil';
+
+  @override
+  String get unfavorite => 'Unfavorite';
 
   @override
   String get unfeaturedPost => 'Unfeatured Post';

--- a/lib/localizations/app_localizations_nl.dart
+++ b/lib/localizations/app_localizations_nl.dart
@@ -999,6 +999,9 @@ class AppLocalizationsNl extends AppLocalizations {
       'Failed to update notification settings';
 
   @override
+  String get favorite => 'Favorite';
+
+  @override
   String get favorites => 'Favorieten';
 
   @override
@@ -2841,6 +2844,9 @@ class AppLocalizationsNl extends AppLocalizations {
 
   @override
   String get unexpectedError => 'Onverwachte fout';
+
+  @override
+  String get unfavorite => 'Unfavorite';
 
   @override
   String get unfeaturedPost => 'Unfeatured Post';

--- a/lib/localizations/app_localizations_pl.dart
+++ b/lib/localizations/app_localizations_pl.dart
@@ -1010,6 +1010,9 @@ class AppLocalizationsPl extends AppLocalizations {
       'Failed to update notification settings';
 
   @override
+  String get favorite => 'Favorite';
+
+  @override
   String get favorites => 'Ulubione';
 
   @override
@@ -2845,6 +2848,9 @@ class AppLocalizationsPl extends AppLocalizations {
 
   @override
   String get unexpectedError => 'Wystąpił niespodziewany błąd';
+
+  @override
+  String get unfavorite => 'Unfavorite';
 
   @override
   String get unfeaturedPost => 'Unfeatured Post';

--- a/lib/localizations/app_localizations_pt.dart
+++ b/lib/localizations/app_localizations_pt.dart
@@ -1009,6 +1009,9 @@ class AppLocalizationsPt extends AppLocalizations {
       'Failed to update notification settings';
 
   @override
+  String get favorite => 'Favorite';
+
+  @override
   String get favorites => 'Favorites';
 
   @override
@@ -2851,6 +2854,9 @@ class AppLocalizationsPt extends AppLocalizations {
 
   @override
   String get unexpectedError => 'Unexpected Error';
+
+  @override
+  String get unfavorite => 'Unfavorite';
 
   @override
   String get unfeaturedPost => 'Unfeatured Post';

--- a/lib/localizations/app_localizations_ru.dart
+++ b/lib/localizations/app_localizations_ru.dart
@@ -1011,6 +1011,9 @@ class AppLocalizationsRu extends AppLocalizations {
       'Failed to update notification settings';
 
   @override
+  String get favorite => 'Favorite';
+
+  @override
   String get favorites => 'Избранные';
 
   @override
@@ -2834,6 +2837,9 @@ class AppLocalizationsRu extends AppLocalizations {
 
   @override
   String get unexpectedError => 'Неожиданная ошибка';
+
+  @override
+  String get unfavorite => 'Unfavorite';
 
   @override
   String get unfeaturedPost => 'Unfeatured Post';

--- a/lib/localizations/app_localizations_sk.dart
+++ b/lib/localizations/app_localizations_sk.dart
@@ -1008,6 +1008,9 @@ class AppLocalizationsSk extends AppLocalizations {
       'Failed to update notification settings';
 
   @override
+  String get favorite => 'Favorite';
+
+  @override
   String get favorites => 'Obľúbené';
 
   @override
@@ -2844,6 +2847,9 @@ class AppLocalizationsSk extends AppLocalizations {
 
   @override
   String get unexpectedError => 'Neočakávaná chyba';
+
+  @override
+  String get unfavorite => 'Unfavorite';
 
   @override
   String get unfeaturedPost => 'Odopnutý príspevok';

--- a/lib/localizations/app_localizations_sv.dart
+++ b/lib/localizations/app_localizations_sv.dart
@@ -994,6 +994,9 @@ class AppLocalizationsSv extends AppLocalizations {
       'Failed to update notification settings';
 
   @override
+  String get favorite => 'Favorite';
+
+  @override
   String get favorites => 'Favorites';
 
   @override
@@ -2828,6 +2831,9 @@ class AppLocalizationsSv extends AppLocalizations {
 
   @override
   String get unexpectedError => 'Unexpected Error';
+
+  @override
+  String get unfavorite => 'Unfavorite';
 
   @override
   String get unfeaturedPost => 'Unfeatured Post';

--- a/lib/localizations/app_localizations_ta.dart
+++ b/lib/localizations/app_localizations_ta.dart
@@ -1015,6 +1015,9 @@ class AppLocalizationsTa extends AppLocalizations {
       'அறிவிப்பு அமைப்புகளைப் புதுப்பிக்கத் தவறிவிட்டது';
 
   @override
+  String get favorite => 'Favorite';
+
+  @override
   String get favorites => 'பிடித்தவை';
 
   @override
@@ -2887,6 +2890,9 @@ class AppLocalizationsTa extends AppLocalizations {
 
   @override
   String get unexpectedError => 'எதிர்பாராத பிழை';
+
+  @override
+  String get unfavorite => 'Unfavorite';
 
   @override
   String get unfeaturedPost => 'தயாரிக்கப்படாத இடுகை';

--- a/lib/localizations/app_localizations_tr.dart
+++ b/lib/localizations/app_localizations_tr.dart
@@ -1009,6 +1009,9 @@ class AppLocalizationsTr extends AppLocalizations {
       'Bildirim ayarları güncellenemedi';
 
   @override
+  String get favorite => 'Favorite';
+
+  @override
   String get favorites => 'Favoriler';
 
   @override
@@ -2860,6 +2863,9 @@ class AppLocalizationsTr extends AppLocalizations {
 
   @override
   String get unexpectedError => 'Beklenmeyen Hata';
+
+  @override
+  String get unfavorite => 'Unfavorite';
 
   @override
   String get unfeaturedPost => 'Öne Çıkmayan Gönderi';

--- a/lib/localizations/app_localizations_uk.dart
+++ b/lib/localizations/app_localizations_uk.dart
@@ -1002,6 +1002,9 @@ class AppLocalizationsUk extends AppLocalizations {
       'Failed to update notification settings';
 
   @override
+  String get favorite => 'Favorite';
+
+  @override
   String get favorites => 'Favorites';
 
   @override
@@ -2838,6 +2841,9 @@ class AppLocalizationsUk extends AppLocalizations {
 
   @override
   String get unexpectedError => 'Unexpected Error';
+
+  @override
+  String get unfavorite => 'Unfavorite';
 
   @override
   String get unfeaturedPost => 'Unfeatured Post';

--- a/lib/localizations/app_localizations_zh.dart
+++ b/lib/localizations/app_localizations_zh.dart
@@ -1000,6 +1000,9 @@ class AppLocalizationsZh extends AppLocalizations {
       'Failed to update notification settings';
 
   @override
+  String get favorite => 'Favorite';
+
+  @override
   String get favorites => 'Favorites';
 
   @override
@@ -2842,6 +2845,9 @@ class AppLocalizationsZh extends AppLocalizations {
 
   @override
   String get unexpectedError => 'Unexpected Error';
+
+  @override
+  String get unfavorite => 'Unfavorite';
 
   @override
   String get unfeaturedPost => 'Unfeatured Post';

--- a/lib/shared/chips/thunder_action_chip.dart
+++ b/lib/shared/chips/thunder_action_chip.dart
@@ -37,7 +37,7 @@ class ThunderActionChip extends StatelessWidget {
       visualDensity: VisualDensity.compact,
       side: BorderSide(color: theme.dividerColor),
       backgroundColor: backgroundColor,
-      label: SizedBox(height: 20.0, child: child),
+      label: child,
       onPressed: onPressed,
     );
   }

--- a/lib/user/widgets/user_header/user_header.dart
+++ b/lib/user/widgets/user_header/user_header.dart
@@ -189,6 +189,7 @@ class _UserHeaderWithBanner extends StatelessWidget {
     final theme = Theme.of(context);
 
     return Stack(
+      alignment: Alignment.center,
       children: [
         if (user.banner != null) ...[
           _BannerImage(url: user.banner!),

--- a/lib/user/widgets/user_header/user_header.dart
+++ b/lib/user/widgets/user_header/user_header.dart
@@ -10,6 +10,7 @@ import 'package:thunder/shared/avatars/user_avatar.dart';
 import 'package:thunder/shared/full_name_widgets.dart';
 import 'package:thunder/shared/icon_text.dart';
 import 'package:thunder/user/widgets/user_header/user_header_actions.dart';
+import 'package:thunder/user/widgets/user_information.dart';
 import 'package:thunder/utils/instance.dart';
 import 'package:thunder/utils/numbers.dart';
 
@@ -56,7 +57,21 @@ class _UserHeaderState extends State<UserHeader> {
       return content;
     }
 
-    content = _UserHeaderWithBanner(user: widget.user, child: content);
+    content = GestureDetector(
+      behavior: HitTestBehavior.opaque,
+      onTap: () => showModalBottomSheet(
+        context: context,
+        showDragHandle: true,
+        enableDrag: true,
+        useSafeArea: true,
+        scrollControlDisabledMaxHeightRatio: 0.90,
+        builder: (context) => UserInformation(
+          user: widget.user,
+          moderates: widget.moderates,
+        ),
+      ),
+      child: _UserHeaderWithBanner(user: widget.user, child: content),
+    );
 
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
@@ -141,7 +156,7 @@ class _UserStats extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    double iconSize = 16.0 * FontScale.small.textScaleFactor;
+    double iconSize = 16.0 * FontScale.base.textScaleFactor;
 
     return Row(
       spacing: 10.0,
@@ -149,12 +164,10 @@ class _UserStats extends StatelessWidget {
         IconText(
           icon: Icon(Icons.wysiwyg_rounded, size: iconSize),
           text: formatNumberToK(user.totalPosts ?? 0),
-          fontScale: FontScale.small,
         ),
         IconText(
           icon: Icon(Icons.chat_rounded, size: iconSize),
           text: formatNumberToK(user.totalComments ?? 0),
-          fontScale: FontScale.small,
         ),
       ],
     );
@@ -173,12 +186,28 @@ class _UserHeaderWithBanner extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+
     return Stack(
       children: [
         if (user.banner != null) ...[
           _BannerImage(url: user.banner!),
           _BannerGradient(),
         ],
+        Positioned(
+          right: 20.0,
+          child: Icon(
+            Icons.info_outline_rounded,
+            size: 24.0,
+            color: theme.colorScheme.onSurface.withValues(alpha: 0.8),
+            shadows: [
+              Shadow(
+                color: theme.colorScheme.onSurface.withValues(alpha: 0.1),
+                blurRadius: 16.0,
+              ),
+            ],
+          ),
+        ),
         child,
       ],
     );

--- a/lib/user/widgets/user_header/user_header_actions.dart
+++ b/lib/user/widgets/user_header/user_header_actions.dart
@@ -136,48 +136,12 @@ class _ActionChipsList extends StatelessWidget {
     return Row(
       spacing: 8.0,
       children: [
-        _InfoActionChip(user: user, moderates: moderates),
         if (feedType != null && onChangeFeedType != null) _FeedTypeActionChip(feedType: feedType!, onChangeFeedType: onChangeFeedType!),
         _SortActionChip(),
         _LabelActionChip(user: user),
         if (isLoggedIn && !isOwnProfile && user.admin != true) _BlockActionChip(user: user),
         _ShareActionChip(user: user),
       ],
-    );
-  }
-}
-
-/// Action chip for displaying user information.
-class _InfoActionChip extends StatelessWidget {
-  /// User to display actions for
-  final ThunderUser user;
-
-  /// Communities the user moderates
-  final List<ThunderCommunity> moderates;
-
-  const _InfoActionChip({
-    required this.user,
-    required this.moderates,
-  });
-
-  @override
-  Widget build(BuildContext context) {
-    final l10n = GlobalContext.l10n;
-
-    return ThunderActionChip(
-      icon: Icons.info_outline_rounded,
-      label: l10n.about,
-      onPressed: () => showModalBottomSheet(
-        context: context,
-        showDragHandle: true,
-        enableDrag: true,
-        useSafeArea: true,
-        scrollControlDisabledMaxHeightRatio: 0.90,
-        builder: (context) => UserInformation(
-          user: user,
-          moderates: moderates,
-        ),
-      ),
     );
   }
 }

--- a/lib/user/widgets/user_header/user_header_actions.dart
+++ b/lib/user/widgets/user_header/user_header_actions.dart
@@ -14,7 +14,6 @@ import 'package:thunder/shared/sort_picker.dart';
 import 'package:thunder/user/bloc/user_bloc.dart';
 import 'package:thunder/user/enums/user_action.dart';
 import 'package:thunder/user/models/user_label.dart';
-import 'package:thunder/user/widgets/user_information.dart';
 import 'package:thunder/utils/bottom_sheet_list_picker.dart';
 import 'package:thunder/utils/global_context.dart';
 

--- a/lib/user/widgets/user_header/user_header_actions.dart
+++ b/lib/user/widgets/user_header/user_header_actions.dart
@@ -138,7 +138,7 @@ class _ActionChipsList extends StatelessWidget {
       children: [
         if (feedType != null && onChangeFeedType != null) _FeedTypeActionChip(feedType: feedType!, onChangeFeedType: onChangeFeedType!),
         _SortActionChip(),
-        _LabelActionChip(user: user),
+        if (!isOwnProfile) _LabelActionChip(user: user),
         if (isLoggedIn && !isOwnProfile && user.admin != true) _BlockActionChip(user: user),
         _ShareActionChip(user: user),
       ],

--- a/lib/user/widgets/user_header/user_header_actions.dart
+++ b/lib/user/widgets/user_header/user_header_actions.dart
@@ -136,11 +136,66 @@ class _ActionChipsList extends StatelessWidget {
       spacing: 8.0,
       children: [
         if (feedType != null && onChangeFeedType != null) _FeedTypeActionChip(feedType: feedType!, onChangeFeedType: onChangeFeedType!),
+        if (isOwnProfile) _SavedActionChip(),
         _SortActionChip(),
         if (!isOwnProfile) _LabelActionChip(user: user),
         if (isLoggedIn && !isOwnProfile && user.admin != true) _BlockActionChip(user: user),
         _ShareActionChip(user: user),
       ],
+    );
+  }
+}
+
+/// Action chip for toggling saved posts/comments.
+class _SavedActionChip extends StatefulWidget {
+  @override
+  State<_SavedActionChip> createState() => _SavedActionChipState();
+}
+
+class _SavedActionChipState extends State<_SavedActionChip> {
+  /// Whether or not to show saved posts. We store a local variable here so that the icon can be optimistically updated
+  bool showSaved = false;
+
+  @override
+  void didUpdateWidget(covariant _SavedActionChip oldWidget) {
+    super.didUpdateWidget(oldWidget);
+
+    final status = context.read<FeedBloc>().state.status;
+    final showSaved = context.read<FeedBloc>().state.showSaved;
+
+    if (this.showSaved != showSaved && status == FeedStatus.success) {
+      setState(() => this.showSaved = showSaved);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+
+    return ThunderActionChip(
+      icon: showSaved ? Icons.bookmark_rounded : Icons.bookmark_border_rounded,
+      label: l10n.saved,
+      backgroundColor: showSaved ? theme.colorScheme.primaryContainer.withValues(alpha: 0.25) : null,
+      onPressed: () {
+        HapticFeedback.mediumImpact();
+        setState(() => showSaved = !showSaved);
+
+        final state = context.read<FeedBloc>().state;
+        context.read<FeedBloc>().add(
+              FeedFetchedEvent(
+                feedType: FeedType.account,
+                feedListType: state.feedListType,
+                sortType: state.sortType,
+                communityId: state.communityId,
+                communityName: state.communityName,
+                userId: state.userId,
+                username: state.username,
+                reset: true,
+                showHidden: state.showHidden,
+                showSaved: showSaved,
+              ),
+            );
+      },
     );
   }
 }


### PR DESCRIPTION
## Pull Request Description

> ~This will be kept as a draft until more feedback is received!~

This PR applies some feedback to the recent changes to user/community headers.
- Shortened the labels for favouriting/unfavouriting a community, creating a new post.
- Removed the "About" chip for user/community. Tapping on the header itself will now open up the sidebar information. This reduces the amount of horizontal scrolling required.
- The "Block" action for a community is only shown when not subscribed to the community. If a user is subscribed to a community, it's assumed that they don't want to block the community. This reduces the amount of horizontal scrolling required.
- The "Label" action for a user is removed if its your own account (e.g., viewing from Account page). User labels only seem to make sense for labelling other users, not yourself!
- Cleaned up Account page app bar actions (overflow menu had redundant options)
- Fixed an issue with the action chips showing bottom shadow on larger font scaling

<!--- Please describe what was changed -->

## Issue Being Fixed

<!-- Please describe the problem that is being fixed and, if applicable, reference a GitHub issue -->

Issue Number: #1856 

## Screenshots / Recordings

<!-- This section is optional but highly recommended to show off your changes! -->

## Checklist

- [ ] If a new package was added, did you ensure it uses an appropriate license and is actively maintained?
- [ ] Did you use localized strings (and added appropriate descriptions) where applicable?
- [ ] Did you add `semanticLabel`s where applicable for accessibility?
