### PR TITLE
Chore: improve documentation and widget structure for post-related widgets

### DIFF
--- a/lib/post/widgets/post_card_title.dart
+++ b/lib/post/widgets/post_card_title.dart
@@ -49,6 +49,7 @@ class PostCardTitle extends StatelessWidget {
 
   Color? _getDimmedColor(Color? color) => color?.withValues(alpha: 0.55);
 
+  /// Returns the color of the title.
   Color? _getTitleColor(ThemeData theme) {
     if (pinned) return dim ? _getDimmedColor(Colors.green) : Colors.green;
     if (dim) return _getDimmedColor(theme.textTheme.bodyMedium?.color);
@@ -56,34 +57,31 @@ class PostCardTitle extends StatelessWidget {
     return null;
   }
 
+  /// Calculates the font size for the title.
+  double _calculateFontSize(BuildContext context, TextStyle? textStyle, double textScaleFactor) {
+    final baseFontSize = (textStyle?.fontSize ?? 14.0) + 0.5;
+    return MediaQuery.textScalerOf(context).scale(baseFontSize * textScaleFactor);
+  }
+
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
-
     final textStyle = theme.textTheme.bodyMedium;
-    final fontSize = (textStyle?.fontSize ?? 14.0) + 0.5;
 
     final textScaleFactor = context.select((ThunderBloc bloc) => bloc.state.titleFontSizeScale.textScaleFactor);
+    final fontSize = _calculateFontSize(context, textStyle, textScaleFactor);
+
+    final statuses = PostStatusIcon(hidden: hidden, locked: locked, saved: saved, pinned: pinned, deleted: deleted, removed: removed, dim: dim);
 
     return Text.rich(
       TextSpan(
         children: [
-          WidgetSpan(
-            child: PostStatusIcon(
-              hidden: hidden,
-              locked: locked,
-              saved: saved,
-              pinned: pinned,
-              deleted: deleted,
-              removed: removed,
-              dim: dim,
-            ),
-          ),
+          WidgetSpan(child: statuses),
           TextSpan(
             text: _html.convert(title),
             style: textStyle?.copyWith(
               fontWeight: FontWeight.w600,
-              fontSize: MediaQuery.textScalerOf(context).scale(fontSize * textScaleFactor),
+              fontSize: fontSize,
               color: _getTitleColor(theme),
             ),
           ),

--- a/lib/post/widgets/post_status_icon.dart
+++ b/lib/post/widgets/post_status_icon.dart
@@ -8,12 +8,25 @@ import 'package:thunder/thunder/bloc/thunder_bloc.dart';
 
 /// Given a list of statuses, returns a list of icons representing the statuses.
 class PostStatusIcon extends StatelessWidget {
+  /// The post status to indicate whether the post is hidden.
   final bool hidden;
+
+  /// The post status to indicate whether the post is locked.
   final bool locked;
+
+  /// The post status to indicate whether the post is saved.
   final bool saved;
+
+  /// The post status to indicate whether the post is pinned.
   final bool pinned;
+
+  /// The post status to indicate whether the post is deleted.
   final bool deleted;
+
+  /// The post status to indicate whether the post is removed.
   final bool removed;
+
+  /// Determines whether the status icons should be dimmed or not. This is usually to indicate when a post has been read.
   final bool dim;
 
   const PostStatusIcon({
@@ -29,9 +42,8 @@ class PostStatusIcon extends StatelessWidget {
 
   static Color getDimmedColor(Color color) => color.withValues(alpha: 0.55);
 
-  Widget _buildStatusIcon(BuildContext context, PostStatusType status, bool isActive, double textScaleFactor) {
-    if (!isActive) return const SizedBox.shrink();
-
+  /// Builds a single status icon.
+  Widget _buildStatusIcon(BuildContext context, PostStatusType status, double textScaleFactor) {
     final color = dim ? getDimmedColor(status.getColor(context)) : status.getColor(context);
 
     return Icon(
@@ -42,31 +54,30 @@ class PostStatusIcon extends StatelessWidget {
     );
   }
 
+  /// Builds the status icons for the post.
+  List<Widget> _buildStatusIcons(BuildContext context, double textScaleFactor) {
+    final statuses = <Widget>[];
+
+    if (hidden) statuses.add(_buildStatusIcon(context, PostStatusType.hidden, textScaleFactor));
+    if (locked) statuses.add(_buildStatusIcon(context, PostStatusType.locked, textScaleFactor));
+    if (saved) statuses.add(_buildStatusIcon(context, PostStatusType.saved, textScaleFactor));
+    if (pinned) statuses.add(_buildStatusIcon(context, PostStatusType.pinned, textScaleFactor));
+    if (deleted) statuses.add(_buildStatusIcon(context, PostStatusType.deleted, textScaleFactor));
+    if (removed) statuses.add(_buildStatusIcon(context, PostStatusType.removed, textScaleFactor));
+
+    return statuses;
+  }
+
   @override
   Widget build(BuildContext context) {
     final textScaleFactor = context.select((ThunderBloc bloc) => bloc.state.titleFontSizeScale.textScaleFactor);
+    final statuses = _buildStatusIcons(context, textScaleFactor);
 
-    final statusMap = {
-      PostStatusType.hidden: hidden,
-      PostStatusType.locked: locked,
-      PostStatusType.saved: saved,
-      PostStatusType.pinned: pinned,
-      PostStatusType.deleted: deleted,
-      PostStatusType.removed: removed,
-    };
-
-    final List<Widget> statuses = statusMap.entries
-        .where((entry) => entry.value)
-        .map((entry) => _buildStatusIcon(context, entry.key, entry.value, textScaleFactor))
-        .whereType<Widget>() // Filter out any null widgets
-        .toList();
+    if (statuses.isEmpty) return SizedBox.shrink();
 
     return Wrap(
       spacing: 2.0,
-      children: [
-        ...statuses,
-        if (statuses.isNotEmpty) const SizedBox(width: 3.5),
-      ],
+      children: [...statuses, SizedBox(width: 3.5)],
     );
   }
 }

--- a/lib/shared/image/image_preview.dart
+++ b/lib/shared/image/image_preview.dart
@@ -59,14 +59,9 @@ class _ImagePreviewState extends State<ImagePreview> with SingleTickerProviderSt
   /// The controller for the image fade animation.
   late AnimationController _controller;
 
-  /// Whether the image URL is valid.
-  late bool _isValidImageUrl;
-
   @override
   void initState() {
     super.initState();
-
-    _isValidImageUrl = widget.contentType != null || isImageUrl(widget.url);
 
     _controller = AnimationController(
       vsync: this,
@@ -77,14 +72,6 @@ class _ImagePreviewState extends State<ImagePreview> with SingleTickerProviderSt
   }
 
   @override
-  void didUpdateWidget(ImagePreview oldWidget) {
-    super.didUpdateWidget(oldWidget);
-    if (oldWidget.url != widget.url) {
-      _isValidImageUrl = isImageUrl(widget.url);
-    }
-  }
-
-  @override
   void dispose() {
     _controller.dispose();
     super.dispose();
@@ -92,60 +79,145 @@ class _ImagePreviewState extends State<ImagePreview> with SingleTickerProviderSt
 
   @override
   Widget build(BuildContext context) {
-    if (!_isValidImageUrl) return ImagePreviewError(mediaType: widget.mediaType, blur: widget.blur == true, viewed: widget.viewed == true);
+    // TODO: Move the logic for determining if the image is valid into data layer so that we don't need to re-evaluate this on every build.
+    final isValidImageUrl = widget.contentType != null || isImageUrl(widget.url);
+    final imageCachingMode = context.select((ThunderBloc bloc) => bloc.state.imageCachingMode);
 
-    return BlocSelector<ThunderBloc, ThunderState, ImageCachingMode>(
-      selector: (state) => state.imageCachingMode,
-      builder: (context, imageCachingMode) {
-        return _buildImage(context, imageCachingMode);
-      },
+    if (!isValidImageUrl) {
+      return ImagePreviewError(
+        mediaType: widget.mediaType,
+        blur: widget.blur == true,
+        viewed: widget.viewed == true,
+      );
+    }
+
+    return _ImageContent(
+      url: widget.url,
+      width: widget.width,
+      height: widget.height,
+      fit: widget.fit,
+      viewed: widget.viewed,
+      blur: widget.blur,
+      mediaType: widget.mediaType,
+      imageCachingMode: imageCachingMode,
+      controller: _controller,
     );
   }
+}
 
-  Widget _buildImage(BuildContext context, ImageCachingMode imageCachingMode) {
+/// A widget that displays an image.
+class _ImageContent extends StatelessWidget {
+  /// The URL of the image to display.
+  final String url;
+
+  /// The width of the image.
+  final double? width;
+
+  /// The height of the image.
+  final double? height;
+
+  /// The box fit of the image.
+  final BoxFit? fit;
+
+  /// Whether the image has been viewed. This will affect the opacity of the image.
+  final bool? viewed;
+
+  /// Whether the image should be blurred.
+  final bool? blur;
+
+  /// The media type that the underlying image represents.
+  final MediaType? mediaType;
+
+  /// The image caching mode.
+  final ImageCachingMode imageCachingMode;
+
+  /// The controller for the image fade animation.
+  final AnimationController controller;
+
+  const _ImageContent({
+    required this.url,
+    required this.width,
+    required this.height,
+    required this.fit,
+    required this.viewed,
+    required this.blur,
+    required this.mediaType,
+    required this.imageCachingMode,
+    required this.controller,
+  });
+
+  @override
+  Widget build(BuildContext context) {
     final devicePixelRatio = MediaQuery.devicePixelRatioOf(context).ceil();
 
     Widget image = ExtendedImage.network(
-      widget.url,
-      height: widget.height,
-      width: widget.width,
-      fit: widget.fit,
-      color: widget.viewed == true ? const Color.fromRGBO(255, 255, 255, 0.55) : null,
-      colorBlendMode: widget.viewed == true ? BlendMode.modulate : null,
+      url,
+      height: height,
+      width: width,
+      fit: fit,
+      color: viewed == true ? const Color.fromRGBO(255, 255, 255, 0.55) : null,
+      colorBlendMode: viewed == true ? BlendMode.modulate : null,
       cache: true,
       clearMemoryCacheWhenDispose: imageCachingMode == ImageCachingMode.relaxed,
-      cacheWidth: widget.width != null ? (widget.width! * devicePixelRatio).toInt() : null,
-      cacheHeight: widget.height != null ? (widget.height! * devicePixelRatio).toInt() : null,
+      cacheWidth: width != null ? (width! * devicePixelRatio).toInt() : null,
+      cacheHeight: height != null ? (height! * devicePixelRatio).toInt() : null,
       loadStateChanged: (ExtendedImageState state) {
         switch (state.extendedImageLoadState) {
           case LoadState.loading:
-            _controller.reset();
+            controller.reset();
             return const SizedBox.shrink();
-
           case LoadState.completed:
             if (state.wasSynchronouslyLoaded) return state.completedWidget;
 
-            _controller.forward();
-            return FadeTransition(opacity: _controller, child: state.completedWidget);
-
+            controller.forward();
+            return _FadeInImage(controller: controller, child: state.completedWidget);
           case LoadState.failed:
-            _controller.reset();
+            controller.reset();
             state.imageProvider.evict();
 
-            return ImagePreviewError(mediaType: widget.mediaType, blur: widget.blur == true, viewed: widget.viewed == true);
+            return ImagePreviewError(mediaType: mediaType, blur: blur == true, viewed: viewed == true);
         }
       },
     );
 
-    if (widget.blur == true) {
-      return ImageFiltered(
-        enabled: true,
-        imageFilter: ImageFilter.blur(sigmaX: 30, sigmaY: 30),
-        child: image,
-      );
-    }
-
+    if (blur == true) return _BlurredImage(child: image);
     return image;
+  }
+}
+
+/// A widget that fades in the child widget.
+class _FadeInImage extends StatelessWidget {
+  /// The controller for the fade animation.
+  final AnimationController controller;
+
+  /// The child widget to display.
+  final Widget child;
+
+  const _FadeInImage({required this.controller, required this.child});
+
+  @override
+  Widget build(BuildContext context) {
+    return FadeTransition(
+      opacity: controller,
+      child: child,
+    );
+  }
+}
+
+/// A widget that blurs the child widget.
+class _BlurredImage extends StatelessWidget {
+  /// The child widget to display.
+  final Widget child;
+
+  const _BlurredImage({required this.child});
+
+  @override
+  Widget build(BuildContext context) {
+    return ImageFiltered(
+      enabled: true,
+      imageFilter: ImageFilter.blur(sigmaX: 30, sigmaY: 30),
+      child: child,
+    );
   }
 }
 
@@ -162,22 +234,8 @@ class ImagePreviewError extends StatelessWidget {
 
   const ImagePreviewError({super.key, this.mediaType, this.blur = false, this.viewed = false});
 
-  @override
-  Widget build(BuildContext context) {
-    final theme = Theme.of(context);
-
-    // Don't display the associated icon if blur is enabled, otherwise there will be two icons displayed at once.
-    if (blur == true) return SizedBox.shrink();
-
-    return Center(
-      child: Icon(
-        _getErrorIcon(mediaType),
-        color: theme.colorScheme.onSecondaryContainer.withValues(alpha: viewed == true ? 0.55 : 1.0),
-      ),
-    );
-  }
-
-  IconData _getErrorIcon(MediaType? mediaType) {
+  /// Returns the icon to display when the image fails to load.
+  static IconData _getErrorIcon(MediaType? mediaType) {
     switch (mediaType) {
       case MediaType.image:
         return Icons.image_not_supported_outlined;
@@ -190,5 +248,22 @@ class ImagePreviewError extends StatelessWidget {
       default:
         return Icons.error_outline_rounded;
     }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+
+    // Don't display the associated icon if blur is enabled, otherwise there will be two icons displayed at once.
+    if (blur) return const SizedBox.shrink();
+
+    return Center(
+      child: Icon(
+        _getErrorIcon(mediaType),
+        color: theme.colorScheme.onSecondaryContainer.withValues(
+          alpha: viewed ? 0.55 : 1.0,
+        ),
+      ),
+    );
   }
 }

--- a/lib/shared/link_information.dart
+++ b/lib/shared/link_information.dart
@@ -9,16 +9,18 @@ import 'package:thunder/utils/links.dart';
 /// A widget that displays information about a link, including the link's media type if applicable.
 ///
 /// A custom [handleTapImage] callback can be provided to handle tap events on the link information.
-class LinkInformation extends StatefulWidget {
-  /// The view mode of the media
-  final ViewMode viewMode;
-
-  /// URL of the media
-  final String? originURL;
+class LinkInformation extends StatelessWidget {
+  /// URL of the link
+  final String? url;
 
   /// Type of media (image, link, text, etc.)
   final MediaType? mediaType;
 
+  /// The view mode of the media
+  final ViewMode viewMode;
+
+  /// Whether to show edge to edge images. This is used to determine the border radius of the container.
+  /// TODO: Potentially fetch this from ThunderBloc. Doing so will affect other parts of the app (e.g., post body)
   final bool showEdgeToEdgeImages;
 
   /// Custom callback function for when the link is tapped
@@ -29,57 +31,68 @@ class LinkInformation extends StatefulWidget {
 
   const LinkInformation({
     super.key,
-    required this.viewMode,
-    this.originURL,
+    this.url,
     this.mediaType,
+    required this.viewMode,
     this.showEdgeToEdgeImages = false,
     this.onTap,
     this.onLongPress,
   });
 
-  @override
-  State<LinkInformation> createState() => _LinkInformationState();
-}
-
-class _LinkInformationState extends State<LinkInformation> {
-  @override
-  Widget build(BuildContext context) {
-    final theme = Theme.of(context);
-
-    final icon = switch (widget.mediaType) {
+  /// Returns the appropriate icon for the media type
+  IconData _getIconForMediaType() {
+    return switch (mediaType) {
       MediaType.image => Icons.image_outlined,
       MediaType.video => Icons.play_arrow_rounded,
       MediaType.text => Icons.wysiwyg_rounded,
       _ => Icons.link_rounded,
     };
+  }
+
+  /// Handles tap events on the link
+  void _handleTap(BuildContext context) {
+    if (onTap != null) {
+      onTap?.call();
+      return;
+    }
+
+    // Fallback to opening the link in the browser
+    handleLink(context, url: url!);
+  }
+
+  /// Handles long press events on the link
+  void _handleLongPress(BuildContext context) {
+    if (onLongPress != null) {
+      onLongPress?.call();
+      return;
+    }
+
+    if (mediaType == MediaType.link) {
+      handleLinkLongPress(context, url!, url);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final icon = _getIconForMediaType();
+
+    final borderRadius = BorderRadius.circular(showEdgeToEdgeImages ? 0 : 12);
 
     return Semantics(
       link: true,
       child: InkWell(
-        customBorder: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
-        onTap: () {
-          if (widget.onTap != null) {
-            widget.onTap?.call();
-            return;
-          }
-
-          // Fallback to opening the link in the browser
-          handleLink(context, url: widget.originURL!);
-        },
-        onLongPress: () {
-          if (widget.onLongPress != null) {
-            widget.onLongPress?.call();
-            return;
-          }
-
-          if (widget.mediaType == MediaType.link) {
-            handleLinkLongPress(context, widget.originURL!, widget.originURL);
-          }
-        },
+        customBorder: RoundedRectangleBorder(borderRadius: borderRadius),
+        onTap: () => _handleTap(context),
+        onLongPress: () => _handleLongPress(context),
         child: Container(
           decoration: BoxDecoration(
-            borderRadius: BorderRadius.circular(widget.showEdgeToEdgeImages ? 0 : 12),
-            color: ElevationOverlay.applySurfaceTint(theme.colorScheme.surface.withValues(alpha: 0.8), theme.colorScheme.surfaceTint, 10),
+            borderRadius: borderRadius,
+            color: ElevationOverlay.applySurfaceTint(
+              theme.colorScheme.surface.withValues(alpha: 0.8),
+              theme.colorScheme.surfaceTint,
+              10,
+            ),
           ),
           padding: const EdgeInsets.symmetric(horizontal: 8.0, vertical: 8.0),
           child: Row(
@@ -88,10 +101,10 @@ class _LinkInformationState extends State<LinkInformation> {
                 padding: const EdgeInsets.only(right: 8.0),
                 child: Icon(icon, color: theme.colorScheme.onSecondaryContainer),
               ),
-              if (widget.viewMode != ViewMode.compact)
+              if (viewMode != ViewMode.compact)
                 Expanded(
                   child: Text(
-                    widget.originURL!,
+                    url!,
                     overflow: TextOverflow.ellipsis,
                     style: theme.textTheme.bodyMedium,
                   ),

--- a/lib/shared/media/media_view.dart
+++ b/lib/shared/media/media_view.dart
@@ -167,7 +167,7 @@ class _MediaViewState extends State<MediaView> with TickerProviderStateMixin {
     if (widget.viewMode == ViewMode.comfortable && (widget.hideThumbnails || !isImage)) {
       return LinkInformation(
         viewMode: widget.viewMode,
-        originURL: widget.media.originalUrl,
+        url: widget.media.originalUrl,
         mediaType: widget.media.mediaType,
         onTap: () {
           handleTap();
@@ -224,7 +224,7 @@ class _MediaViewState extends State<MediaView> with TickerProviderStateMixin {
                   child: LinkInformation(
                     viewMode: widget.viewMode,
                     mediaType: widget.media.mediaType,
-                    originURL: widget.media.originalUrl ?? '',
+                    url: widget.media.originalUrl ?? '',
                     showEdgeToEdgeImages: widget.edgeToEdgeImages,
                   ),
                 ),
@@ -289,7 +289,7 @@ class _MediaViewState extends State<MediaView> with TickerProviderStateMixin {
                       child: LinkInformation(
                         viewMode: widget.viewMode,
                         mediaType: widget.media.mediaType,
-                        originURL: widget.media.originalUrl ?? '',
+                        url: widget.media.originalUrl ?? '',
                         showEdgeToEdgeImages: widget.edgeToEdgeImages,
                       ),
                     ),

--- a/lib/shared/media/media_view_text.dart
+++ b/lib/shared/media/media_view_text.dart
@@ -25,22 +25,33 @@ class MediaViewText extends StatelessWidget {
     this.read,
   });
 
+  /// Extracts plain text from markdown/HTML content.
+  /// TODO: Move this parsing outside of the UI layer to improve performance.
+  String? parseText() {
+    if (text?.isNotEmpty != true) return null;
+
+    final htmlText = cleanImagesFromHtml(markdownToHtml(text!));
+    return parse(parse(htmlText).body?.text).documentElement?.text ?? text;
+  }
+
+  /// Calculates the optimal font size based on text length.
+  double _calculateFontSize(String text) {
+    return min(20, max(4.5, (20 * (1 / log(text.length)))));
+  }
+
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
-    final readColor = theme.colorScheme.onSecondaryContainer.withValues(alpha: 0.55);
-    final unreadColor = theme.colorScheme.onSecondaryContainer.withValues(alpha: 0.7);
 
-    String? plainText;
+    final baseColor = theme.colorScheme.onSecondaryContainer;
+    final readColor = baseColor.withValues(alpha: 0.55);
+    final unreadColor = baseColor.withValues(alpha: 0.7);
+    final color = read == true ? readColor : unreadColor;
 
-    if (text?.isNotEmpty == true) {
-      final htmlText = cleanImagesFromHtml(markdownToHtml(text!));
-      plainText = parse(parse(htmlText).body?.text).documentElement?.text ?? text;
-    }
+    final plainText = parseText();
 
-    return Container(
-      clipBehavior: Clip.hardEdge,
-      decoration: BoxDecoration(borderRadius: BorderRadius.circular(12)),
+    return ClipRRect(
+      borderRadius: BorderRadius.circular(12),
       child: Container(
         height: ViewMode.compact.height,
         width: ViewMode.compact.height,
@@ -48,18 +59,17 @@ class MediaViewText extends StatelessWidget {
         child: plainText != null
             ? Padding(
                 padding: const EdgeInsets.all(10.0),
-                child: Align(
-                  alignment: Alignment.center,
+                child: Center(
                   child: Text(
                     plainText,
                     style: TextStyle(
-                      fontSize: min(20, max(4.5, (20 * (1 / log(plainText.length))))),
-                      color: read == true ? readColor : unreadColor,
+                      fontSize: _calculateFontSize(plainText),
+                      color: color,
                     ),
                   ),
                 ),
               )
-            : Icon(Icons.text_fields_rounded, color: read == true ? readColor : unreadColor),
+            : Icon(Icons.text_fields_rounded, color: color),
       ),
     );
   }


### PR DESCRIPTION
## Pull Request Description

This PR applies some general improvements to some frequently used widgets - in particular `PostCardTitle`, `PostStatusIcon`, `ImagePreview`, `LinkInformation`, `MediaViewText`.

The main goal here is to add documentation wherever necessary and improve the readability of the `build` methods for these widgets (by extracting out some logic into functions, and splitting up larger widgets into smaller ones). This will help to determine possible performance improvements to target in the future. For example, moving parsing of the post body for `MediaViewText` out of the build method and into more appropriate layers (e.g., when parsing posts)

<!--- Please describe what was changed -->

## Issue Being Fixed

<!-- Please describe the problem that is being fixed and, if applicable, reference a GitHub issue -->

Issue Number: N/A

## Screenshots / Recordings

<!-- This section is optional but highly recommended to show off your changes! -->

## Checklist

- [ ] If a new package was added, did you ensure it uses an appropriate license and is actively maintained?
- [ ] Did you use localized strings (and added appropriate descriptions) where applicable?
- [ ] Did you add `semanticLabel`s where applicable for accessibility?
