### PR TITLE
Add language to post body metadata

### DIFF
--- a/lib/post/widgets/post_body/post_body.dart
+++ b/lib/post/widgets/post_body/post_body.dart
@@ -214,6 +214,7 @@ class _PostBodyState extends State<PostBody> with SingleTickerProviderStateMixin
 
     children.add(
       PostBodyMetadata(
+        languageId: post.languageId,
         commentCount: post.comments,
         unreadCommentCount: post.unreadComments,
         dateTime: post.updated?.toIso8601String() ?? post.created.toIso8601String(),

--- a/lib/post/widgets/post_body/post_body_metadata.dart
+++ b/lib/post/widgets/post_body/post_body_metadata.dart
@@ -6,6 +6,9 @@ import 'package:thunder/community/widgets/post_card_metadata.dart';
 ///
 /// This includes the total number of comments and the date/time the post was created or updated.
 class PostBodyMetadata extends StatelessWidget {
+  /// The language of the post. If null, no language will be displayed.
+  final int? languageId;
+
   /// The number of comments on the post. If null, no comment count will be displayed.
   final int? commentCount;
 
@@ -23,6 +26,7 @@ class PostBodyMetadata extends StatelessWidget {
 
   const PostBodyMetadata({
     super.key,
+    this.languageId,
     this.commentCount,
     this.unreadCommentCount,
     this.dateTime,
@@ -40,6 +44,7 @@ class PostBodyMetadata extends StatelessWidget {
           UrlPostCardMetaData(url: url, dim: false),
           Row(
             children: [
+              if (languageId != null && languageId != 0) LanguagePostCardMetaData(languageId: languageId, hasBeenRead: false),
               CommentCountPostCardMetaData(commentCount: commentCount, unreadCommentCount: unreadCommentCount ?? 0, dim: false),
               DateTimePostCardMetaData(dateTime: dateTime!, dim: false, edited: hasBeenEdited ?? false),
             ],


### PR DESCRIPTION
## Pull Request Description

This PR adds the post language to the metadata section of the post page, beside the number of comments. The language will only show up if its set (e.g., Undetermined will not show up)

<!--- Please describe what was changed -->

## Issue Being Fixed

<!-- Please describe the problem that is being fixed and, if applicable, reference a GitHub issue -->

Issue Number: #1870

## Screenshots / Recordings
![image](https://github.com/user-attachments/assets/da904999-8f19-4e51-a6c3-5b2ccefb9b01)

<!-- This section is optional but highly recommended to show off your changes! -->

## Checklist

- [ ] If a new package was added, did you ensure it uses an appropriate license and is actively maintained?
- [ ] Did you use localized strings (and added appropriate descriptions) where applicable?
- [ ] Did you add `semanticLabel`s where applicable for accessibility?
