### PR TITLE
User post/comment action chip toggle

### DIFF
--- a/lib/shared/chips/thunder_action_chip.dart
+++ b/lib/shared/chips/thunder_action_chip.dart
@@ -8,6 +8,9 @@ class ThunderActionChip extends StatelessWidget {
   /// The trailing icon to display in the action chip.
   final IconData? trailingIcon;
 
+  /// The size of the trailing icon.
+  final double? trailingIconSize;
+
   /// The label of the action chip.
   final String label;
 
@@ -17,7 +20,7 @@ class ThunderActionChip extends StatelessWidget {
   /// The function to call when the action chip is pressed.
   final void Function()? onPressed;
 
-  const ThunderActionChip({super.key, this.icon, this.trailingIcon, required this.label, this.onPressed, this.backgroundColor});
+  const ThunderActionChip({super.key, this.icon, this.trailingIcon, this.trailingIconSize, required this.label, this.onPressed, this.backgroundColor});
 
   @override
   Widget build(BuildContext context) {
@@ -28,7 +31,7 @@ class ThunderActionChip extends StatelessWidget {
       children: [
         if (icon != null) ...[Icon(icon, size: 15.0), const SizedBox(width: 5.0)],
         Text(label),
-        if (trailingIcon != null) ...[const SizedBox(width: 5.0), Icon(trailingIcon, size: 20.0)],
+        if (trailingIcon != null) ...[const SizedBox(width: 5.0), Icon(trailingIcon, size: trailingIconSize ?? 20.0)],
       ],
     );
 

--- a/lib/user/widgets/user_header/user_header_actions.dart
+++ b/lib/user/widgets/user_header/user_header_actions.dart
@@ -220,11 +220,16 @@ class _FeedTypeActionChip extends StatelessWidget {
     final icon = feedType == FeedTypeSubview.post ? Icons.article_rounded : Icons.chat_rounded;
     final label = feedType == FeedTypeSubview.post ? l10n.posts : l10n.comments;
 
-    return ThunderActionChip(
-      icon: icon,
-      trailingIcon: Icons.arrow_drop_down_rounded,
-      label: label,
-      onPressed: () => _showFeedTypePicker(context),
+    return AnimatedSize(
+      duration: const Duration(milliseconds: 500),
+      curve: Curves.easeInOutCubicEmphasized,
+      child: ThunderActionChip(
+        icon: icon,
+        trailingIcon: Icons.swap_horiz_rounded,
+        trailingIconSize: 17.0,
+        label: label,
+        onPressed: () => onChangeFeedType(feedType == FeedTypeSubview.post ? FeedTypeSubview.comment : FeedTypeSubview.post),
+      ),
     );
   }
 


### PR DESCRIPTION
## Pull Request Description

This PR adjusts the user post/comment action chip to be a toggle rather than a menu. Additionally, `trailingIconSize` was added in order to adjust the size of the trailing icon.

<!--- Please describe what was changed -->

## Issue Being Fixed

<!-- Please describe the problem that is being fixed and, if applicable, reference a GitHub issue -->

Issue Number: #1856

## Screenshots / Recordings

<!-- This section is optional but highly recommended to show off your changes! -->

## Checklist

- [ ] If a new package was added, did you ensure it uses an appropriate license and is actively maintained?
- [ ] Did you use localized strings (and added appropriate descriptions) where applicable?
- [ ] Did you add `semanticLabel`s where applicable for accessibility?
