### PR TITLE
Migrate app bar title logic from feed page to app bars

### DIFF
--- a/lib/account/widgets/account_page_app_bar.dart
+++ b/lib/account/widgets/account_page_app_bar.dart
@@ -15,33 +15,70 @@ import 'package:thunder/utils/instance.dart';
 import 'package:thunder/utils/navigation.dart';
 
 /// Holds the app bar for the account page
-class AccountPageAppBar extends StatelessWidget {
-  const AccountPageAppBar({super.key, this.showAppBarTitle = true});
+class AccountPageAppBar extends StatefulWidget {
+  const AccountPageAppBar({super.key, required this.scrollController});
 
-  /// Whether to show the app bar title
-  final bool showAppBarTitle;
+  /// The scroll controller used to determine when to show/hide the app bar title
+  final ScrollController scrollController;
+
+  @override
+  State<AccountPageAppBar> createState() => _AccountPageAppBarState();
+}
+
+class _AccountPageAppBarState extends State<AccountPageAppBar> {
+  /// Boolean which indicates whether the title on the app bar should be shown
+  bool showAppBarTitle = false;
+
+  @override
+  void initState() {
+    super.initState();
+    widget.scrollController.addListener(onScroll);
+  }
+
+  @override
+  void dispose() {
+    widget.scrollController.removeListener(onScroll);
+    super.dispose();
+  }
+
+  void onScroll() {
+    // Updates the [showAppBarTitle] value when the user has scrolled past a given threshold
+    if (widget.scrollController.position.pixels > 100.0 && showAppBarTitle == false) {
+      setState(() => showAppBarTitle = true);
+    } else if (widget.scrollController.position.pixels < 100.0 && showAppBarTitle == true) {
+      setState(() => showAppBarTitle = false);
+    }
+  }
 
   @override
   Widget build(BuildContext context) {
     final l10n = AppLocalizations.of(context)!;
     final state = context.read<ThunderBloc>().state;
 
-    return SliverAppBar(
-      pinned: true,
-      centerTitle: false,
-      titleSpacing: 0.0,
-      toolbarHeight: APP_BAR_HEIGHT,
-      surfaceTintColor: state.hideTopBarOnScroll ? Colors.transparent : null,
-      title: AccountAppBarTitle(visible: showAppBarTitle),
-      leading: IconButton(
-        onPressed: () {
-          HapticFeedback.mediumImpact();
-          showProfileModalSheet(context);
-        },
-        icon: Icon(Icons.people_alt_rounded, semanticLabel: l10n.profiles),
-        tooltip: l10n.profiles,
+    return BlocListener<FeedBloc, FeedState>(
+      listenWhen: (previous, current) => current.status == FeedStatus.initial,
+      listener: (context, state) {
+        if (state.status == FeedStatus.initial) {
+          setState(() => showAppBarTitle = false);
+        }
+      },
+      child: SliverAppBar(
+        pinned: true,
+        centerTitle: false,
+        titleSpacing: 0.0,
+        toolbarHeight: APP_BAR_HEIGHT,
+        surfaceTintColor: state.hideTopBarOnScroll ? Colors.transparent : null,
+        title: AccountAppBarTitle(visible: showAppBarTitle),
+        leading: IconButton(
+          onPressed: () {
+            HapticFeedback.mediumImpact();
+            showProfileModalSheet(context);
+          },
+          icon: Icon(Icons.people_alt_rounded, semanticLabel: l10n.profiles),
+          tooltip: l10n.profiles,
+        ),
+        actions: [AccountAppBarUserActions()],
       ),
-      actions: [AccountAppBarUserActions()],
     );
   }
 }

--- a/lib/feed/view/feed_page.dart
+++ b/lib/feed/view/feed_page.dart
@@ -171,9 +171,6 @@ class FeedView extends StatefulWidget {
 class _FeedViewState extends State<FeedView> {
   final ScrollController _scrollController = ScrollController();
 
-  /// Boolean which indicates whether the title on the app bar should be shown
-  bool showAppBarTitle = false;
-
   /// Indicates which "tab" is selected. This is used for user profiles, where we can switch between posts and comments
   List<bool> selectedUserOption = [true, false];
 
@@ -187,13 +184,6 @@ class _FeedViewState extends State<FeedView> {
     super.initState();
 
     _scrollController.addListener(() {
-      // Updates the [showAppBarTitle] value when the user has scrolled past a given threshold
-      if (_scrollController.position.pixels > 100.0 && showAppBarTitle == false) {
-        setState(() => showAppBarTitle = true);
-      } else if (_scrollController.position.pixels < 100.0 && showAppBarTitle == true) {
-        setState(() => showAppBarTitle = false);
-      }
-
       // Fetches new posts when the user has scrolled past 70% list
       if (_scrollController.position.pixels > _scrollController.position.maxScrollExtent * 0.7 && context.read<FeedBloc>().state.status != FeedStatus.fetching) {
         context.read<FeedBloc>().add(FeedFetchedEvent(feedTypeSubview: selectedUserOption[0] ? FeedTypeSubview.post : FeedTypeSubview.comment));
@@ -315,7 +305,6 @@ class _FeedViewState extends State<FeedView> {
           top: false,
           child: BlocConsumer<FeedBloc, FeedState>(
             listenWhen: (previous, current) {
-              if (current.status == FeedStatus.initial) setState(() => showAppBarTitle = false);
               if (previous.scrollId != current.scrollId) _scrollController.animateTo(0, duration: const Duration(milliseconds: 300), curve: Curves.easeInOut);
               if (previous.dismissReadId != current.dismissReadId) dismissRead();
               if (current.dismissBlockedUserId != null || current.dismissBlockedCommunityId != null) dismissBlockedUsersAndCommunities(current.dismissBlockedUserId, current.dismissBlockedCommunityId);
@@ -362,11 +351,8 @@ class _FeedViewState extends State<FeedView> {
                       controller: _scrollController,
                       slivers: <Widget>[
                         widget.feedType == FeedType.account
-                            ? AccountPageAppBar(showAppBarTitle: showAppBarTitle)
-                            : FeedPageAppBar(
-                                showAppBarTitle: (state.feedType == FeedType.general && state.status != FeedStatus.initial) ? true : showAppBarTitle,
-                                scaffoldStateKey: widget.scaffoldStateKey,
-                              ),
+                            ? AccountPageAppBar(scrollController: _scrollController)
+                            : FeedPageAppBar(scrollController: _scrollController, scaffoldStateKey: widget.scaffoldStateKey),
                         // Display loading indicator until the feed is fetched
                         if (state.status == FeedStatus.initial)
                           const SliverFillRemaining(

--- a/lib/feed/widgets/feed_page_app_bar.dart
+++ b/lib/feed/widgets/feed_page_app_bar.dart
@@ -22,10 +22,10 @@ import 'package:thunder/thunder/bloc/thunder_bloc.dart';
 
 /// Holds the app bar for the feed page. The app bar actions changes depending on the type of feed (general, community, user)
 class FeedPageAppBar extends StatefulWidget {
-  const FeedPageAppBar({super.key, this.showAppBarTitle = true, this.scaffoldStateKey});
+  const FeedPageAppBar({super.key, required this.scrollController, this.scaffoldStateKey});
 
-  /// Whether to show the app bar title
-  final bool showAppBarTitle;
+  /// The scroll controller used to determine when to show/hide the app bar title
+  final ScrollController scrollController;
 
   /// The scaffold key of the parent scaffold holding the drawer.
   /// This is used to determine if we are in a pushed navigation stack.
@@ -38,6 +38,30 @@ class FeedPageAppBar extends StatefulWidget {
 class _FeedPageAppBarState extends State<FeedPageAppBar> {
   ThunderUser? user;
 
+  /// Boolean which indicates whether the title on the app bar should be shown
+  bool showAppBarTitle = false;
+
+  @override
+  void initState() {
+    super.initState();
+    widget.scrollController.addListener(_onScroll);
+  }
+
+  @override
+  void dispose() {
+    widget.scrollController.removeListener(_onScroll);
+    super.dispose();
+  }
+
+  void _onScroll() {
+    // Updates the [showAppBarTitle] value when the user has scrolled past a given threshold
+    if (widget.scrollController.position.pixels > 100.0 && showAppBarTitle == false) {
+      setState(() => showAppBarTitle = true);
+    } else if (widget.scrollController.position.pixels < 100.0 && showAppBarTitle == true) {
+      setState(() => showAppBarTitle = false);
+    }
+  }
+
   @override
   Widget build(BuildContext context) {
     final feedBloc = context.read<FeedBloc>();
@@ -46,57 +70,65 @@ class _FeedPageAppBarState extends State<FeedPageAppBar> {
 
     user = profileState.reload ? profileState.user : user;
 
-    return SliverAppBar(
-      pinned: !thunderBloc.state.hideTopBarOnScroll,
-      floating: true,
-      centerTitle: false,
-      toolbarHeight: APP_BAR_HEIGHT,
-      surfaceTintColor: thunderBloc.state.hideTopBarOnScroll ? Colors.transparent : null,
-      title: FeedAppBarTitle(visible: widget.showAppBarTitle),
-      leadingWidth: widget.scaffoldStateKey != null && thunderBloc.state.useProfilePictureForDrawer && profileState.isLoggedIn ? 50 : null,
-      leading: feedBloc.state.status == FeedStatus.initial
-          ? null
-          : widget.scaffoldStateKey != null && thunderBloc.state.useProfilePictureForDrawer && profileState.isLoggedIn
-              ? Padding(
-                  padding: const EdgeInsets.only(left: 16.0),
-                  child: Semantics(
-                    label: MaterialLocalizations.of(context).openAppDrawerTooltip,
-                    child: Stack(
-                      children: [
-                        if (user != null)
-                          Align(
-                            alignment: Alignment.center,
-                            child: UserAvatar(user: user!),
+    return BlocListener<FeedBloc, FeedState>(
+      listenWhen: (previous, current) => current.status == FeedStatus.initial,
+      listener: (context, state) {
+        if (state.status == FeedStatus.initial) {
+          setState(() => showAppBarTitle = false);
+        }
+      },
+      child: SliverAppBar(
+        pinned: !thunderBloc.state.hideTopBarOnScroll,
+        floating: true,
+        centerTitle: false,
+        toolbarHeight: APP_BAR_HEIGHT,
+        surfaceTintColor: thunderBloc.state.hideTopBarOnScroll ? Colors.transparent : null,
+        title: FeedAppBarTitle(visible: (feedBloc.state.feedType == FeedType.general && feedBloc.state.status != FeedStatus.initial) ? true : showAppBarTitle),
+        leadingWidth: widget.scaffoldStateKey != null && thunderBloc.state.useProfilePictureForDrawer && profileState.isLoggedIn ? 50 : null,
+        leading: feedBloc.state.status == FeedStatus.initial
+            ? null
+            : widget.scaffoldStateKey != null && thunderBloc.state.useProfilePictureForDrawer && profileState.isLoggedIn
+                ? Padding(
+                    padding: const EdgeInsets.only(left: 16.0),
+                    child: Semantics(
+                      label: MaterialLocalizations.of(context).openAppDrawerTooltip,
+                      child: Stack(
+                        children: [
+                          if (user != null)
+                            Align(
+                              alignment: Alignment.center,
+                              child: UserAvatar(user: user!),
+                            ),
+                          Material(
+                            color: Colors.transparent,
+                            child: InkWell(
+                              customBorder: const CircleBorder(),
+                              onTap: () => _openDrawerOrGoBack(context, feedBloc),
+                            ),
                           ),
-                        Material(
-                          color: Colors.transparent,
-                          child: InkWell(
-                            customBorder: const CircleBorder(),
-                            onTap: () => _openDrawerOrGoBack(context, feedBloc),
-                          ),
-                        ),
-                      ],
+                        ],
+                      ),
                     ),
+                  )
+                : IconButton(
+                    icon: widget.scaffoldStateKey == null
+                        ? (!kIsWeb && Platform.isIOS
+                            ? Icon(
+                                Icons.arrow_back_ios_new_rounded,
+                                semanticLabel: MaterialLocalizations.of(context).backButtonTooltip,
+                              )
+                            : Icon(Icons.arrow_back_rounded, semanticLabel: MaterialLocalizations.of(context).backButtonTooltip))
+                        : Icon(Icons.menu, semanticLabel: MaterialLocalizations.of(context).openAppDrawerTooltip),
+                    onPressed: () => _openDrawerOrGoBack(context, feedBloc),
                   ),
-                )
-              : IconButton(
-                  icon: widget.scaffoldStateKey == null
-                      ? (!kIsWeb && Platform.isIOS
-                          ? Icon(
-                              Icons.arrow_back_ios_new_rounded,
-                              semanticLabel: MaterialLocalizations.of(context).backButtonTooltip,
-                            )
-                          : Icon(Icons.arrow_back_rounded, semanticLabel: MaterialLocalizations.of(context).backButtonTooltip))
-                      : Icon(Icons.menu, semanticLabel: MaterialLocalizations.of(context).openAppDrawerTooltip),
-                  onPressed: () => _openDrawerOrGoBack(context, feedBloc),
-                ),
-      actions: (feedBloc.state.status != FeedStatus.initial && feedBloc.state.status != FeedStatus.failureLoadingCommunity && feedBloc.state.status != FeedStatus.failureLoadingUser)
-          ? [
-              if (feedBloc.state.feedType == FeedType.general) const FeedAppBarGeneralActions(),
-              if (feedBloc.state.feedType == FeedType.community) const FeedAppBarCommunityActions(),
-              if (feedBloc.state.feedType == FeedType.user) const FeedAppBarUserActions(),
-            ]
-          : [],
+        actions: (feedBloc.state.status != FeedStatus.initial && feedBloc.state.status != FeedStatus.failureLoadingCommunity && feedBloc.state.status != FeedStatus.failureLoadingUser)
+            ? [
+                if (feedBloc.state.feedType == FeedType.general) const FeedAppBarGeneralActions(),
+                if (feedBloc.state.feedType == FeedType.community) const FeedAppBarCommunityActions(),
+                if (feedBloc.state.feedType == FeedType.user) const FeedAppBarUserActions(),
+              ]
+            : [],
+      ),
     );
   }
 


### PR DESCRIPTION
## Pull Request Description

This PR migrates the logic for handling the visibility of the app bar title from the feed page to their respective app bars. This change was previously mentioned in #1742, but I've decided to split up that PR

> The `showAppBarTitle` logic has been moved from FeedPage to its respective app bar widgets (FeedPageAppBar and AccountPageAppBar). This change ensures that `setState` calls are handled within the app bar widgets and prevents unnecessary rebuilds of the entire FeedPage when `showAppBarTitle` updates.

<!--- Please describe what was changed -->

## Issue Being Fixed

<!-- Please describe the problem that is being fixed and, if applicable, reference a GitHub issue -->

Issue Number: N/A

## Screenshots / Recordings

<!-- This section is optional but highly recommended to show off your changes! -->

## Checklist

- [ ] If a new package was added, did you ensure it uses an appropriate license and is actively maintained?
- [ ] Did you use localized strings (and added appropriate descriptions) where applicable?
- [ ] Did you add `semanticLabel`s where applicable for accessibility?
