### PR TITLE
Chore: refactor post sort type enum to internal enum

### DIFF
--- a/lib/account/views/account_page.dart
+++ b/lib/account/views/account_page.dart
@@ -1,9 +1,9 @@
 import 'package:flutter/material.dart';
 
 import 'package:flutter_bloc/flutter_bloc.dart';
-import 'package:lemmy_api_client/v3.dart';
 
 import 'package:thunder/account/account.dart';
+import 'package:thunder/core/enums/post_sort_type.dart';
 import 'package:thunder/feed/feed.dart';
 
 class AccountPage extends StatefulWidget {
@@ -25,7 +25,7 @@ class _AccountPageState extends State<AccountPage> with AutomaticKeepAliveClient
         return FeedPage(
           feedType: FeedType.account,
           userId: state.account?.userId,
-          sortType: SortType.new_,
+          sortType: PostSortType.new_,
         );
       },
     );

--- a/lib/community/widgets/community_drawer.dart
+++ b/lib/community/widgets/community_drawer.dart
@@ -10,6 +10,7 @@ import 'package:sliver_tools/sliver_tools.dart';
 import 'package:thunder/account/account.dart';
 import 'package:thunder/community/bloc/anonymous_subscriptions_bloc.dart';
 import 'package:thunder/core/enums/enums.dart';
+import 'package:thunder/core/enums/post_sort_type.dart';
 import 'package:thunder/core/models/models.dart';
 import 'package:thunder/feed/feed.dart';
 import 'package:thunder/shared/avatars/community_avatar.dart';
@@ -100,7 +101,7 @@ class _CommunityDrawerState extends State<CommunityDrawer> {
                               context.read<FeedBloc>().add(
                                     FeedFetchedEvent(
                                       feedType: FeedType.community,
-                                      sortType: profileState.getSiteResponse?.myUser?.localUserView.localUser.defaultSortType ?? thunderState.sortTypeForInstance,
+                                      sortType: PostSortTypeMapping.fromLemmyType(profileState.getSiteResponse?.myUser?.localUserView.localUser.defaultSortType) ?? thunderState.sortTypeForInstance,
                                       communityId: community.id,
                                       reset: true,
                                       showHidden: thunderState.showHiddenPosts,
@@ -301,7 +302,7 @@ class FavoriteCommunities extends StatelessWidget {
                   context.read<FeedBloc>().add(
                         FeedFetchedEvent(
                           feedType: FeedType.community,
-                          sortType: profileState.getSiteResponse?.myUser?.localUserView.localUser.defaultSortType ?? thunderState.sortTypeForInstance,
+                          sortType: PostSortTypeMapping.fromLemmyType(profileState.getSiteResponse?.myUser?.localUserView.localUser.defaultSortType) ?? thunderState.sortTypeForInstance,
                           communityId: community.id,
                           reset: true,
                           showHidden: thunderState.showHiddenPosts,
@@ -361,7 +362,7 @@ class ModeratedCommunities extends StatelessWidget {
                     context.read<FeedBloc>().add(
                           FeedFetchedEvent(
                             feedType: FeedType.community,
-                            sortType: profileState.getSiteResponse?.myUser?.localUserView.localUser.defaultSortType ?? thunderState.sortTypeForInstance,
+                            sortType: PostSortTypeMapping.fromLemmyType(profileState.getSiteResponse?.myUser?.localUserView.localUser.defaultSortType) ?? thunderState.sortTypeForInstance,
                             communityId: community.id,
                             reset: true,
                             showHidden: thunderState.showHiddenPosts,

--- a/lib/community/widgets/community_header/community_header_actions.dart
+++ b/lib/community/widgets/community_header/community_header_actions.dart
@@ -8,6 +8,7 @@ import 'package:thunder/community/bloc/anonymous_subscriptions_bloc.dart';
 import 'package:thunder/community/bloc/community_bloc.dart';
 import 'package:thunder/community/enums/community_action.dart';
 import 'package:thunder/core/enums/full_name.dart';
+import 'package:thunder/core/enums/post_sort_type.dart';
 import 'package:thunder/core/enums/subscription_status.dart';
 import 'package:thunder/core/models/models.dart';
 import 'package:thunder/core/singletons/lemmy_client.dart';
@@ -176,12 +177,12 @@ class _SortActionChip extends StatelessWidget {
             title: l10n.sortOptions,
             onSelect: (selected) async {
               try {
-                context.read<FeedBloc>().add(FeedChangeSortTypeEvent(selected.payload));
+                context.read<FeedBloc>().add(FeedChangeSortTypeEvent(PostSortTypeMapping.fromLemmyType(selected.payload)!));
               } catch (e) {
                 debugPrint('Failed to update sort type: $e');
               }
             },
-            previouslySelected: state.sortType,
+            previouslySelected: state.sortType?.toLemmyType(),
             minimumVersion: LemmyClient.instance.version,
           ),
         );

--- a/lib/core/enums/post_sort_type.dart
+++ b/lib/core/enums/post_sort_type.dart
@@ -1,0 +1,115 @@
+import 'package:lemmy_api_client/v3.dart' as lemmy;
+
+enum PostSortType {
+  active,
+  hot,
+  new_,
+  old,
+  topDay,
+  topWeek,
+  topMonth,
+  topYear,
+  topAll,
+  mostComments,
+  newComments,
+  topHour,
+  topSixHour,
+  topTwelveHour,
+  topThreeMonths,
+  topSixMonths,
+  topNineMonths,
+  controversial,
+  scaled,
+}
+
+extension PostSortTypeMapping on PostSortType {
+  /// Converts a local PostSortType to lemmy API SortType
+  lemmy.SortType toLemmyType() {
+    switch (this) {
+      case PostSortType.active:
+        return lemmy.SortType.active;
+      case PostSortType.hot:
+        return lemmy.SortType.hot;
+      case PostSortType.new_:
+        return lemmy.SortType.new_;
+      case PostSortType.old:
+        return lemmy.SortType.old;
+      case PostSortType.topDay:
+        return lemmy.SortType.topDay;
+      case PostSortType.topWeek:
+        return lemmy.SortType.topWeek;
+      case PostSortType.topMonth:
+        return lemmy.SortType.topMonth;
+      case PostSortType.topYear:
+        return lemmy.SortType.topYear;
+      case PostSortType.topAll:
+        return lemmy.SortType.topAll;
+      case PostSortType.mostComments:
+        return lemmy.SortType.mostComments;
+      case PostSortType.newComments:
+        return lemmy.SortType.newComments;
+      case PostSortType.topHour:
+        return lemmy.SortType.topHour;
+      case PostSortType.topSixHour:
+        return lemmy.SortType.topSixHour;
+      case PostSortType.topTwelveHour:
+        return lemmy.SortType.topTwelveHour;
+      case PostSortType.topThreeMonths:
+        return lemmy.SortType.topThreeMonths;
+      case PostSortType.topSixMonths:
+        return lemmy.SortType.topSixMonths;
+      case PostSortType.topNineMonths:
+        return lemmy.SortType.topNineMonths;
+      case PostSortType.controversial:
+        return lemmy.SortType.controversial;
+      case PostSortType.scaled:
+        return lemmy.SortType.scaled;
+    }
+  }
+
+  /// Converts a lemmy API SortType to local PostSortType
+  static PostSortType? fromLemmyType(lemmy.SortType? lemmyType) {
+    switch (lemmyType) {
+      case lemmy.SortType.active:
+        return PostSortType.active;
+      case lemmy.SortType.hot:
+        return PostSortType.hot;
+      case lemmy.SortType.new_:
+        return PostSortType.new_;
+      case lemmy.SortType.old:
+        return PostSortType.old;
+      case lemmy.SortType.topDay:
+        return PostSortType.topDay;
+      case lemmy.SortType.topWeek:
+        return PostSortType.topWeek;
+      case lemmy.SortType.topMonth:
+        return PostSortType.topMonth;
+      case lemmy.SortType.topYear:
+        return PostSortType.topYear;
+      case lemmy.SortType.topAll:
+        return PostSortType.topAll;
+      case lemmy.SortType.mostComments:
+        return PostSortType.mostComments;
+      case lemmy.SortType.newComments:
+        return PostSortType.newComments;
+      case lemmy.SortType.topHour:
+        return PostSortType.topHour;
+      case lemmy.SortType.topSixHour:
+        return PostSortType.topSixHour;
+      case lemmy.SortType.topTwelveHour:
+        return PostSortType.topTwelveHour;
+      case lemmy.SortType.topThreeMonths:
+        return PostSortType.topThreeMonths;
+      case lemmy.SortType.topSixMonths:
+        return PostSortType.topSixMonths;
+      case lemmy.SortType.topNineMonths:
+        return PostSortType.topNineMonths;
+      case lemmy.SortType.controversial:
+        return PostSortType.controversial;
+      case lemmy.SortType.scaled:
+        return PostSortType.scaled;
+      default:
+        return null;
+    }
+  }
+}

--- a/lib/feed/bloc/feed_bloc.dart
+++ b/lib/feed/bloc/feed_bloc.dart
@@ -6,6 +6,7 @@ import 'package:stream_transform/stream_transform.dart';
 
 import 'package:thunder/account/account.dart';
 import 'package:thunder/core/enums/enums.dart';
+import 'package:thunder/core/enums/post_sort_type.dart';
 import 'package:thunder/core/models/models.dart';
 import 'package:thunder/core/singletons/lemmy_client.dart';
 import 'package:thunder/feed/enums/feed_type_subview.dart';

--- a/lib/feed/bloc/feed_event.dart
+++ b/lib/feed/bloc/feed_event.dart
@@ -18,7 +18,7 @@ final class FeedFetchedEvent extends FeedEvent {
   final FeedListType? feedListType;
 
   /// The sorting to be applied to the feed.
-  final SortType? sortType;
+  final PostSortType? sortType;
 
   /// The id of the community to display posts for.
   final int? communityId;
@@ -57,7 +57,7 @@ final class FeedFetchedEvent extends FeedEvent {
 }
 
 final class FeedChangeSortTypeEvent extends FeedEvent {
-  final SortType sortType;
+  final PostSortType sortType;
 
   const FeedChangeSortTypeEvent(this.sortType);
 }

--- a/lib/feed/bloc/feed_state.dart
+++ b/lib/feed/bloc/feed_state.dart
@@ -55,7 +55,7 @@ final class FeedState extends Equatable {
   final FeedListType? feedListType;
 
   /// The sorting to be applied to the feed.
-  final SortType? sortType;
+  final PostSortType? sortType;
 
   /// The community information if applicable
   final ThunderCommunity? community;
@@ -122,7 +122,7 @@ final class FeedState extends Equatable {
     bool? hasReachedCommentsEnd,
     FeedType? feedType,
     FeedListType? feedListType,
-    SortType? sortType,
+    PostSortType? sortType,
     ThunderCommunity? community,
     ThunderInstance? communityInstance,
     List<ThunderUser>? communityModerators,

--- a/lib/feed/utils/post.dart
+++ b/lib/feed/utils/post.dart
@@ -4,6 +4,7 @@ import 'package:lemmy_api_client/v3.dart';
 import 'package:thunder/account/account.dart';
 import 'package:thunder/core/enums/enums.dart';
 import 'package:thunder/core/enums/local_settings.dart';
+import 'package:thunder/core/enums/post_sort_type.dart';
 import 'package:thunder/core/enums/subscription_status.dart';
 import 'package:thunder/core/models/models.dart';
 import 'package:thunder/core/singletons/lemmy_client.dart';
@@ -18,7 +19,7 @@ import 'package:thunder/utils/global_context.dart';
 Future<Map<String, dynamic>> fetchFeedItems({
   int page = 1,
   FeedListType? feedListType,
-  SortType? sortType,
+  PostSortType? sortType,
   int? communityId,
   String? communityName,
   int? userId,
@@ -48,7 +49,7 @@ Future<Map<String, dynamic>> fetchFeedItems({
       GetPostsResponse getPostsResponse = await lemmy.run(GetPosts(
         auth: account.jwt,
         page: currentPage,
-        sort: sortType,
+        sort: sortType?.toLemmyType(),
         type: feedListType?.toLemmyType(),
         communityId: communityId,
         communityName: communityName,
@@ -104,7 +105,7 @@ Future<Map<String, dynamic>> fetchFeedItems({
         personId: userId,
         username: username,
         page: currentPage,
-        sort: sortType,
+        sort: sortType?.toLemmyType(),
         savedOnly: showSaved,
       ));
 

--- a/lib/feed/utils/utils.dart
+++ b/lib/feed/utils/utils.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 
+import 'package:thunder/core/enums/post_sort_type.dart';
 import 'package:thunder/feed/feed.dart';
 import 'package:thunder/shared/sort_picker.dart';
 import 'package:thunder/community/widgets/community_drawer.dart';
@@ -26,7 +27,7 @@ String getSortName(FeedState state) {
     return '';
   }
 
-  final sortTypeItemIndex = allSortTypeItems.indexWhere((sortTypeItem) => sortTypeItem.payload == state.sortType);
+  final sortTypeItemIndex = allSortTypeItems.indexWhere((sortTypeItem) => sortTypeItem.payload == state.sortType?.toLemmyType());
   final sortTypeItem = sortTypeItemIndex > -1 ? allSortTypeItems[sortTypeItemIndex] : null;
 
   return sortTypeItem?.label ?? '';
@@ -37,7 +38,7 @@ IconData? getSortIcon(FeedState state) {
     return null;
   }
 
-  final sortTypeItemIndex = allSortTypeItems.indexWhere((sortTypeItem) => sortTypeItem.payload == state.sortType);
+  final sortTypeItemIndex = allSortTypeItems.indexWhere((sortTypeItem) => sortTypeItem.payload == state.sortType?.toLemmyType());
   final sortTypeItem = sortTypeItemIndex > -1 ? allSortTypeItems[sortTypeItemIndex] : null;
 
   return sortTypeItem?.icon;

--- a/lib/feed/view/feed_page.dart
+++ b/lib/feed/view/feed_page.dart
@@ -11,6 +11,7 @@ import 'package:thunder/community/bloc/community_bloc.dart';
 import 'package:thunder/community/widgets/community_header/community_header.dart';
 import 'package:thunder/core/enums/enums.dart';
 import 'package:thunder/core/enums/local_settings.dart';
+import 'package:thunder/core/enums/post_sort_type.dart';
 import 'package:thunder/core/models/models.dart';
 import 'package:thunder/core/singletons/lemmy_client.dart';
 import 'package:thunder/feed/bloc/feed_bloc.dart';
@@ -63,7 +64,7 @@ class FeedPage extends StatefulWidget {
   final FeedListType? feedListType;
 
   /// The sorting to be applied to the feed.
-  final SortType? sortType;
+  final PostSortType? sortType;
 
   /// The id of the community to display posts for.
   final int? communityId;
@@ -502,7 +503,7 @@ class _FeedViewState extends State<FeedView> {
     if (!canPop && (desiredFeedListType != currentFeedListType || communityMode)) {
       feedBloc.add(
         FeedFetchedEvent(
-          sortType: authBloc.state.getSiteResponse?.myUser?.localUserView.localUser.defaultSortType ?? thunderBloc.state.sortTypeForInstance,
+          sortType: PostSortTypeMapping.fromLemmyType(authBloc.state.getSiteResponse?.myUser?.localUserView.localUser.defaultSortType) ?? thunderBloc.state.sortTypeForInstance,
           reset: true,
           feedListType: desiredFeedListType,
           feedType: FeedType.general,

--- a/lib/feed/widgets/feed_fab.dart
+++ b/lib/feed/widgets/feed_fab.dart
@@ -8,6 +8,7 @@ import 'package:thunder/localizations/app_localizations.dart';
 
 import 'package:thunder/account/account.dart';
 import 'package:thunder/core/enums/fab_action.dart';
+import 'package:thunder/core/enums/post_sort_type.dart';
 import 'package:thunder/core/singletons/lemmy_client.dart';
 import 'package:thunder/feed/bloc/feed_bloc.dart';
 import 'package:thunder/feed/utils/utils.dart';
@@ -277,8 +278,8 @@ class FeedFAB extends StatelessWidget {
       isScrollControlled: true,
       builder: (builderContext) => SortPicker(
         title: l10n.sortOptions,
-        onSelect: (selected) async => context.read<FeedBloc>().add(FeedChangeSortTypeEvent(selected.payload)),
-        previouslySelected: context.read<FeedBloc>().state.sortType,
+        onSelect: (selected) async => context.read<FeedBloc>().add(FeedChangeSortTypeEvent(PostSortTypeMapping.fromLemmyType(selected.payload)!)),
+        previouslySelected: context.read<FeedBloc>().state.sortType?.toLemmyType(),
         minimumVersion: LemmyClient.instance.version,
       ),
     );

--- a/lib/feed/widgets/feed_page_app_bar.dart
+++ b/lib/feed/widgets/feed_page_app_bar.dart
@@ -7,6 +7,7 @@ import 'package:flutter/services.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 
 import 'package:thunder/account/account.dart';
+import 'package:thunder/core/enums/post_sort_type.dart';
 import 'package:thunder/core/models/models.dart';
 import 'package:thunder/core/singletons/lemmy_client.dart';
 import 'package:thunder/feed/bloc/feed_bloc.dart';
@@ -205,8 +206,8 @@ class FeedAppBarCommunityActions extends StatelessWidget {
                 isScrollControlled: true,
                 builder: (builderContext) => SortPicker(
                   title: l10n.sortOptions,
-                  onSelect: (selected) async => context.read<FeedBloc>().add(FeedChangeSortTypeEvent(selected.payload)),
-                  previouslySelected: sortType,
+                  onSelect: (selected) async => context.read<FeedBloc>().add(FeedChangeSortTypeEvent(PostSortTypeMapping.fromLemmyType(selected.payload)!)),
+                  previouslySelected: sortType?.toLemmyType(),
                   minimumVersion: LemmyClient.instance.version,
                 ),
               );
@@ -249,8 +250,8 @@ class FeedAppBarUserActions extends StatelessWidget {
                 isScrollControlled: true,
                 builder: (builderContext) => SortPicker(
                   title: l10n.sortOptions,
-                  onSelect: (selected) async => feedBloc.add(FeedChangeSortTypeEvent(selected.payload)),
-                  previouslySelected: feedBloc.state.sortType,
+                  onSelect: (selected) async => feedBloc.add(FeedChangeSortTypeEvent(PostSortTypeMapping.fromLemmyType(selected.payload)!)),
+                  previouslySelected: feedBloc.state.sortType?.toLemmyType(),
                   minimumVersion: LemmyClient.instance.version,
                 ),
               );
@@ -291,8 +292,8 @@ class FeedAppBarGeneralActions extends StatelessWidget {
               isScrollControlled: true,
               builder: (builderContext) => SortPicker(
                 title: l10n.sortOptions,
-                onSelect: (selected) async => feedBloc.add(FeedChangeSortTypeEvent(selected.payload)),
-                previouslySelected: feedBloc.state.sortType,
+                onSelect: (selected) async => feedBloc.add(FeedChangeSortTypeEvent(PostSortTypeMapping.fromLemmyType(selected.payload)!)),
+                previouslySelected: feedBloc.state.sortType?.toLemmyType(),
                 minimumVersion: LemmyClient.instance.version,
               ),
             );

--- a/lib/search/bloc/search_bloc.dart
+++ b/lib/search/bloc/search_bloc.dart
@@ -9,6 +9,7 @@ import 'package:collection/collection.dart';
 import 'package:thunder/account/account.dart';
 import 'package:thunder/core/enums/enums.dart';
 import 'package:thunder/core/enums/meta_search_type.dart';
+import 'package:thunder/core/enums/post_sort_type.dart';
 import 'package:thunder/core/models/models.dart';
 import 'package:thunder/core/singletons/lemmy_client.dart';
 import 'package:thunder/feed/utils/community.dart';
@@ -132,7 +133,7 @@ class SearchBloc extends Bloc<SearchEvent, SearchState> {
           q: event.query,
           page: 1,
           limit: 15,
-          sort: event.sortType,
+          sort: event.sortType.toLemmyType(),
           listingType: event.feedListType.toLemmyType(),
           type: event.searchType.searchType,
           communityId: event.communityId,
@@ -224,7 +225,7 @@ class SearchBloc extends Bloc<SearchEvent, SearchState> {
               q: event.query,
               page: state.page,
               limit: 15,
-              sort: event.sortType,
+              sort: event.sortType.toLemmyType(),
               listingType: event.feedListType.toLemmyType(),
               type: event.searchType.searchType,
               communityId: event.communityId,
@@ -349,7 +350,7 @@ class SearchBloc extends Bloc<SearchEvent, SearchState> {
 
       final response = await lemmy.run(ListCommunities(
         type: ListingType.local,
-        sort: SortType.active,
+        sort: PostSortType.active.toLemmyType(),
         limit: 5,
         auth: account.jwt,
       ));

--- a/lib/search/bloc/search_event.dart
+++ b/lib/search/bloc/search_event.dart
@@ -9,7 +9,7 @@ abstract class SearchEvent extends Equatable {
 
 class StartSearchEvent extends SearchEvent {
   final String query;
-  final SortType sortType;
+  final PostSortType sortType;
   final FeedListType feedListType;
   final MetaSearchType searchType;
   final int? communityId;
@@ -41,7 +41,7 @@ class ResetSearch extends SearchEvent {}
 
 class ContinueSearchEvent extends SearchEvent {
   final String query;
-  final SortType sortType;
+  final PostSortType sortType;
   final FeedListType feedListType;
   final MetaSearchType searchType;
   final int? communityId;

--- a/lib/search/bloc/search_state.dart
+++ b/lib/search/bloc/search_state.dart
@@ -29,7 +29,7 @@ class SearchState extends Equatable {
   final String? errorMessage;
 
   final int page;
-  final SortType? sortType;
+  final PostSortType? sortType;
 
   final int focusSearchId;
   final bool viewingAll;
@@ -44,7 +44,7 @@ class SearchState extends Equatable {
     List<ThunderInstanceInfo>? instances,
     String? errorMessage,
     int? page,
-    SortType? sortType,
+    PostSortType? sortType,
     int? focusSearchId,
     bool? viewingAll,
   }) {

--- a/lib/search/pages/search_page.dart
+++ b/lib/search/pages/search_page.dart
@@ -18,6 +18,7 @@ import 'package:thunder/comment/comment.dart';
 import 'package:thunder/community/bloc/anonymous_subscriptions_bloc.dart';
 import 'package:thunder/community/widgets/community_list_entry.dart';
 import 'package:thunder/core/enums/enums.dart';
+import 'package:thunder/core/enums/post_sort_type.dart';
 import 'package:thunder/core/enums/subscription_status.dart';
 import 'package:thunder/core/enums/full_name.dart';
 import 'package:thunder/core/enums/meta_search_type.dart';
@@ -133,7 +134,7 @@ class _SearchPageState extends State<SearchPage> with AutomaticKeepAliveClientMi
       if (context.read<SearchBloc>().state.status != SearchStatus.done) {
         context.read<SearchBloc>().add(ContinueSearchEvent(
               query: _controller.text,
-              sortType: sortType,
+              sortType: PostSortTypeMapping.fromLemmyType(sortType)!,
               feedListType: _currentFeedType,
               searchType: _getSearchTypeToUse(),
               communityId: widget.communityToSearch?.id ?? _currentCommunityFilter,
@@ -895,7 +896,7 @@ class _SearchPageState extends State<SearchPage> with AutomaticKeepAliveClientMi
     if (_controller.text.isNotEmpty || force || searchBloc.state.viewingAll) {
       searchBloc.add(StartSearchEvent(
         query: _controller.text,
-        sortType: sortType,
+        sortType: PostSortTypeMapping.fromLemmyType(sortType)!,
         feedListType: _currentFeedType,
         searchType: _getSearchTypeToUse(),
         communityId: widget.communityToSearch?.id ?? _currentCommunityFilter,

--- a/lib/settings/pages/general_settings_page.dart
+++ b/lib/settings/pages/general_settings_page.dart
@@ -16,6 +16,7 @@ import 'package:thunder/core/database/database.dart' hide Account;
 import 'package:thunder/core/enums/browser_mode.dart';
 import 'package:thunder/core/enums/enums.dart';
 import 'package:thunder/core/enums/image_caching_mode.dart';
+import 'package:thunder/core/enums/post_sort_type.dart';
 
 import 'package:thunder/core/enums/local_settings.dart';
 import 'package:thunder/notification/enums/notification_type.dart';
@@ -126,7 +127,7 @@ class _GeneralSettingsPageState extends State<GeneralSettingsPage> with SingleTi
   /// Whether or not to show navigation labels
   bool showNavigationLabels = true;
 
-  SortType defaultSortType = DEFAULT_SORT_TYPE;
+  PostSortType defaultSortType = DEFAULT_SORT_TYPE;
 
   GlobalKey settingToHighlightKey = GlobalKey();
   LocalSettings? settingToHighlight;
@@ -159,7 +160,7 @@ class _GeneralSettingsPageState extends State<GeneralSettingsPage> with SingleTi
         break;
       case LocalSettings.defaultFeedSortType:
         await prefs.setString(LocalSettings.defaultFeedSortType.name, value);
-        setState(() => defaultSortType = SortType.values.byName(value ?? DEFAULT_SORT_TYPE.name));
+        setState(() => defaultSortType = PostSortTypeMapping.fromLemmyType(SortType.values.byName(value ?? DEFAULT_SORT_TYPE.name))!);
         break;
       case LocalSettings.defaultCommentSortType:
         await prefs.setString(LocalSettings.defaultCommentSortType.name, value);
@@ -275,10 +276,10 @@ class _GeneralSettingsPageState extends State<GeneralSettingsPage> with SingleTi
       // Default Sorts and Listing
       try {
         defaultFeedListType = FeedListType.values.byName(prefs.getString(LocalSettings.defaultFeedListType.name) ?? DEFAULT_LISTING_TYPE.name);
-        defaultSortType = SortType.values.byName(prefs.getString(LocalSettings.defaultFeedSortType.name) ?? DEFAULT_SORT_TYPE.name);
+        defaultSortType = PostSortTypeMapping.fromLemmyType(SortType.values.byName(prefs.getString(LocalSettings.defaultFeedSortType.name) ?? DEFAULT_SORT_TYPE.name))!;
       } catch (e) {
         defaultFeedListType = FeedListType.values.byName(DEFAULT_LISTING_TYPE.name);
-        defaultSortType = SortType.values.byName(DEFAULT_SORT_TYPE.name);
+        defaultSortType = PostSortTypeMapping.fromLemmyType(SortType.values.byName(DEFAULT_SORT_TYPE.name))!;
       }
 
       defaultCommentSortType = CommentSortType.values.byName(prefs.getString(LocalSettings.defaultCommentSortType.name) ?? DEFAULT_COMMENT_SORT_TYPE.name);
@@ -393,7 +394,11 @@ class _GeneralSettingsPageState extends State<GeneralSettingsPage> with SingleTi
                 ),
                 ListOption(
                   description: l10n.defaultFeedSortType,
-                  value: ListPickerItem(label: defaultSortType.value, icon: Icons.local_fire_department_rounded, payload: defaultSortType),
+                  value: ListPickerItem(
+                    label: allSortTypeItems.firstWhere((sortTypeItem) => sortTypeItem.payload == defaultSortType.toLemmyType()).label,
+                    icon: Icons.local_fire_department_rounded,
+                    payload: defaultSortType,
+                  ),
                   options: [
                     ...SortPicker.getDefaultSortTypeItems(minimumVersion: Version(0, 19, 0, preRelease: ["rc", "1"])),
                     ...topSortTypeItems
@@ -407,7 +412,7 @@ class _GeneralSettingsPageState extends State<GeneralSettingsPage> with SingleTi
                     onSelect: (value) async {
                       setPreferences(LocalSettings.defaultFeedSortType, value.payload.name);
                     },
-                    previouslySelected: defaultSortType,
+                    previouslySelected: defaultSortType.toLemmyType(),
                   ),
                   valueDisplay: Row(
                     children: [

--- a/lib/thunder/bloc/thunder_bloc.dart
+++ b/lib/thunder/bloc/thunder_bloc.dart
@@ -13,6 +13,7 @@ import 'package:thunder/core/enums/custom_theme_type.dart';
 import 'package:thunder/core/enums/fab_action.dart';
 import 'package:thunder/core/enums/feed_card_divider_thickness.dart';
 import 'package:thunder/core/enums/enums.dart';
+import 'package:thunder/core/enums/post_sort_type.dart';
 import 'package:thunder/core/enums/font_scale.dart';
 import 'package:thunder/core/enums/full_name.dart';
 import 'package:thunder/core/enums/image_caching_mode.dart';
@@ -87,13 +88,13 @@ class ThunderBloc extends Bloc<ThunderEvent, ThunderState> {
       /// -------------------------- Feed Related Settings --------------------------
       // Default Listing/Sort Settings
       FeedListType defaultFeedListType = DEFAULT_LISTING_TYPE;
-      SortType defaultSortType = DEFAULT_SORT_TYPE;
+      PostSortType defaultSortType = DEFAULT_SORT_TYPE;
       try {
         defaultFeedListType = FeedListType.values.byName(UserPreferences.getLocalSetting(LocalSettings.defaultFeedListType) ?? DEFAULT_LISTING_TYPE.name);
-        defaultSortType = SortType.values.byName(UserPreferences.getLocalSetting(LocalSettings.defaultFeedSortType) ?? DEFAULT_SORT_TYPE.name);
+        defaultSortType = PostSortType.values.byName(UserPreferences.getLocalSetting(LocalSettings.defaultFeedSortType) ?? DEFAULT_SORT_TYPE.name);
       } catch (e) {
         defaultFeedListType = FeedListType.values.byName(DEFAULT_LISTING_TYPE.name);
-        defaultSortType = SortType.values.byName(DEFAULT_SORT_TYPE.name);
+        defaultSortType = PostSortType.values.byName(DEFAULT_SORT_TYPE.name);
       }
 
       bool useProfilePictureForDrawer = UserPreferences.getLocalSetting(LocalSettings.useProfilePictureForDrawer) ?? false;

--- a/lib/thunder/bloc/thunder_state.dart
+++ b/lib/thunder/bloc/thunder_state.dart
@@ -184,8 +184,8 @@ class ThunderState extends Equatable {
   /// -------------------------- Feed Related Settings --------------------------
   // Default Listing/Sort Settings
   final FeedListType defaultFeedListType;
-  final SortType defaultSortType;
-  SortType get sortTypeForInstance => LemmyClient.instance.supportsSortType(defaultSortType) ? defaultSortType : DEFAULT_SORT_TYPE;
+  final PostSortType defaultSortType;
+  PostSortType get sortTypeForInstance => LemmyClient.instance.supportsSortType(defaultSortType.toLemmyType()) ? defaultSortType : DEFAULT_SORT_TYPE;
   final bool useProfilePictureForDrawer;
 
   // NSFW Settings
@@ -365,7 +365,7 @@ class ThunderState extends Equatable {
     /// -------------------------- Feed Related Settings --------------------------
     // Default Listing/Sort Settings
     FeedListType? defaultFeedListType,
-    SortType? defaultSortType,
+    PostSortType? defaultSortType,
     bool? useProfilePictureForDrawer,
 
     // NSFW Settings

--- a/lib/thunder/pages/thunder_page.dart
+++ b/lib/thunder/pages/thunder_page.dart
@@ -19,6 +19,7 @@ import 'package:thunder/account/account.dart';
 import 'package:thunder/community/widgets/community_drawer.dart';
 import 'package:thunder/core/enums/enums.dart';
 import 'package:thunder/core/enums/local_settings.dart';
+import 'package:thunder/core/enums/post_sort_type.dart';
 import 'package:thunder/core/singletons/lemmy_client.dart';
 import 'package:thunder/core/singletons/preferences.dart';
 import 'package:thunder/core/update/check_github_update.dart';
@@ -274,7 +275,7 @@ class _ThunderState extends State<Thunder> {
                               FeedFetchedEvent(
                                 feedType: FeedType.general,
                                 feedListType: FeedListType.fromLemmyType(state.getSiteResponse?.myUser?.localUserView.localUser.defaultListingType) ?? thunderBlocState.defaultFeedListType,
-                                sortType: state.getSiteResponse?.myUser?.localUserView.localUser.defaultSortType ?? thunderBlocState.sortTypeForInstance,
+                                sortType: PostSortTypeMapping.fromLemmyType(state.getSiteResponse?.myUser?.localUserView.localUser.defaultSortType) ?? thunderBlocState.sortTypeForInstance,
                                 reset: true,
                                 showHidden: thunderBlocState.showHiddenPosts,
                               ),
@@ -411,7 +412,7 @@ class _ThunderState extends State<Thunder> {
                                 useGlobalFeedBloc: true,
                                 feedType: FeedType.general,
                                 feedListType: FeedListType.fromLemmyType(state.getSiteResponse?.myUser?.localUserView.localUser.defaultListingType) ?? thunderBlocState.defaultFeedListType,
-                                sortType: state.getSiteResponse?.myUser?.localUserView.localUser.defaultSortType ?? thunderBlocState.sortTypeForInstance,
+                                sortType: PostSortTypeMapping.fromLemmyType(state.getSiteResponse?.myUser?.localUserView.localUser.defaultSortType) ?? thunderBlocState.sortTypeForInstance,
                                 scaffoldStateKey: scaffoldStateKey,
                                 showHidden: thunderBlocState.showHiddenPosts,
                               ),

--- a/lib/user/widgets/user_header/user_header_actions.dart
+++ b/lib/user/widgets/user_header/user_header_actions.dart
@@ -4,6 +4,7 @@ import 'package:flutter/services.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 
 import 'package:thunder/account/account.dart';
+import 'package:thunder/core/enums/post_sort_type.dart';
 import 'package:thunder/core/models/models.dart';
 import 'package:thunder/core/singletons/lemmy_client.dart';
 import 'package:thunder/feed/feed.dart';
@@ -296,12 +297,12 @@ class _SortActionChip extends StatelessWidget {
             title: l10n.sortOptions,
             onSelect: (selected) async {
               try {
-                context.read<FeedBloc>().add(FeedChangeSortTypeEvent(selected.payload));
+                context.read<FeedBloc>().add(FeedChangeSortTypeEvent(PostSortTypeMapping.fromLemmyType(selected.payload)!));
               } catch (e) {
                 debugPrint('Failed to update sort type: $e');
               }
             },
-            previouslySelected: state.sortType,
+            previouslySelected: state.sortType?.toLemmyType(),
             minimumVersion: LemmyClient.instance.version,
           ),
         );

--- a/lib/utils/constants.dart
+++ b/lib/utils/constants.dart
@@ -6,13 +6,14 @@ import 'package:lemmy_api_client/v3.dart';
 
 import 'package:thunder/core/enums/enums.dart';
 import 'package:thunder/core/enums/nested_comment_indicator.dart';
+import 'package:thunder/core/enums/post_sort_type.dart';
 import 'package:thunder/post/enums/post_card_metadata_item.dart';
 
 const FeedListType DEFAULT_LISTING_TYPE = FeedListType.all;
 
-const SortType DEFAULT_SORT_TYPE = SortType.hot;
+const PostSortType DEFAULT_SORT_TYPE = PostSortType.hot;
 
-const SortType DEFAULT_SEARCH_SORT_TYPE = SortType.topYear;
+const PostSortType DEFAULT_SEARCH_SORT_TYPE = PostSortType.topYear;
 
 const CommentSortType DEFAULT_COMMENT_SORT_TYPE = CommentSortType.top;
 

--- a/lib/utils/navigation.dart
+++ b/lib/utils/navigation.dart
@@ -17,6 +17,7 @@ import 'package:thunder/community/bloc/community_bloc.dart';
 import 'package:thunder/community/pages/create_post_page.dart';
 import 'package:thunder/core/enums/enums.dart';
 import 'package:thunder/core/enums/local_settings.dart';
+import 'package:thunder/core/enums/post_sort_type.dart';
 import 'package:thunder/core/models/models.dart';
 import 'package:thunder/core/singletons/lemmy_client.dart';
 import 'package:thunder/feed/bloc/feed_bloc.dart';
@@ -582,7 +583,7 @@ Future<void> navigateToFeedPage(
   BuildContext context, {
   required FeedType feedType,
   FeedListType? feedListType,
-  SortType? sortType,
+  PostSortType? sortType,
   String? communityName,
   int? communityId,
   String? username,
@@ -603,7 +604,10 @@ Future<void> navigateToFeedPage(
           FeedFetchedEvent(
             feedType: feedType,
             feedListType: feedListType,
-            sortType: sortType ?? profileBloc.state.getSiteResponse?.myUser?.localUserView.localUser.defaultSortType ?? thunderBloc.state.sortTypeForInstance,
+            sortType: sortType ??
+                (profileBloc.state.getSiteResponse?.myUser?.localUserView.localUser.defaultSortType != null
+                    ? PostSortTypeMapping.fromLemmyType(profileBloc.state.getSiteResponse!.myUser!.localUserView.localUser.defaultSortType)
+                    : thunderBloc.state.sortTypeForInstance),
             communityId: communityId,
             communityName: communityName,
             userId: userId,
@@ -635,7 +639,10 @@ Future<void> navigateToFeedPage(
       child: Material(
         child: FeedPage(
           feedType: feedType,
-          sortType: sortType ?? profileBloc.state.getSiteResponse?.myUser?.localUserView.localUser.defaultSortType ?? thunderBloc.state.sortTypeForInstance,
+          sortType: sortType ??
+              (profileBloc.state.getSiteResponse?.myUser?.localUserView.localUser.defaultSortType != null
+                  ? PostSortTypeMapping.fromLemmyType(profileBloc.state.getSiteResponse!.myUser!.localUserView.localUser.defaultSortType)
+                  : thunderBloc.state.sortTypeForInstance),
           communityName: communityName,
           communityId: communityId,
           userId: userId,


### PR DESCRIPTION
## Pull Request Description

This PR creates a new internal enum to handle post sort types PostSortType, and migrates our usage of SortType over to the new enum.

Some helper functions were implemented to translate between the two enums!

<!--- Please describe what was changed -->

## Issue Being Fixed

<!-- Please describe the problem that is being fixed and, if applicable, reference a GitHub issue -->

Issue Number: N/A

## Screenshots / Recordings

<!-- This section is optional but highly recommended to show off your changes! -->

## Checklist

- [ ] If a new package was added, did you ensure it uses an appropriate license and is actively maintained?
- [ ] Did you use localized strings (and added appropriate descriptions) where applicable?
- [ ] Did you add `semanticLabel`s where applicable for accessibility?
