### PR TITLE
Fix issue with feed improperly displaying after switching profiles

### DIFF
--- a/lib/thunder/pages/thunder_page.dart
+++ b/lib/thunder/pages/thunder_page.dart
@@ -58,6 +58,7 @@ class _ThunderState extends State<Thunder> {
 
   bool hasShownUpdateDialog = false;
   bool hasShownChangelogDialog = false;
+  bool hasShownPageView = false;
 
   bool _isFabOpen = false;
 
@@ -246,7 +247,13 @@ class _ThunderState extends State<Thunder> {
                       if (previous.isLoggedIn != current.isLoggedIn || previous.status == ProfileStatus.initial) return true;
                       return false;
                     },
-                    buildWhen: (previous, current) => current.status != ProfileStatus.failure && current.status != ProfileStatus.loading,
+                    buildWhen: (previous, current) {
+                      // Don't rebuild on ProfileStatus.initial after we've shown the PageView once. This prevents PageView rebuilds during profile switching
+                      if (current.status == ProfileStatus.initial && hasShownPageView) {
+                        return false;
+                      }
+                      return current.status != ProfileStatus.failure && current.status != ProfileStatus.loading;
+                    },
                     listener: (context, state) {
                       // Although the buildWhen delegate exlcudes this state,
                       // there seems to be a timing issue where we can end up here anyway.
@@ -391,6 +398,8 @@ class _ThunderState extends State<Thunder> {
                               }
                             }
                           });
+
+                          hasShownPageView = true; // Set to true to prevent PageView rebuilds during profile switching
 
                           return PageView(
                             controller: widget.pageController,


### PR DESCRIPTION
## Pull Request Description

This PR fixes an issue that was introduced in #1826, where switching between profiles while not on the feed page would show the feed page regardless. This was caused because of an issue where PageView's state was reset after a profile switch event occurred.

<!--- Please describe what was changed -->

## Issue Being Fixed

<!-- Please describe the problem that is being fixed and, if applicable, reference a GitHub issue -->

Issue Number: N/A

## Screenshots / Recordings

<!-- This section is optional but highly recommended to show off your changes! -->

## Checklist

- [ ] If a new package was added, did you ensure it uses an appropriate license and is actively maintained?
- [ ] Did you use localized strings (and added appropriate descriptions) where applicable?
- [ ] Did you add `semanticLabel`s where applicable for accessibility?
