### PR TITLE
Improve notification user handling

### DIFF
--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -2571,6 +2571,10 @@
   "@suggestedTitle": {
     "description": "Suggested title for the post."
   },
+  "switchedAccount": "Switched to {username}",
+  "@switchedAccount": {
+    "description": "Message shown to the user when Thunder automatically switches accounts"
+  },
   "system": "System",
   "@system": {
     "description": "Describes using the system settings for theme"

--- a/lib/localizations/app_localizations.dart
+++ b/lib/localizations/app_localizations.dart
@@ -4688,6 +4688,12 @@ abstract class AppLocalizations {
   /// **'Suggested title'**
   String get suggestedTitle;
 
+  /// Message shown to the user when Thunder automatically switches accounts
+  ///
+  /// In en, this message translates to:
+  /// **'Switched to {username}'**
+  String switchedAccount(Object username);
+
   /// Describes using the system settings for theme
   ///
   /// In en, this message translates to:

--- a/lib/localizations/app_localizations_ar.dart
+++ b/lib/localizations/app_localizations_ar.dart
@@ -2578,6 +2578,11 @@ class AppLocalizationsAr extends AppLocalizations {
   String get suggestedTitle => 'Suggested title';
 
   @override
+  String switchedAccount(Object username) {
+    return 'Switched to $username';
+  }
+
+  @override
   String get system => 'System';
 
   @override

--- a/lib/localizations/app_localizations_cs.dart
+++ b/lib/localizations/app_localizations_cs.dart
@@ -2584,6 +2584,11 @@ class AppLocalizationsCs extends AppLocalizations {
   String get suggestedTitle => 'Navrhovaný název';
 
   @override
+  String switchedAccount(Object username) {
+    return 'Switched to $username';
+  }
+
+  @override
   String get system => 'Systém';
 
   @override

--- a/lib/localizations/app_localizations_de.dart
+++ b/lib/localizations/app_localizations_de.dart
@@ -2622,6 +2622,11 @@ class AppLocalizationsDe extends AppLocalizations {
   String get suggestedTitle => 'Vorgeschlagener Titel';
 
   @override
+  String switchedAccount(Object username) {
+    return 'Switched to $username';
+  }
+
+  @override
   String get system => 'System';
 
   @override

--- a/lib/localizations/app_localizations_en.dart
+++ b/lib/localizations/app_localizations_en.dart
@@ -2586,6 +2586,11 @@ class AppLocalizationsEn extends AppLocalizations {
   String get suggestedTitle => 'Suggested title';
 
   @override
+  String switchedAccount(Object username) {
+    return 'Switched to $username';
+  }
+
+  @override
   String get system => 'System';
 
   @override

--- a/lib/localizations/app_localizations_eo.dart
+++ b/lib/localizations/app_localizations_eo.dart
@@ -2568,6 +2568,11 @@ class AppLocalizationsEo extends AppLocalizations {
   String get suggestedTitle => 'Sugestita titolo';
 
   @override
+  String switchedAccount(Object username) {
+    return 'Switched to $username';
+  }
+
+  @override
   String get system => 'System';
 
   @override

--- a/lib/localizations/app_localizations_es.dart
+++ b/lib/localizations/app_localizations_es.dart
@@ -2641,6 +2641,11 @@ class AppLocalizationsEs extends AppLocalizations {
   String get suggestedTitle => 'Título sugerido';
 
   @override
+  String switchedAccount(Object username) {
+    return 'Switched to $username';
+  }
+
+  @override
   String get system => 'Sistema';
 
   @override

--- a/lib/localizations/app_localizations_fi.dart
+++ b/lib/localizations/app_localizations_fi.dart
@@ -2572,6 +2572,11 @@ class AppLocalizationsFi extends AppLocalizations {
   String get suggestedTitle => 'Otsikkoehdotus';
 
   @override
+  String switchedAccount(Object username) {
+    return 'Switched to $username';
+  }
+
+  @override
   String get system => 'System';
 
   @override

--- a/lib/localizations/app_localizations_fr.dart
+++ b/lib/localizations/app_localizations_fr.dart
@@ -2599,6 +2599,11 @@ class AppLocalizationsFr extends AppLocalizations {
   String get suggestedTitle => 'Titre suggéré';
 
   @override
+  String switchedAccount(Object username) {
+    return 'Switched to $username';
+  }
+
+  @override
   String get system => 'System';
 
   @override

--- a/lib/localizations/app_localizations_hu.dart
+++ b/lib/localizations/app_localizations_hu.dart
@@ -2586,6 +2586,11 @@ class AppLocalizationsHu extends AppLocalizations {
   String get suggestedTitle => 'Suggested title';
 
   @override
+  String switchedAccount(Object username) {
+    return 'Switched to $username';
+  }
+
+  @override
   String get system => 'System';
 
   @override

--- a/lib/localizations/app_localizations_it.dart
+++ b/lib/localizations/app_localizations_it.dart
@@ -2583,6 +2583,11 @@ class AppLocalizationsIt extends AppLocalizations {
   String get suggestedTitle => 'Titolo consigliato';
 
   @override
+  String switchedAccount(Object username) {
+    return 'Switched to $username';
+  }
+
+  @override
   String get system => 'Sistema';
 
   @override

--- a/lib/localizations/app_localizations_nb.dart
+++ b/lib/localizations/app_localizations_nb.dart
@@ -2569,6 +2569,11 @@ class AppLocalizationsNb extends AppLocalizations {
   String get suggestedTitle => 'Suggested title';
 
   @override
+  String switchedAccount(Object username) {
+    return 'Switched to $username';
+  }
+
+  @override
   String get system => 'System';
 
   @override

--- a/lib/localizations/app_localizations_nl.dart
+++ b/lib/localizations/app_localizations_nl.dart
@@ -2585,6 +2585,11 @@ class AppLocalizationsNl extends AppLocalizations {
   String get suggestedTitle => 'Voor­gestelde titel';
 
   @override
+  String switchedAccount(Object username) {
+    return 'Switched to $username';
+  }
+
+  @override
   String get system => 'Systeem';
 
   @override

--- a/lib/localizations/app_localizations_pl.dart
+++ b/lib/localizations/app_localizations_pl.dart
@@ -2588,6 +2588,11 @@ class AppLocalizationsPl extends AppLocalizations {
   String get suggestedTitle => 'Sugerowany tytuł';
 
   @override
+  String switchedAccount(Object username) {
+    return 'Switched to $username';
+  }
+
+  @override
   String get system => 'System';
 
   @override

--- a/lib/localizations/app_localizations_pt.dart
+++ b/lib/localizations/app_localizations_pt.dart
@@ -2595,6 +2595,11 @@ class AppLocalizationsPt extends AppLocalizations {
   String get suggestedTitle => 'Suggested title';
 
   @override
+  String switchedAccount(Object username) {
+    return 'Switched to $username';
+  }
+
+  @override
   String get system => 'System';
 
   @override

--- a/lib/localizations/app_localizations_ru.dart
+++ b/lib/localizations/app_localizations_ru.dart
@@ -2579,6 +2579,11 @@ class AppLocalizationsRu extends AppLocalizations {
   String get suggestedTitle => 'Предлагаемое название';
 
   @override
+  String switchedAccount(Object username) {
+    return 'Switched to $username';
+  }
+
+  @override
   String get system => 'Система';
 
   @override

--- a/lib/localizations/app_localizations_sk.dart
+++ b/lib/localizations/app_localizations_sk.dart
@@ -2587,6 +2587,11 @@ class AppLocalizationsSk extends AppLocalizations {
   String get suggestedTitle => 'Navrhovaný názov';
 
   @override
+  String switchedAccount(Object username) {
+    return 'Switched to $username';
+  }
+
+  @override
   String get system => 'Systém';
 
   @override

--- a/lib/localizations/app_localizations_sv.dart
+++ b/lib/localizations/app_localizations_sv.dart
@@ -2573,6 +2573,11 @@ class AppLocalizationsSv extends AppLocalizations {
   String get suggestedTitle => 'Suggested title';
 
   @override
+  String switchedAccount(Object username) {
+    return 'Switched to $username';
+  }
+
+  @override
   String get system => 'System';
 
   @override

--- a/lib/localizations/app_localizations_ta.dart
+++ b/lib/localizations/app_localizations_ta.dart
@@ -2629,6 +2629,11 @@ class AppLocalizationsTa extends AppLocalizations {
   String get suggestedTitle => 'பரிந்துரைக்கப்பட்ட தலைப்பு';
 
   @override
+  String switchedAccount(Object username) {
+    return 'Switched to $username';
+  }
+
+  @override
   String get system => 'மண்டலம்';
 
   @override

--- a/lib/localizations/app_localizations_tr.dart
+++ b/lib/localizations/app_localizations_tr.dart
@@ -2604,6 +2604,11 @@ class AppLocalizationsTr extends AppLocalizations {
   String get suggestedTitle => 'Önerilen başlık';
 
   @override
+  String switchedAccount(Object username) {
+    return 'Switched to $username';
+  }
+
+  @override
   String get system => 'Sistem';
 
   @override

--- a/lib/localizations/app_localizations_uk.dart
+++ b/lib/localizations/app_localizations_uk.dart
@@ -2582,6 +2582,11 @@ class AppLocalizationsUk extends AppLocalizations {
   String get suggestedTitle => 'Suggested title';
 
   @override
+  String switchedAccount(Object username) {
+    return 'Switched to $username';
+  }
+
+  @override
   String get system => 'System';
 
   @override

--- a/lib/localizations/app_localizations_zh.dart
+++ b/lib/localizations/app_localizations_zh.dart
@@ -2586,6 +2586,11 @@ class AppLocalizationsZh extends AppLocalizations {
   String get suggestedTitle => 'Suggested title';
 
   @override
+  String switchedAccount(Object username) {
+    return 'Switched to $username';
+  }
+
+  @override
   String get system => 'System';
 
   @override

--- a/lib/utils/navigation.dart
+++ b/lib/utils/navigation.dart
@@ -7,6 +7,7 @@ import 'package:collection/collection.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:lemmy_api_client/v3.dart' hide ModlogActionType;
 import 'package:swipeable_page_route/swipeable_page_route.dart';
+import 'package:thunder/core/enums/full_name.dart';
 import 'package:thunder/localizations/app_localizations.dart';
 
 import 'package:thunder/account/account.dart';
@@ -470,11 +471,8 @@ void navigateToNotificationReplyPage(BuildContext context, {required int? replyI
 
   final ThunderBloc thunderBloc = context.read<ThunderBloc>();
   final bool reduceAnimations = thunderBloc.state.reduceAnimations;
+  final AppLocalizations l10n = AppLocalizations.of(context)!;
   Account? account = await fetchActiveProfile();
-
-  bool switchedAccount = false;
-  String? originalAccount = account.id;
-  String? originalAnonymousInstance = context.mounted ? context.read<ThunderBloc>().state.currentAnonymousInstance : null;
 
   if (account.id != accountId && accountId != null && context.mounted) {
     // Switch to the notification's account without reloading the app
@@ -483,8 +481,8 @@ void navigateToNotificationReplyPage(BuildContext context, {required int? replyI
     // Set the account locally here so we don't have to wait for the event to complete
     account = await Account.fetchAccount(accountId);
 
-    // Note that we switched so we can switch back
-    switchedAccount = true;
+    // Show the user a message indicating that we switched
+    showSnackbar(l10n.switchedAccount(generateUserFullName(context, account?.username, account?.displayName, account?.instance)));
   }
 
   // If account is still null, we can't do anything.
@@ -535,12 +533,6 @@ void navigateToNotificationReplyPage(BuildContext context, {required int? replyI
     );
 
     pushOnTopOfLoadingPage(context, route).then((_) {
-      // If needed, switch back to the original account or anonymous instance
-      if (switchedAccount) {
-        // We switched from an account, so switch back
-        context.read<ProfileBloc>().add(SwitchProfile(accountId: originalAccount, reload: false));
-      }
-
       context.read<InboxBloc>().add(const GetInboxEvent(reset: true, inboxType: InboxType.all));
     });
   }


### PR DESCRIPTION
## Pull Request Description

<!--- Please describe what was changed -->

This PR makes a slight tweak to how notifications across multiple accounts are handled, specifically the use case of opening a notification directed at a user which is not the currently selected user in Thunder.

The previous behavior is:
- Temporarily switch the context of the app to the new user
- Perform any actions while looking at the notification as the new user
- Restore the previous context when navigating out of the notifications page

This workflow has the potential for confusion regarding which user you are when you look at the notification, as well as when you navigate back (it changes without any indication), and it has potential for bugs as well.

I propose a new workflow, which is to *explicitly* change the selected user to the one that received the notification, and tell the user we are making this change via a snackbar. Then do *not* automatically switch back to another user. That can be done manually if desired.

This change is inspired by how some popular social media apps work, and I think it makes the whole interaction much more clear and straightforward.

## Issue Being Fixed

<!-- Please describe the problem that is being fixed and, if applicable, reference a GitHub issue -->

Issue Number: N/A

## Screenshots / Recordings

<!-- This section is optional but highly recommended to show off your changes! -->

https://github.com/user-attachments/assets/1315d9e1-c0c6-4708-a063-1fdbc6f3f8ac


## Checklist

- [ ] If a new package was added, did you ensure it uses an appropriate license and is actively maintained?
- [ ] Did you use localized strings (and added appropriate descriptions) where applicable?
- [ ] Did you add `semanticLabel`s where applicable for accessibility?
