### PR TITLE
Chore: refactor subscription status enum to internal enum

### DIFF
--- a/lib/comment/utils/comment.dart
+++ b/lib/comment/utils/comment.dart
@@ -3,6 +3,7 @@ import 'package:lemmy_api_client/v3.dart';
 import 'package:thunder/account/account.dart';
 import 'package:thunder/comment/comment.dart';
 import 'package:thunder/core/models/models.dart';
+import 'package:thunder/core/enums/subscription_status.dart';
 import 'package:thunder/core/singletons/lemmy_client.dart';
 import 'package:thunder/utils/global_context.dart';
 
@@ -282,7 +283,7 @@ ThunderComment createExampleComment({
       childCount: commentChildCount ?? 0,
     ),
     creatorBannedFromCommunity: false,
-    subscribed: SubscribedType.notSubscribed,
+    subscribed: SubscriptionStatus.notSubscribed.toLemmyType(),
     saved: saved ?? false,
     creatorBlocked: false,
   );

--- a/lib/community/bloc/community_bloc.dart
+++ b/lib/community/bloc/community_bloc.dart
@@ -1,10 +1,10 @@
 import 'package:bloc/bloc.dart';
 import 'package:bloc_concurrency/bloc_concurrency.dart';
 import 'package:equatable/equatable.dart';
-import 'package:lemmy_api_client/v3.dart';
 import 'package:stream_transform/stream_transform.dart';
 
 import 'package:thunder/community/enums/community_action.dart';
+import 'package:thunder/core/enums/subscription_status.dart';
 import 'package:thunder/core/models/models.dart';
 import 'package:thunder/core/singletons/lemmy_client.dart';
 import 'package:thunder/feed/utils/community.dart';
@@ -69,9 +69,9 @@ class CommunityBloc extends Bloc<CommunityEvent, CommunityState> {
           // Determines the desired subscribed type outcome based on the value.
           // If [event.value] is true, then the desired outcome is to subscribe.
           // If [event.value] is false, then the desired outcome is to unsubscribe.
-          SubscribedType? subscribedType = switch (event.value) {
-            true => SubscribedType.subscribed,
-            false => SubscribedType.notSubscribed,
+          SubscriptionStatus? subscriptionStatus = switch (event.value) {
+            true => SubscriptionStatus.subscribed,
+            false => SubscriptionStatus.notSubscribed,
             _ => null,
           };
 
@@ -80,14 +80,14 @@ class CommunityBloc extends Bloc<CommunityEvent, CommunityState> {
           String? message;
 
           // Check if the subscription was successful
-          if (community.subscribed == subscribedType) {
-            message = subscribedType == SubscribedType.subscribed ? l10n.subscribed : l10n.unsubscribed;
+          if (community.subscribed == subscriptionStatus) {
+            message = subscriptionStatus == SubscriptionStatus.subscribed ? l10n.subscribed : l10n.unsubscribed;
           } else {
             message = l10n.subscriptionRequestSent;
           }
 
           emit(state.copyWith(status: CommunityStatus.success, community: community, message: message));
-          if (community.subscribed == subscribedType) return;
+          if (community.subscribed == subscriptionStatus) return;
 
           // Otherwise, retry fetching the community information after a small delay
           emit(state.copyWith(status: CommunityStatus.fetching));
@@ -99,8 +99,8 @@ class CommunityBloc extends Bloc<CommunityEvent, CommunityState> {
 
             String? message;
 
-            if (community.subscribed == subscribedType) {
-              message = subscribedType == SubscribedType.subscribed ? l10n.subscribed : l10n.unsubscribed;
+            if (community.subscribed == subscriptionStatus) {
+              message = subscriptionStatus == SubscriptionStatus.subscribed ? l10n.subscribed : l10n.unsubscribed;
             }
 
             emit(state.copyWith(status: CommunityStatus.success, community: community, message: message));

--- a/lib/community/widgets/community_header/community_header_actions.dart
+++ b/lib/community/widgets/community_header/community_header_actions.dart
@@ -2,13 +2,13 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 
 import 'package:flutter_bloc/flutter_bloc.dart';
-import 'package:lemmy_api_client/v3.dart';
 
 import 'package:thunder/account/account.dart';
 import 'package:thunder/community/bloc/anonymous_subscriptions_bloc.dart';
 import 'package:thunder/community/bloc/community_bloc.dart';
 import 'package:thunder/community/enums/community_action.dart';
 import 'package:thunder/core/enums/full_name.dart';
+import 'package:thunder/core/enums/subscription_status.dart';
 import 'package:thunder/core/models/models.dart';
 import 'package:thunder/core/singletons/lemmy_client.dart';
 import 'package:thunder/feed/feed.dart';
@@ -138,9 +138,9 @@ class _ActionChipsList extends StatelessWidget {
 
     return [
       _SubscriptionActionChip(community: community),
-      if (community.subscribed != SubscribedType.notSubscribed) _FavoritesActionChip(community: community),
+      if (community.subscribed != SubscriptionStatus.notSubscribed) _FavoritesActionChip(community: community),
       _CreatePostActionChip(community: community),
-      if (community.subscribed == SubscribedType.notSubscribed) _BlockActionChip(community: community),
+      if (community.subscribed == SubscriptionStatus.notSubscribed) _BlockActionChip(community: community),
     ];
   }
 }
@@ -212,23 +212,21 @@ class _SubscriptionActionChip extends StatelessWidget {
     );
   }
 
-  IconData _getSubscriptionIcon(SubscribedType? subscribed) {
+  IconData _getSubscriptionIcon(SubscriptionStatus subscribed) {
     return switch (subscribed) {
-      SubscribedType.notSubscribed => Icons.add_circle_outline_rounded,
-      SubscribedType.pending => Icons.pending_outlined,
-      SubscribedType.subscribed => Icons.remove_circle_outline_rounded,
-      _ => Icons.add_circle_outline_rounded,
+      SubscriptionStatus.notSubscribed => Icons.add_circle_outline_rounded,
+      SubscriptionStatus.pending => Icons.pending_outlined,
+      SubscriptionStatus.subscribed => Icons.remove_circle_outline_rounded,
     };
   }
 
-  String _getSubscriptionLabel(SubscribedType? subscribed) {
+  String _getSubscriptionLabel(SubscriptionStatus subscribed) {
     final l10n = GlobalContext.l10n;
 
     return switch (subscribed) {
-      SubscribedType.notSubscribed => l10n.subscribe,
-      SubscribedType.pending => l10n.pending,
-      SubscribedType.subscribed => l10n.unsubscribe,
-      _ => '',
+      SubscriptionStatus.notSubscribed => l10n.subscribe,
+      SubscriptionStatus.pending => l10n.pending,
+      SubscriptionStatus.subscribed => l10n.unsubscribe,
     };
   }
 
@@ -288,7 +286,7 @@ class _FavoritesActionChip extends StatelessWidget {
     final favorited = favorites.any((c) => c.id == community.id);
 
     // Only show for subscribed communities
-    if (community.subscribed != SubscribedType.subscribed) {
+    if (community.subscribed != SubscriptionStatus.subscribed) {
       return const SizedBox.shrink();
     }
 

--- a/lib/community/widgets/community_list_entry.dart
+++ b/lib/community/widgets/community_list_entry.dart
@@ -6,6 +6,7 @@ import 'package:thunder/localizations/app_localizations.dart';
 
 import 'package:thunder/account/account.dart';
 import 'package:thunder/core/enums/full_name.dart';
+import 'package:thunder/core/enums/subscription_status.dart';
 import 'package:thunder/core/models/models.dart';
 import 'package:thunder/core/singletons/lemmy_client.dart';
 import 'package:thunder/feed/view/feed_page.dart';
@@ -33,7 +34,7 @@ class CommunityListEntry extends StatelessWidget {
   final bool Function(BuildContext context, ThunderCommunity community)? getFavoriteStatus;
 
   /// Callback function that occurs when the subscription status is requested.
-  final SubscribedType Function(bool isUserLoggedIn, ThunderCommunity community, Set<int>? currentSubscriptions)? getCurrentSubscriptionStatus;
+  final SubscriptionStatus Function(bool isUserLoggedIn, ThunderCommunity community, Set<int>? currentSubscriptions)? getCurrentSubscriptionStatus;
 
   /// Callback function that occurs when the subscribe icon is pressed.
   final void Function(bool isUserLoggedIn, BuildContext context, ThunderCommunity community)? onSubscribeIconPressed;
@@ -59,9 +60,9 @@ class CommunityListEntry extends StatelessWidget {
     assert(community.subscribers != null);
 
     String subscriptionButtonLabel = switch (getCurrentSubscriptionStatus?.call(isUserLoggedIn, community, currentSubscriptions)) {
-      SubscribedType.notSubscribed => l10n.subscribe,
-      SubscribedType.pending => l10n.unsubscribePending,
-      SubscribedType.subscribed => l10n.unsubscribe,
+      SubscriptionStatus.notSubscribed => l10n.subscribe,
+      SubscriptionStatus.pending => l10n.unsubscribePending,
+      SubscriptionStatus.subscribed => l10n.unsubscribe,
       _ => '',
     };
 
@@ -97,7 +98,7 @@ class CommunityListEntry extends StatelessWidget {
             const Icon(Icons.people_rounded, size: 16.0),
             if (indicateFavorites &&
                 getFavoriteStatus?.call(context, community) == true &&
-                getCurrentSubscriptionStatus?.call(isUserLoggedIn, community, currentSubscriptions) == SubscribedType.subscribed) ...const [
+                getCurrentSubscriptionStatus?.call(isUserLoggedIn, community, currentSubscriptions) == SubscriptionStatus.subscribed) ...const [
               Text(' · '),
               Icon(Icons.star_rounded, size: 15),
             ]
@@ -107,18 +108,18 @@ class CommunityListEntry extends StatelessWidget {
             ? null
             : IconButton(
                 onPressed: () {
-                  SubscribedType? subscriptionStatus = getCurrentSubscriptionStatus!(isUserLoggedIn, community, currentSubscriptions);
+                  SubscriptionStatus subscriptionStatus = getCurrentSubscriptionStatus!(isUserLoggedIn, community, currentSubscriptions);
                   onSubscribeIconPressed?.call(isUserLoggedIn, context, community);
-                  showSnackbar(subscriptionStatus == SubscribedType.notSubscribed ? l10n.addedCommunityToSubscriptions : l10n.removedCommunityFromSubscriptions);
+                  showSnackbar(subscriptionStatus == SubscriptionStatus.notSubscribed ? l10n.addedCommunityToSubscriptions : l10n.removedCommunityFromSubscriptions);
                   context.read<ProfileBloc>().add(const FetchProfileSubscriptions());
                 },
                 icon: Semantics(
                   label: subscriptionButtonLabel,
                   child: Icon(
                     switch (getCurrentSubscriptionStatus!(isUserLoggedIn, community, currentSubscriptions)) {
-                      SubscribedType.notSubscribed => Icons.add_circle_outline_rounded,
-                      SubscribedType.pending => Icons.pending_outlined,
-                      SubscribedType.subscribed => Icons.remove_circle_outline_rounded,
+                      SubscriptionStatus.notSubscribed => Icons.add_circle_outline_rounded,
+                      SubscriptionStatus.pending => Icons.pending_outlined,
+                      SubscriptionStatus.subscribed => Icons.remove_circle_outline_rounded,
                     },
                   ),
                 ),

--- a/lib/community/widgets/post_card_metadata.dart
+++ b/lib/community/widgets/post_card_metadata.dart
@@ -7,6 +7,7 @@ import 'package:thunder/localizations/app_localizations.dart';
 
 import 'package:thunder/account/account.dart';
 import 'package:thunder/core/enums/enums.dart';
+import 'package:thunder/core/enums/subscription_status.dart';
 import 'package:thunder/core/enums/view_mode.dart';
 import 'package:thunder/core/models/models.dart';
 import 'package:thunder/feed/feed.dart';
@@ -585,7 +586,7 @@ class PostCommunityAndAuthor extends StatelessWidget {
                 communityName: community.communityName,
                 displayName: community.title,
                 actorId: community.url,
-                subscribed: community.subscribed != SubscribedType.notSubscribed,
+                subscribed: community.subscribed != SubscriptionStatus.notSubscribed,
                 dim: dim,
               ),
               UserPostCardMetadata(
@@ -601,7 +602,7 @@ class PostCommunityAndAuthor extends StatelessWidget {
             communityName: community.communityName,
             displayName: community.title,
             actorId: community.url,
-            subscribed: community.subscribed != SubscribedType.notSubscribed,
+            subscribed: community.subscribed != SubscriptionStatus.notSubscribed,
             dim: dim,
           )
         else if (showUsername)

--- a/lib/core/enums/subscription_status.dart
+++ b/lib/core/enums/subscription_status.dart
@@ -1,0 +1,34 @@
+import 'package:lemmy_api_client/v3.dart' as lemmy;
+
+enum SubscriptionStatus {
+  subscribed,
+  notSubscribed,
+  pending,
+}
+
+extension SubscriptionStatusMapping on SubscriptionStatus {
+  /// Converts a local SubscriptionStatus to lemmy API SubscribedType
+  lemmy.SubscribedType toLemmyType() {
+    switch (this) {
+      case SubscriptionStatus.subscribed:
+        return lemmy.SubscribedType.subscribed;
+      case SubscriptionStatus.notSubscribed:
+        return lemmy.SubscribedType.notSubscribed;
+      case SubscriptionStatus.pending:
+        return lemmy.SubscribedType.pending;
+    }
+  }
+
+  /// Converts a lemmy API SubscribedType to local SubscriptionStatus
+  static SubscriptionStatus fromLemmyType(lemmy.SubscribedType? lemmyType) {
+    switch (lemmyType) {
+      case lemmy.SubscribedType.subscribed:
+        return SubscriptionStatus.subscribed;
+      case lemmy.SubscribedType.pending:
+        return SubscriptionStatus.pending;
+      case lemmy.SubscribedType.notSubscribed:
+      case null:
+        return SubscriptionStatus.notSubscribed;
+    }
+  }
+}

--- a/lib/core/models/thunder_community.dart
+++ b/lib/core/models/thunder_community.dart
@@ -1,5 +1,7 @@
 import 'package:lemmy_api_client/v3.dart';
 
+import 'package:thunder/core/enums/subscription_status.dart';
+
 class ThunderCommunity {
   /// The Lemmy API model for the community.
   final Community _community;
@@ -7,12 +9,12 @@ class ThunderCommunity {
   /// The Lemmy API model for the community view.
   late CommunityView? _communityView;
 
-  ThunderCommunity(this._community, {CommunityView? communityView, SubscribedType? subscribed}) {
+  ThunderCommunity(this._community, {CommunityView? communityView, SubscriptionStatus? subscribed}) {
     if (communityView == null && subscribed != null) {
       // If the community view is not provided, create a new one with the provided subscription status.
       _communityView = CommunityView(
         community: _community,
-        subscribed: subscribed,
+        subscribed: subscribed.toLemmyType(),
         blocked: false,
         counts: CommunityAggregates(
           communityId: _community.id,
@@ -85,7 +87,7 @@ class ThunderCommunity {
   int? get usersActiveHalfYear => _communityView?.counts.usersActiveHalfYear;
 
   /// The current user subscription status to the community.
-  SubscribedType? get subscribed => _communityView?.subscribed;
+  SubscriptionStatus get subscribed => SubscriptionStatusMapping.fromLemmyType(_communityView?.subscribed);
 
   /// The date and time that the community was created.
   DateTime get created => _community.published;

--- a/lib/core/models/thunder_post.dart
+++ b/lib/core/models/thunder_post.dart
@@ -1,5 +1,6 @@
 import 'package:lemmy_api_client/v3.dart';
 
+import 'package:thunder/core/enums/subscription_status.dart';
 import 'package:thunder/core/models/media.dart';
 import 'package:thunder/core/models/models.dart';
 
@@ -64,7 +65,7 @@ class ThunderPost {
   bool? get creatorBannedFromCommunity => _postView?.creatorBannedFromCommunity;
 
   /// The subscribed status of the post.
-  SubscribedType? get subscribed => _postView?.subscribed;
+  SubscriptionStatus get subscribed => SubscriptionStatusMapping.fromLemmyType(_postView?.subscribed);
 
   /// The title of the post.
   String get title => _post.name;
@@ -127,7 +128,7 @@ class ThunderPost {
   ThunderUser? get creator => _postView?.creator != null ? ThunderUser(_postView!.creator) : null;
 
   /// The community associated with the post
-  ThunderCommunity? get community => _postView?.community != null ? ThunderCommunity(_postView!.community, subscribed: _postView?.subscribed) : null;
+  ThunderCommunity? get community => _postView?.community != null ? ThunderCommunity(_postView!.community, subscribed: SubscriptionStatusMapping.fromLemmyType(_postView?.subscribed)) : null;
 
   /// The url for the post. This is generally associated with the ActivityPub actor URL.
   String get url => _post.apId;

--- a/lib/feed/utils/community.dart
+++ b/lib/feed/utils/community.dart
@@ -5,6 +5,7 @@ import 'package:thunder/community/enums/community_action.dart';
 import 'package:thunder/localizations/app_localizations.dart';
 
 import 'package:lemmy_api_client/v3.dart';
+import 'package:thunder/core/enums/subscription_status.dart';
 import 'package:thunder/account/account.dart';
 import 'package:thunder/community/models/favourite.dart';
 import 'package:thunder/core/models/models.dart';
@@ -108,7 +109,7 @@ List<ThunderCommunity>? prioritizeFavorites(List<ThunderCommunity>? communities,
 /// When subcribed, shows a confirmation dialog for unsubscription.
 Future<void> handleSubscription(BuildContext context, ThunderCommunity community) async {
   final l10n = GlobalContext.l10n;
-  final isSubscribed = community.subscribed != SubscribedType.notSubscribed;
+  final isSubscribed = community.subscribed != SubscriptionStatus.notSubscribed;
 
   if (isSubscribed) {
     bool shouldUnsubscribe = false;

--- a/lib/feed/utils/post.dart
+++ b/lib/feed/utils/post.dart
@@ -4,6 +4,7 @@ import 'package:lemmy_api_client/v3.dart';
 import 'package:thunder/account/account.dart';
 import 'package:thunder/core/enums/enums.dart';
 import 'package:thunder/core/enums/local_settings.dart';
+import 'package:thunder/core/enums/subscription_status.dart';
 import 'package:thunder/core/models/models.dart';
 import 'package:thunder/core/singletons/lemmy_client.dart';
 import 'package:thunder/core/singletons/preferences.dart';
@@ -254,7 +255,7 @@ Future<ThunderPost?> createExamplePost({
       downvotes: 0,
       published: DateTime.now(),
     ),
-    subscribed: SubscribedType.notSubscribed,
+    subscribed: SubscriptionStatus.notSubscribed.toLemmyType(),
     saved: saved ?? false,
     read: read ?? false,
     creatorBlocked: false,

--- a/lib/moderator/view/report_page.dart
+++ b/lib/moderator/view/report_page.dart
@@ -10,6 +10,7 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:thunder/account/account.dart';
 import 'package:thunder/community/widgets/post_card_view_compact.dart';
 import 'package:thunder/core/enums/media_type.dart';
+import 'package:thunder/core/enums/subscription_status.dart';
 import 'package:thunder/core/models/media.dart';
 import 'package:thunder/core/models/models.dart';
 import 'package:thunder/core/singletons/lemmy_client.dart';
@@ -209,7 +210,7 @@ class _ReportFeedViewState extends State<ReportFeedView> {
                                   community: state.postReports[index].community,
                                   creatorBannedFromCommunity: state.postReports[index].creatorBannedFromCommunity,
                                   counts: state.postReports[index].counts,
-                                  subscribed: SubscribedType.notSubscribed, // Not available
+                                  subscribed: SubscriptionStatus.notSubscribed.toLemmyType(), // Not available
                                   saved: false, // Not available
                                   read: false, // Not available
                                   creatorBlocked: false, // Not available
@@ -322,7 +323,7 @@ class _ReportFeedViewState extends State<ReportFeedView> {
                                   community: state.commentReports[index].community,
                                   counts: state.commentReports[index].counts,
                                   creatorBannedFromCommunity: state.commentReports[index].creatorBannedFromCommunity,
-                                  subscribed: SubscribedType.notSubscribed, // Not available
+                                  subscribed: SubscriptionStatus.notSubscribed.toLemmyType(), // Not available
                                   saved: false, // Not available
                                   creatorBlocked: false, // Not available
                                 );

--- a/lib/post/widgets/post_bottom_sheet/community_post_action_bottom_sheet.dart
+++ b/lib/post/widgets/post_bottom_sheet/community_post_action_bottom_sheet.dart
@@ -1,9 +1,9 @@
 import 'package:flutter/material.dart';
 
 import 'package:flutter_bloc/flutter_bloc.dart';
-import 'package:lemmy_api_client/v3.dart';
 
 import 'package:thunder/account/account.dart';
+import 'package:thunder/core/enums/subscription_status.dart';
 import 'package:thunder/community/bloc/community_bloc.dart';
 import 'package:thunder/community/enums/community_action.dart';
 import 'package:thunder/core/models/models.dart';
@@ -105,7 +105,7 @@ class _CommunityPostActionBottomSheetState extends State<CommunityPostActionBott
     final blockedCommunities = authState.getSiteResponse?.myUser?.communityBlocks ?? [];
 
     final isCommunityBlocked = blockedCommunities.where((cbv) => cbv.community.actorId == widget.post.community?.url).isNotEmpty;
-    final isSubscribedToCommunity = widget.post.subscribed != SubscribedType.notSubscribed;
+    final isSubscribedToCommunity = widget.post.subscribed != SubscriptionStatus.notSubscribed;
 
     if (!isLoggedIn) {
       userActions = userActions.where((action) => action.requiresAuthentication == false).toList();

--- a/lib/search/pages/search_page.dart
+++ b/lib/search/pages/search_page.dart
@@ -18,6 +18,7 @@ import 'package:thunder/comment/comment.dart';
 import 'package:thunder/community/bloc/anonymous_subscriptions_bloc.dart';
 import 'package:thunder/community/widgets/community_list_entry.dart';
 import 'package:thunder/core/enums/enums.dart';
+import 'package:thunder/core/enums/subscription_status.dart';
 import 'package:thunder/core/enums/full_name.dart';
 import 'package:thunder/core/enums/meta_search_type.dart';
 import 'package:thunder/core/models/models.dart';
@@ -835,21 +836,20 @@ class _SearchPageState extends State<SearchPage> with AutomaticKeepAliveClientMi
     );
   }
 
-  SubscribedType _getCurrentSubscriptionStatus(bool isUserLoggedIn, ThunderCommunity community, Set<int>? currentSubscriptions) {
-    assert(community.subscribed != null);
-    if (isUserLoggedIn) return community.subscribed!;
+  SubscriptionStatus _getCurrentSubscriptionStatus(bool isUserLoggedIn, ThunderCommunity community, Set<int>? currentSubscriptions) {
+    if (isUserLoggedIn) return community.subscribed;
 
     bool isSubscribed =
         newAnonymousSubscriptions.firstWhereOrNull((c) => c.id == community.id) != null || (currentSubscriptions?.contains(community.id) == true && !removedSubs.contains(community.id));
 
-    return isSubscribed ? SubscribedType.subscribed : SubscribedType.notSubscribed;
+    return isSubscribed ? SubscriptionStatus.subscribed : SubscriptionStatus.notSubscribed;
   }
 
   void _onSubscribeIconPressed(bool isUserLoggedIn, BuildContext context, ThunderCommunity community) {
     if (isUserLoggedIn) {
       context.read<SearchBloc>().add(ChangeCommunitySubsciptionStatusEvent(
             communityId: community.id,
-            follow: community.subscribed == SubscribedType.notSubscribed ? true : false,
+            follow: community.subscribed == SubscriptionStatus.notSubscribed ? true : false,
             query: _controller.text,
           ));
       return;

--- a/lib/shared/input_dialogs.dart
+++ b/lib/shared/input_dialogs.dart
@@ -10,6 +10,7 @@ import 'package:thunder/localizations/app_localizations.dart';
 
 import 'package:thunder/account/account.dart';
 import 'package:thunder/core/enums/full_name.dart';
+import 'package:thunder/core/enums/subscription_status.dart';
 import 'package:thunder/core/models/models.dart';
 import 'package:thunder/core/singletons/lemmy_client.dart';
 import 'package:thunder/feed/utils/community.dart';
@@ -226,11 +227,11 @@ Widget buildCommunitySuggestionWidget(BuildContext context, ThunderCommunity pay
                   const Icon(Icons.people_rounded, size: 16),
                   const SizedBox(width: 5),
                   Text(formatNumberToK(payload.subscribers ?? -1)),
-                  if (payload.subscribed != SubscribedType.notSubscribed) ...[
+                  if (payload.subscribed != SubscriptionStatus.notSubscribed) ...[
                     Text(' · ${switch (payload.subscribed) {
-                      SubscribedType.pending => l10n.pending,
-                      SubscribedType.subscribed => l10n.subscribed,
-                      _ => '',
+                      SubscriptionStatus.pending => l10n.pending,
+                      SubscriptionStatus.subscribed => l10n.subscribed,
+                      SubscriptionStatus.notSubscribed => '',
                     }}'),
                   ],
                   if (_getFavoriteStatus(context, payload)) ...const [


### PR DESCRIPTION
## Pull Request Description

This PR creates a new internal enum to handle subscription statuses `SubscriptionStatus`, and migrates our usage of `SubscribedType` over to the new enum.

Some helper functions were implemented to translate between the two enums!

<!--- Please describe what was changed -->

## Issue Being Fixed

<!-- Please describe the problem that is being fixed and, if applicable, reference a GitHub issue -->

Issue Number: N/A

## Screenshots / Recordings

<!-- This section is optional but highly recommended to show off your changes! -->

## Checklist

- [ ] If a new package was added, did you ensure it uses an appropriate license and is actively maintained?
- [ ] Did you use localized strings (and added appropriate descriptions) where applicable?
- [ ] Did you add `semanticLabel`s where applicable for accessibility?
