### PR TITLE
Fix community naming

### DIFF
--- a/lib/comment/view/create_comment_page.dart
+++ b/lib/comment/view/create_comment_page.dart
@@ -443,7 +443,7 @@ class _CreateCommentPageState extends State<CreateCommentPage> {
                                         _bodyTextController.text = _bodyTextController.text.replaceRange(
                                           _bodyTextController.selection.end,
                                           _bodyTextController.selection.end,
-                                          '!${community.communityName}@${fetchInstanceNameFromUrl(community.url)}',
+                                          '!${community.name}@${fetchInstanceNameFromUrl(community.url)}',
                                         );
                                       });
                                     },

--- a/lib/community/bloc/community_bloc.dart
+++ b/lib/community/bloc/community_bloc.dart
@@ -58,7 +58,7 @@ class CommunityBloc extends Bloc<CommunityEvent, CommunityState> {
           emit(state.copyWith(
             status: CommunityStatus.success,
             community: community,
-            message: response.blocked ? l10n.successfullyBlockedCommunity(community.communityName) : l10n.successfullyUnblockedCommunity(community.communityName),
+            message: response.blocked ? l10n.successfullyBlockedCommunity(community.name) : l10n.successfullyUnblockedCommunity(community.name),
           ));
         } catch (e) {
           return emit(state.copyWith(status: CommunityStatus.failure));

--- a/lib/community/helpers/anonymous_subscriptions_helper.dart
+++ b/lib/community/helpers/anonymous_subscriptions_helper.dart
@@ -9,7 +9,7 @@ Future<List<ThunderCommunity>> getSubscriptions() async {
 }
 
 Future<void> insertSubscriptions(Set<ThunderCommunity> communities) async {
-  Set<LocalCommunity> subscriptions = communities.map((c) => LocalCommunity(id: c.id, name: c.communityName, title: c.title, actorId: c.url)).toSet();
+  Set<LocalCommunity> subscriptions = communities.map((c) => LocalCommunity(id: c.id, name: c.name, title: c.title, actorId: c.url)).toSet();
   await AnonymousSubscriptions.insertCommunities(subscriptions);
 }
 

--- a/lib/community/pages/create_post_page.dart
+++ b/lib/community/pages/create_post_page.dart
@@ -678,7 +678,7 @@ class _CreatePostPageState extends State<CreatePostPage> {
                                 MarkdownType.community: () {
                                   showCommunityInputDialog(context, title: l10n.community, onCommunitySelected: (community) {
                                     _bodyTextController.text = _bodyTextController.text
-                                        .replaceRange(_bodyTextController.selection.end, _bodyTextController.selection.end, '!${community.communityName}@${fetchInstanceNameFromUrl(community.url)}');
+                                        .replaceRange(_bodyTextController.selection.end, _bodyTextController.selection.end, '!${community.name}@${fetchInstanceNameFromUrl(community.url)}');
                                   });
                                 },
                               },
@@ -873,7 +873,7 @@ class _CommunitySelectorState extends State<CommunitySelector> {
                             Text('${widget.community!.title} '),
                             CommunityFullNameWidget(
                               context,
-                              widget.community!.communityName,
+                              widget.community!.name,
                               widget.community!.title,
                               fetchInstanceNameFromUrl(widget.community!.url),
                               // Override, because we have the display name right above

--- a/lib/community/widgets/community_header/community_header.dart
+++ b/lib/community/widgets/community_header/community_header.dart
@@ -127,7 +127,7 @@ class _CommunityInfo extends StatelessWidget {
         ),
         CommunityFullNameWidget(
           context,
-          community.communityName,
+          community.name,
           community.title,
           fetchInstanceNameFromUrl(community.url),
           useDisplayName: false, // Override because we're showing title above

--- a/lib/community/widgets/community_header/community_header_actions.dart
+++ b/lib/community/widgets/community_header/community_header_actions.dart
@@ -394,7 +394,7 @@ class _ModlogActionChip extends StatelessWidget {
         communityId: community.id,
         subtitle: generateCommunityFullName(
           context,
-          community.communityName,
+          community.name,
           community.title,
           fetchInstanceNameFromUrl(community.url),
         ),

--- a/lib/community/widgets/community_list_entry.dart
+++ b/lib/community/widgets/community_list_entry.dart
@@ -69,7 +69,7 @@ class CommunityListEntry extends StatelessWidget {
       excludeFromSemantics: true,
       message: '${community.title}\n${generateCommunityFullName(
         context,
-        community.communityName,
+        community.name,
         community.title,
         fetchInstanceNameFromUrl(community.url),
       )}',
@@ -82,7 +82,7 @@ class CommunityListEntry extends StatelessWidget {
             Flexible(
               child: CommunityFullNameWidget(
                 context,
-                community.communityName,
+                community.name,
                 community.title,
                 fetchInstanceNameFromUrl(community.url),
                 // Override because we're showing display name above

--- a/lib/community/widgets/post_card_metadata.dart
+++ b/lib/community/widgets/post_card_metadata.dart
@@ -582,7 +582,7 @@ class PostCommunityAndAuthor extends StatelessWidget {
             crossAxisAlignment: CrossAxisAlignment.start,
             children: [
               CommunityPostCardMetadata(
-                communityName: community.communityName,
+                communityName: community.name,
                 displayName: community.title,
                 actorId: community.url,
                 subscribed: community.subscribed != SubscribedType.notSubscribed,
@@ -598,7 +598,7 @@ class PostCommunityAndAuthor extends StatelessWidget {
           )
         else if (showCommunityName)
           CommunityPostCardMetadata(
-            communityName: community.communityName,
+            communityName: community.name,
             displayName: community.title,
             actorId: community.url,
             subscribed: community.subscribed != SubscribedType.notSubscribed,

--- a/lib/core/models/thunder_community.dart
+++ b/lib/core/models/thunder_community.dart
@@ -37,10 +37,10 @@ class ThunderCommunity {
   int get id => _community.id;
 
   /// The name of the community. If the community has a title, it is used. Otherwise, the name is used.
-  String get name => _community.title.isNotEmpty == true ? _community.title : _community.name;
+  String get titleOrName => _community.title.isNotEmpty == true ? _community.title : _community.name;
 
   /// The name of the community.
-  String get communityName => _community.name;
+  String get name => _community.name;
 
   /// The title of the community.
   String get title => _community.title;

--- a/lib/search/pages/search_page.dart
+++ b/lib/search/pages/search_page.dart
@@ -229,7 +229,7 @@ class _SearchPageState extends State<SearchPage> with AutomaticKeepAliveClientMi
                           },
                           decoration: InputDecoration(
                             fillColor: Theme.of(context).searchViewTheme.backgroundColor,
-                            hintText: l10n.searchInstance(widget.communityToSearch?.communityName ?? (isUserLoggedIn ? accountInstance : currentAnonymousInstance) ?? ''),
+                            hintText: l10n.searchInstance(widget.communityToSearch?.name ?? (isUserLoggedIn ? accountInstance : currentAnonymousInstance) ?? ''),
                             filled: true,
                             border: OutlineInputBorder(
                               borderRadius: BorderRadius.circular(50),
@@ -404,7 +404,7 @@ class _SearchPageState extends State<SearchPage> with AutomaticKeepAliveClientMi
                                           _currentCommunityFilter = community.id;
                                           _currentCommunityFilterName = generateCommunityFullName(
                                             context,
-                                            community.communityName,
+                                            community.name,
                                             community.title,
                                             fetchInstanceNameFromUrl(community.url),
                                           );

--- a/lib/shared/avatars/community_avatar.dart
+++ b/lib/shared/avatars/community_avatar.dart
@@ -43,7 +43,7 @@ class CommunityAvatar extends StatelessWidget {
       backgroundColor: theme.colorScheme.secondaryContainer,
       maxRadius: radius,
       child: Text(
-        community.name.isNotEmpty ? community.name[0].toUpperCase() : '',
+        community.titleOrName.isNotEmpty ? community.titleOrName[0].toUpperCase() : '',
         semanticsLabel: '',
         style: TextStyle(fontWeight: FontWeight.bold, fontSize: radius),
       ),

--- a/lib/shared/input_dialogs.dart
+++ b/lib/shared/input_dialogs.dart
@@ -193,7 +193,7 @@ Widget buildCommunitySuggestionWidget(BuildContext context, ThunderCommunity pay
   return Tooltip(
     message: generateCommunityFullName(
       context,
-      payload.communityName,
+      payload.name,
       payload.title,
       fetchInstanceNameFromUrl(payload.url),
     ),
@@ -214,7 +214,7 @@ Widget buildCommunitySuggestionWidget(BuildContext context, ThunderCommunity pay
                 pauseDuration: const Duration(seconds: 1),
                 child: CommunityFullNameWidget(
                   context,
-                  payload.communityName,
+                  payload.name,
                   payload.title,
                   fetchInstanceNameFromUrl(payload.url),
                   // Override because we're showing display name above

--- a/lib/user/widgets/user_information.dart
+++ b/lib/user/widgets/user_information.dart
@@ -191,7 +191,7 @@ class UserModeratorList extends StatelessWidget {
                       ),
                       CommunityFullNameWidget(
                         context,
-                        community.communityName,
+                        community.name,
                         community.title,
                         fetchInstanceNameFromUrl(community.url),
                         textStyle: const TextStyle(fontSize: 13.0),


### PR DESCRIPTION
## Pull Request Description

<!--- Please describe what was changed -->

This PR fixes an issue where community display names were being shown in the post body, despite having display names turned off in settings.

The problem originated from one of the refactorings where a confusing property, `name`, returns either the `title` (display name) or the `name`. You would have to explicitly use `communityName` to *not* get the `title`.

The concern was raised at the time...
https://github.com/thunder-app/thunder/pull/1754#discussion_r1999475977
...and I think this bug is a perfect example of the confusion in usage.

If it's ok, I've implemented the change that I proposed at the time, where the property that returns the title or name is explicitly called `titleOrName` and the `name` is just `name`. I think it's much more clear. Plus, there is very little usage of `titleOrName`, so the fact that it has kind of a clunky name is not really big deal. Let me know if that's ok or if there is a better suggestion.

While implementing the fix, I found several other places where I believe we were using the wrong value. Due to the renaming, the places that were _wrong_ before are _right_ now, so they don't appear in the PR, but I'll list them below.

https://github.com/thunder-app/thunder/blob/78a5d9c22de57bba2d66a21cde93f0127169a355/lib/community/widgets/community_drawer.dart#L485

https://github.com/thunder-app/thunder/blob/78a5d9c22de57bba2d66a21cde93f0127169a355/lib/modlog/widgets/modlog_item_context_card.dart#L126

https://github.com/thunder-app/thunder/blob/78a5d9c22de57bba2d66a21cde93f0127169a355/lib/modlog/widgets/modlog_item_context_card.dart#L282

https://github.com/thunder-app/thunder/blob/78a5d9c22de57bba2d66a21cde93f0127169a355/lib/modlog/widgets/modlog_item_context_card.dart#L394

https://github.com/thunder-app/thunder/blob/78a5d9c22de57bba2d66a21cde93f0127169a355/lib/modlog/widgets/modlog_item_context_card.dart#L400

(this is the one that prompted the PR)
https://github.com/thunder-app/thunder/blob/78a5d9c22de57bba2d66a21cde93f0127169a355/lib/post/widgets/post_body/post_body_title.dart#L212

https://github.com/thunder-app/thunder/blob/78a5d9c22de57bba2d66a21cde93f0127169a355/lib/post/widgets/post_bottom_sheet/general_post_action_bottom_sheet.dart#L105

https://github.com/thunder-app/thunder/blob/78a5d9c22de57bba2d66a21cde93f0127169a355/lib/post/widgets/post_bottom_sheet/post_action_bottom_sheet.dart#L94

https://github.com/thunder-app/thunder/blob/78a5d9c22de57bba2d66a21cde93f0127169a355/lib/shared/cross_posts.dart#L76

https://github.com/thunder-app/thunder/blob/78a5d9c22de57bba2d66a21cde93f0127169a355/lib/shared/cross_posts.dart#L122

## Issue Being Fixed

<!-- Please describe the problem that is being fixed and, if applicable, reference a GitHub issue -->

Issue Number: N/A

## Screenshots / Recordings

<!-- This section is optional but highly recommended to show off your changes! -->

### Before

https://github.com/user-attachments/assets/0fe18513-b75e-480b-8781-c6823a03fc4f

### After

https://github.com/user-attachments/assets/cfb188f5-e325-4702-98ba-e2351b0df4ff

## Checklist

- [ ] If a new package was added, did you ensure it uses an appropriate license and is actively maintained?
- [ ] Did you use localized strings (and added appropriate descriptions) where applicable?
- [ ] Did you add `semanticLabel`s where applicable for accessibility?
