### PR TITLE
Fix the position of the refresh indicator

### DIFF
--- a/lib/account/widgets/account_page_app_bar.dart
+++ b/lib/account/widgets/account_page_app_bar.dart
@@ -14,6 +14,7 @@ import 'package:thunder/feed/utils/utils.dart';
 import 'package:thunder/shared/sort_picker.dart';
 import 'package:thunder/shared/thunder_popup_menu_item.dart';
 import 'package:thunder/thunder/bloc/thunder_bloc.dart';
+import 'package:thunder/utils/constants.dart';
 import 'package:thunder/utils/instance.dart';
 import 'package:thunder/utils/navigation.dart';
 
@@ -61,7 +62,7 @@ class _AccountPageAppBarState extends State<AccountPageAppBar> {
       pinned: true,
       centerTitle: false,
       titleSpacing: 0.0,
-      toolbarHeight: 70.0,
+      toolbarHeight: APP_BAR_HEIGHT,
       surfaceTintColor: state.hideTopBarOnScroll ? Colors.transparent : null,
       title: AccountAppBarTitle(visible: widget.showAppBarTitle),
       leading: IconButton(

--- a/lib/comment/view/create_comment_page.dart
+++ b/lib/comment/view/create_comment_page.dart
@@ -26,6 +26,7 @@ import 'package:thunder/shared/snackbar.dart';
 import 'package:thunder/user/utils/restore_user.dart';
 import 'package:thunder/user/widgets/user_selector.dart';
 import 'package:thunder/utils/colors.dart';
+import 'package:thunder/utils/constants.dart';
 import 'package:thunder/utils/instance.dart';
 import 'package:thunder/utils/media/image.dart';
 
@@ -275,7 +276,7 @@ class _CreateCommentPageState extends State<CreateCommentPage> {
                 resizeToAvoidBottomInset: false,
                 appBar: AppBar(
                   title: Text(widget.commentView != null ? l10n.editComment : l10n.createComment),
-                  toolbarHeight: 70.0,
+                  toolbarHeight: APP_BAR_HEIGHT,
                   centerTitle: false,
                 ),
                 body: SafeArea(

--- a/lib/feed/view/feed_page.dart
+++ b/lib/feed/view/feed_page.dart
@@ -28,6 +28,7 @@ import 'package:thunder/shared/text/scalable_text.dart';
 import 'package:thunder/thunder/bloc/thunder_bloc.dart';
 import 'package:thunder/user/bloc/user_bloc.dart';
 import 'package:thunder/user/widgets/user_header/user_header.dart';
+import 'package:thunder/utils/constants.dart';
 import 'package:thunder/utils/navigation.dart';
 
 enum FeedType { community, user, general, account }
@@ -354,7 +355,7 @@ class _FeedViewState extends State<FeedView> {
                   HapticFeedback.mediumImpact();
                   triggerRefresh(context);
                 },
-                edgeOffset: 95.0, // This offset is placed to allow the correct positioning of the refresh indicator
+                edgeOffset: MediaQuery.of(context).padding.top + APP_BAR_HEIGHT, // This offset is placed to allow the correct positioning of the refresh indicator
                 child: Stack(
                   children: [
                     CustomScrollView(

--- a/lib/feed/widgets/feed_page_app_bar.dart
+++ b/lib/feed/widgets/feed_page_app_bar.dart
@@ -12,6 +12,7 @@ import 'package:thunder/core/singletons/lemmy_client.dart';
 import 'package:thunder/feed/bloc/feed_bloc.dart';
 import 'package:thunder/feed/utils/utils.dart';
 import 'package:thunder/feed/view/feed_page.dart';
+import 'package:thunder/utils/constants.dart';
 import 'package:thunder/utils/global_context.dart';
 import 'package:thunder/utils/navigation.dart';
 import 'package:thunder/shared/avatars/user_avatar.dart';
@@ -49,7 +50,7 @@ class _FeedPageAppBarState extends State<FeedPageAppBar> {
       pinned: !thunderBloc.state.hideTopBarOnScroll,
       floating: true,
       centerTitle: false,
-      toolbarHeight: 70.0,
+      toolbarHeight: APP_BAR_HEIGHT,
       surfaceTintColor: thunderBloc.state.hideTopBarOnScroll ? Colors.transparent : null,
       title: FeedAppBarTitle(visible: widget.showAppBarTitle),
       leadingWidth: widget.scaffoldStateKey != null && thunderBloc.state.useProfilePictureForDrawer && profileState.isLoggedIn ? 50 : null,

--- a/lib/inbox/pages/inbox_page.dart
+++ b/lib/inbox/pages/inbox_page.dart
@@ -16,6 +16,7 @@ import 'package:thunder/shared/comment_sort_picker.dart';
 import 'package:thunder/shared/dialogs.dart';
 import 'package:thunder/shared/snackbar.dart';
 import 'package:thunder/shared/thunder_popup_menu_item.dart';
+import 'package:thunder/utils/constants.dart';
 
 /// A widget that displays the user's inbox replies, mentions, and private messages.
 class InboxPage extends StatefulWidget {
@@ -127,7 +128,7 @@ class _InboxPageState extends State<InboxPage> with SingleTickerProviderStateMix
                   sliver: SliverAppBar(
                     pinned: true,
                     centerTitle: false,
-                    toolbarHeight: 70.0,
+                    toolbarHeight: APP_BAR_HEIGHT,
                     forceElevated: innerBoxIsScrolled,
                     title: Text(l10n.inbox),
                     actions: [

--- a/lib/instance/pages/instance_page.dart
+++ b/lib/instance/pages/instance_page.dart
@@ -13,6 +13,7 @@ import 'package:thunder/instance/bloc/instance_bloc.dart';
 import 'package:thunder/instance/cubit/instance_page_cubit.dart';
 import 'package:thunder/instance/enums/instance_action.dart';
 import 'package:thunder/instance/widgets/instance_view.dart';
+import 'package:thunder/utils/constants.dart';
 import 'package:thunder/utils/navigation.dart';
 import 'package:thunder/shared/chips/thunder_action_chip.dart';
 import 'package:thunder/shared/error_message.dart';
@@ -123,7 +124,7 @@ class _InstancePageState extends State<InstancePage> {
                     slivers: [
                       SliverAppBar(
                         pinned: true,
-                        toolbarHeight: 70.0,
+                        toolbarHeight: APP_BAR_HEIGHT,
                         title: ListTile(
                           title: Text(
                             fetchInstanceNameFromUrl(widget.getSiteResponse.siteView.site.actorId) ?? '',

--- a/lib/modlog/view/modlog_page.dart
+++ b/lib/modlog/view/modlog_page.dart
@@ -9,6 +9,7 @@ import 'package:thunder/modlog/modlog.dart';
 import 'package:thunder/shared/snackbar.dart';
 import 'package:thunder/thunder/bloc/thunder_bloc.dart';
 import 'package:thunder/modlog/repository/modlog_repository.dart';
+import 'package:thunder/utils/constants.dart';
 
 /// Creates a [ModlogPage] which holds a list of modlog events.
 class ModlogFeedPage extends StatefulWidget {
@@ -161,7 +162,7 @@ class _ModlogFeedViewState extends State<ModlogFeedView> {
                       reset: true,
                     );
               },
-              edgeOffset: 95.0, // This offset is placed to allow the correct positioning of the refresh indicator
+              edgeOffset: MediaQuery.of(context).padding.top + APP_BAR_HEIGHT, // This offset is placed to allow the correct positioning of the refresh indicator
               child: Stack(
                 children: [
                   CustomScrollView(

--- a/lib/modlog/widgets/modlog_feed_page_app_bar.dart
+++ b/lib/modlog/widgets/modlog_feed_page_app_bar.dart
@@ -9,6 +9,7 @@ import 'package:thunder/localizations/app_localizations.dart';
 
 import 'package:thunder/modlog/modlog.dart';
 import 'package:thunder/thunder/thunder.dart';
+import 'package:thunder/utils/constants.dart';
 
 /// The app bar for the modlog feed page
 class ModlogFeedPageAppBar extends StatelessWidget {
@@ -28,7 +29,7 @@ class ModlogFeedPageAppBar extends StatelessWidget {
       pinned: !hideTopBarOnScroll,
       floating: true,
       centerTitle: false,
-      toolbarHeight: 70.0,
+      toolbarHeight: APP_BAR_HEIGHT,
       surfaceTintColor: hideTopBarOnScroll ? Colors.transparent : null,
       title: ListTile(
         title: Text(

--- a/lib/post/pages/post_page.dart
+++ b/lib/post/pages/post_page.dart
@@ -20,6 +20,7 @@ import 'package:thunder/shared/error_message.dart';
 import 'package:thunder/shared/gesture_fab.dart';
 import 'package:thunder/shared/input_dialogs.dart';
 import 'package:thunder/shared/snackbar.dart';
+import 'package:thunder/utils/constants.dart';
 import 'package:thunder/utils/global_context.dart';
 import 'package:thunder/utils/navigation.dart';
 import 'package:thunder/post/bloc/post_bloc.dart';
@@ -328,7 +329,7 @@ class _PostPageState extends State<PostPage> {
               HapticFeedback.mediumImpact();
               context.read<PostBloc>().add(GetPostEvent(post: widget.initialPost, selectedCommentPath: widget.commentPath, highlightedCommentId: widget.highlightedCommentId));
             },
-            edgeOffset: 95.0, // This offset is placed to allow the correct positioning of the refresh indicator
+            edgeOffset: MediaQuery.of(context).padding.top + APP_BAR_HEIGHT, // This offset is placed to allow the correct positioning of the refresh indicator
             child: Scaffold(
               floatingActionButtonLocation: FloatingActionButtonLocation.centerFloat,
               floatingActionButton: Stack(

--- a/lib/post/widgets/post_page_app_bar.dart
+++ b/lib/post/widgets/post_page_app_bar.dart
@@ -15,6 +15,7 @@ import 'package:thunder/shared/thunder_popup_menu_item.dart';
 import 'package:thunder/thunder/bloc/thunder_bloc.dart';
 import 'package:thunder/user/widgets/user_selector.dart';
 import 'package:thunder/utils/bottom_sheet_list_picker.dart';
+import 'package:thunder/utils/constants.dart';
 import 'package:thunder/utils/links.dart';
 
 /// Holds the app bar for the post page.
@@ -59,7 +60,7 @@ class PostPageAppBar extends StatelessWidget {
       pinned: !state.hideTopBarOnScroll,
       floating: true,
       centerTitle: false,
-      toolbarHeight: 70.0,
+      toolbarHeight: APP_BAR_HEIGHT,
       surfaceTintColor: state.hideTopBarOnScroll ? Colors.transparent : null,
       title: const PostAppBarTitle(),
       actions: [

--- a/lib/settings/pages/appearance_settings_page.dart
+++ b/lib/settings/pages/appearance_settings_page.dart
@@ -4,6 +4,7 @@ import 'package:thunder/localizations/app_localizations.dart';
 
 import 'package:thunder/core/enums/local_settings.dart';
 import 'package:thunder/shared/divider.dart';
+import 'package:thunder/utils/constants.dart';
 import 'package:thunder/utils/navigation.dart';
 
 class AppearanceSettingsPage extends StatelessWidget {
@@ -21,7 +22,7 @@ class AppearanceSettingsPage extends StatelessWidget {
           SliverAppBar(
             title: Text(l10n.appearance),
             centerTitle: false,
-            toolbarHeight: 70.0,
+            toolbarHeight: APP_BAR_HEIGHT,
             pinned: true,
           ),
           const SliverToBoxAdapter(child: SizedBox(height: 16.0)),

--- a/lib/settings/pages/comment_appearance_settings_page.dart
+++ b/lib/settings/pages/comment_appearance_settings_page.dart
@@ -214,7 +214,7 @@ class _CommentAppearanceSettingsPageState extends State<CommentAppearanceSetting
           SliverAppBar(
             title: Text(l10n.comments),
             centerTitle: false,
-            toolbarHeight: 70.0,
+            toolbarHeight: APP_BAR_HEIGHT,
             pinned: true,
             actions: [
               IconButton(

--- a/lib/settings/pages/debug_settings_page.dart
+++ b/lib/settings/pages/debug_settings_page.dart
@@ -171,7 +171,7 @@ class _DebugSettingsPageState extends State<DebugSettingsPage> {
           SliverAppBar(
             title: Text(l10n.debug),
             centerTitle: false,
-            toolbarHeight: 70.0,
+            toolbarHeight: APP_BAR_HEIGHT,
             pinned: true,
           ),
           SliverToBoxAdapter(

--- a/lib/settings/pages/fab_settings_page.dart
+++ b/lib/settings/pages/fab_settings_page.dart
@@ -13,6 +13,7 @@ import 'package:thunder/settings/widgets/toggle_option.dart';
 import 'package:thunder/shared/common_markdown_body.dart';
 import 'package:thunder/thunder/bloc/thunder_bloc.dart';
 import 'package:thunder/utils/bottom_sheet_list_picker.dart';
+import 'package:thunder/utils/constants.dart';
 
 class FabSettingsPage extends StatefulWidget {
   final LocalSettings? settingToHighlight;
@@ -244,7 +245,7 @@ class _FabSettingsPage extends State<FabSettingsPage> with TickerProviderStateMi
           SliverAppBar(
             title: Text(l10n.floatingActionButton),
             centerTitle: false,
-            toolbarHeight: 70.0,
+            toolbarHeight: APP_BAR_HEIGHT,
             pinned: true,
           ),
           SliverToBoxAdapter(

--- a/lib/settings/pages/filter_settings_page.dart
+++ b/lib/settings/pages/filter_settings_page.dart
@@ -13,6 +13,7 @@ import 'package:thunder/settings/widgets/settings_list_tile.dart';
 import 'package:thunder/shared/dialogs.dart';
 import 'package:thunder/shared/input_dialogs.dart';
 import 'package:thunder/thunder/bloc/thunder_bloc.dart';
+import 'package:thunder/utils/constants.dart';
 import 'package:thunder/utils/navigation.dart';
 
 class FilterSettingsPage extends StatefulWidget {
@@ -95,7 +96,7 @@ class _FilterSettingsPageState extends State<FilterSettingsPage> with SingleTick
           SliverAppBar(
             title: Text(l10n.filters),
             centerTitle: false,
-            toolbarHeight: 70.0,
+            toolbarHeight: APP_BAR_HEIGHT,
             pinned: true,
           ),
           SliverToBoxAdapter(

--- a/lib/settings/pages/general_settings_page.dart
+++ b/lib/settings/pages/general_settings_page.dart
@@ -362,7 +362,7 @@ class _GeneralSettingsPageState extends State<GeneralSettingsPage> with SingleTi
           SliverAppBar(
             title: Text(l10n.general),
             centerTitle: false,
-            toolbarHeight: 70.0,
+            toolbarHeight: APP_BAR_HEIGHT,
             pinned: true,
           ),
           SliverList(

--- a/lib/settings/pages/post_appearance_settings_page.dart
+++ b/lib/settings/pages/post_appearance_settings_page.dart
@@ -425,7 +425,7 @@ class _PostAppearanceSettingsPageState extends State<PostAppearanceSettingsPage>
           SliverAppBar(
             title: Text(l10n.posts),
             centerTitle: false,
-            toolbarHeight: 70.0,
+            toolbarHeight: APP_BAR_HEIGHT,
             pinned: true,
             actions: [
               IconButton(

--- a/lib/settings/pages/settings_page.dart
+++ b/lib/settings/pages/settings_page.dart
@@ -50,7 +50,7 @@ class _SettingsPageState extends State<SettingsPage> {
           SliverAppBar(
             title: Text(l10n.settings),
             centerTitle: false,
-            toolbarHeight: 70.0,
+            toolbarHeight: APP_BAR_HEIGHT,
             pinned: true,
           ),
           SliverToBoxAdapter(

--- a/lib/settings/pages/user_labels_settings_page.dart
+++ b/lib/settings/pages/user_labels_settings_page.dart
@@ -11,6 +11,7 @@ import 'package:thunder/post/utils/user_label_utils.dart';
 import 'package:thunder/shared/dialogs.dart';
 import 'package:thunder/shared/full_name_widgets.dart';
 import 'package:thunder/shared/input_dialogs.dart';
+import 'package:thunder/utils/constants.dart';
 
 class UserLabelSettingsPage extends StatefulWidget {
   final LocalSettings? settingToHighlight;
@@ -102,7 +103,7 @@ class _UserLabelSettingsPageState extends State<UserLabelSettingsPage> with Sing
           SliverAppBar(
             title: Text(l10n.userLabels),
             centerTitle: false,
-            toolbarHeight: 70.0,
+            toolbarHeight: APP_BAR_HEIGHT,
             pinned: true,
           ),
           SliverToBoxAdapter(

--- a/lib/settings/widgets/discussion_language_selector.dart
+++ b/lib/settings/widgets/discussion_language_selector.dart
@@ -7,6 +7,7 @@ import 'package:lemmy_api_client/v3.dart';
 import 'package:thunder/shared/dialogs.dart';
 import 'package:thunder/shared/input_dialogs.dart';
 import 'package:thunder/user/bloc/user_settings_bloc.dart';
+import 'package:thunder/utils/constants.dart';
 
 class DiscussionLanguageSelector extends StatefulWidget {
   const DiscussionLanguageSelector({super.key});
@@ -55,7 +56,7 @@ class _DiscussionLanguageSelector extends State<DiscussionLanguageSelector> {
                 pinned: true,
                 floating: true,
                 centerTitle: false,
-                toolbarHeight: 70.0,
+                toolbarHeight: APP_BAR_HEIGHT,
                 scrolledUnderElevation: 0.0,
                 title: Text(l10n.discussionLanguages),
               ),

--- a/lib/shared/pages/loading_page.dart
+++ b/lib/shared/pages/loading_page.dart
@@ -5,6 +5,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:swipeable_page_route/swipeable_page_route.dart';
 import 'package:thunder/thunder/bloc/thunder_bloc.dart';
+import 'package:thunder/utils/constants.dart';
 
 bool isLoadingPageShown = false;
 
@@ -23,7 +24,7 @@ class LoadingPage extends StatelessWidget {
           child: CustomScrollView(
             slivers: [
               SliverAppBar(
-                  toolbarHeight: 70.0,
+                  toolbarHeight: APP_BAR_HEIGHT,
                   leading: IconButton(
                     icon: !kIsWeb && Platform.isIOS
                         ? Icon(

--- a/lib/shared/webview.dart
+++ b/lib/shared/webview.dart
@@ -8,6 +8,7 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:share_plus/share_plus.dart';
 import 'package:thunder/shared/thunder_popup_menu_item.dart';
 import 'package:thunder/thunder/bloc/thunder_bloc.dart';
+import 'package:thunder/utils/constants.dart';
 import 'package:thunder/utils/links.dart';
 import 'package:thunder/utils/web_utils.dart';
 import 'package:url_launcher/url_launcher.dart';
@@ -120,7 +121,7 @@ class _WebViewState extends State<WebView> {
       future: Future.wait([_controller.getTitle(), _controller.currentUrl()]),
       builder: (context, snapshot) => Scaffold(
         appBar: AppBar(
-          toolbarHeight: 70.0,
+          toolbarHeight: APP_BAR_HEIGHT,
           titleSpacing: 0,
           title: ListTile(
             title: Text(snapshot.data?[0] ?? snapshot.data?[1] ?? '', overflow: TextOverflow.fade, softWrap: false),

--- a/lib/thunder/pages/notifications_pages.dart
+++ b/lib/thunder/pages/notifications_pages.dart
@@ -7,6 +7,7 @@ import 'package:thunder/localizations/app_localizations.dart';
 import 'package:thunder/inbox/bloc/inbox_bloc.dart';
 import 'package:thunder/inbox/widgets/inbox_replies_view.dart';
 import 'package:thunder/post/bloc/post_bloc.dart';
+import 'package:thunder/utils/constants.dart';
 
 /// A page for displaying the result of reply notifications
 class NotificationsReplyPage extends StatelessWidget {
@@ -39,7 +40,7 @@ class NotificationsReplyPage extends StatelessWidget {
                   sliver: SliverAppBar(
                     pinned: true,
                     centerTitle: false,
-                    toolbarHeight: 70.0,
+                    toolbarHeight: APP_BAR_HEIGHT,
                     forceElevated: innerBoxIsScrolled,
                     title: ListTile(
                       title: Text(l10n.inbox, style: theme.textTheme.titleLarge),

--- a/lib/thunder/pages/thunder_page.dart
+++ b/lib/thunder/pages/thunder_page.dart
@@ -25,6 +25,7 @@ import 'package:thunder/core/update/check_github_update.dart';
 import 'package:thunder/feed/feed.dart';
 import 'package:thunder/thunder/utils/deep_link.dart';
 import 'package:thunder/thunder/utils/share_intent_handler.dart';
+import 'package:thunder/utils/constants.dart';
 import 'package:thunder/utils/navigation.dart';
 import 'package:thunder/shared/common_markdown_body.dart';
 import 'package:thunder/shared/snackbar.dart';
@@ -285,7 +286,7 @@ class _ThunderState extends State<Thunder> {
                         case ProfileStatus.initial:
                           context.read<ProfileBloc>().add(InitializeAuth());
                           return Scaffold(
-                            appBar: AppBar(toolbarHeight: 70.0),
+                            appBar: AppBar(toolbarHeight: APP_BAR_HEIGHT),
                             body: Center(
                               child: CircularProgressIndicator(),
                             ),

--- a/lib/user/pages/media_management_page.dart
+++ b/lib/user/pages/media_management_page.dart
@@ -16,6 +16,7 @@ import 'package:thunder/shared/snackbar.dart';
 import 'package:thunder/shared/text/scalable_text.dart';
 import 'package:thunder/thunder/bloc/thunder_bloc.dart';
 import 'package:thunder/user/bloc/user_settings_bloc.dart';
+import 'package:thunder/utils/constants.dart';
 import 'package:thunder/utils/media/image.dart';
 
 class MediaManagementPage extends StatelessWidget {
@@ -46,7 +47,7 @@ class MediaManagementPage extends StatelessWidget {
                 slivers: [
                   SliverAppBar(
                     pinned: true,
-                    toolbarHeight: 70.0,
+                    toolbarHeight: APP_BAR_HEIGHT,
                     title: ListTile(
                       title: Text(
                         l10n.manageMedia,

--- a/lib/user/pages/user_settings_block_page.dart
+++ b/lib/user/pages/user_settings_block_page.dart
@@ -7,6 +7,7 @@ import 'package:lemmy_api_client/v3.dart';
 import 'package:thunder/core/enums/full_name.dart';
 import 'package:thunder/core/models/models.dart';
 import 'package:thunder/feed/view/feed_page.dart';
+import 'package:thunder/utils/constants.dart';
 import 'package:thunder/utils/navigation.dart';
 import 'package:thunder/shared/avatars/community_avatar.dart';
 import 'package:thunder/shared/avatars/user_avatar.dart';
@@ -259,7 +260,7 @@ class _UserSettingsBlockPageState extends State<UserSettingsBlockPage> with Sing
                   pinned: true,
                   floating: true,
                   centerTitle: false,
-                  toolbarHeight: 70.0,
+                  toolbarHeight: APP_BAR_HEIGHT,
                   scrolledUnderElevation: 0.0,
                   title: Text(l10n.blockManagement),
                   bottom: TabBar(

--- a/lib/user/pages/user_settings_page.dart
+++ b/lib/user/pages/user_settings_page.dart
@@ -27,6 +27,7 @@ import "package:thunder/thunder/thunder_icons.dart";
 import "package:thunder/user/bloc/user_settings_bloc.dart";
 import "package:thunder/user/widgets/user_indicator.dart";
 import "package:thunder/utils/bottom_sheet_list_picker.dart";
+import "package:thunder/utils/constants.dart";
 import "package:thunder/utils/error_messages.dart";
 import "package:thunder/utils/global_context.dart";
 import "package:thunder/utils/links.dart";
@@ -125,7 +126,7 @@ class _UserSettingsPageState extends State<UserSettingsPage> {
                       pinned: true,
                       floating: true,
                       centerTitle: false,
-                      toolbarHeight: 70.0,
+                      toolbarHeight: APP_BAR_HEIGHT,
                       title: Text(l10n.accountSettings),
                       actions: [
                         IconButton(

--- a/lib/utils/constants.dart
+++ b/lib/utils/constants.dart
@@ -68,3 +68,5 @@ const String THUNDER_SERVER_URL = 'https://thunderapp.dev';
 
 const Color DARK_THEME_BACKGROUND_COLOR = Color.fromARGB(255, 50, 50, 50);
 const Color LIGHT_THEME_BACKGROUND_COLOR = Color.fromARGB(255, 242, 242, 242);
+
+const double APP_BAR_HEIGHT = 70.0;


### PR DESCRIPTION
## Pull Request Description

<!--- Please describe what was changed -->

This PR fixes a longstanding issue I've had where the position of the refresh indicator was not in the right location on my physical device. The problem was that the offset was hard-coded, rather than being calculated as the height of the status bar plus the app bar.

Note that in making this change, I refactored the app bar height, everywhere it was used, into a constant, which is why it looks like there are a lot of changes.

@hjiangsu Can you verify that it still looks right on iOS?

## Issue Being Fixed

<!-- Please describe the problem that is being fixed and, if applicable, reference a GitHub issue -->

Issue Number: N/A

## Screenshots / Recordings

<!-- This section is optional but highly recommended to show off your changes! -->

## Checklist

- [ ] If a new package was added, did you ensure it uses an appropriate license and is actively maintained?
- [ ] Did you use localized strings (and added appropriate descriptions) where applicable?
- [ ] Did you add `semanticLabel`s where applicable for accessibility?
