### PR TITLE
Chore: refactor comment sort type enum to internal enum

### DIFF
--- a/lib/core/enums/comment_sort_type.dart
+++ b/lib/core/enums/comment_sort_type.dart
@@ -1,0 +1,45 @@
+import 'package:lemmy_api_client/v3.dart' as lemmy;
+
+enum CommentSortType {
+  hot,
+  top,
+  new_,
+  old,
+  controversial,
+}
+
+extension CommentSortTypeMapping on CommentSortType {
+  /// Converts a local CommentSortType to lemmy API CommentSortType
+  lemmy.CommentSortType toLemmyType() {
+    switch (this) {
+      case CommentSortType.hot:
+        return lemmy.CommentSortType.hot;
+      case CommentSortType.top:
+        return lemmy.CommentSortType.top;
+      case CommentSortType.new_:
+        return lemmy.CommentSortType.new_;
+      case CommentSortType.old:
+        return lemmy.CommentSortType.old;
+      case CommentSortType.controversial:
+        return lemmy.CommentSortType.controversial;
+    }
+  }
+
+  /// Converts a lemmy API CommentSortType to local CommentSortType
+  static CommentSortType? fromLemmyType(lemmy.CommentSortType? lemmyType) {
+    switch (lemmyType) {
+      case lemmy.CommentSortType.hot:
+        return CommentSortType.hot;
+      case lemmy.CommentSortType.top:
+        return CommentSortType.top;
+      case lemmy.CommentSortType.new_:
+        return CommentSortType.new_;
+      case lemmy.CommentSortType.old:
+        return CommentSortType.old;
+      case lemmy.CommentSortType.controversial:
+        return CommentSortType.controversial;
+      default:
+        return null;
+    }
+  }
+}

--- a/lib/core/singletons/lemmy_client.dart
+++ b/lib/core/singletons/lemmy_client.dart
@@ -1,7 +1,9 @@
-import 'package:lemmy_api_client/v3.dart';
-import 'package:thunder/account/account.dart';
-import 'package:thunder/core/enums/post_sort_type.dart';
+import 'package:lemmy_api_client/v3.dart' hide CommentSortType;
 import 'package:version/version.dart';
+
+import 'package:thunder/account/account.dart';
+import 'package:thunder/core/enums/comment_sort_type.dart';
+import 'package:thunder/core/enums/post_sort_type.dart';
 
 class LemmyClient {
   LemmyApiV3 lemmyApiV3 = const LemmyApiV3('');

--- a/lib/inbox/bloc/inbox_bloc.dart
+++ b/lib/inbox/bloc/inbox_bloc.dart
@@ -1,9 +1,10 @@
 import 'package:bloc/bloc.dart';
 import 'package:equatable/equatable.dart';
 import 'package:bloc_concurrency/bloc_concurrency.dart';
-import 'package:lemmy_api_client/v3.dart';
+import 'package:lemmy_api_client/v3.dart' hide CommentSortType;
 import 'package:stream_transform/stream_transform.dart';
 
+import 'package:thunder/core/enums/comment_sort_type.dart';
 import 'package:thunder/core/extensions/comment_reply_view.dart';
 import 'package:thunder/core/extensions/person_mention_view.dart';
 import 'package:thunder/core/models/models.dart';
@@ -82,7 +83,7 @@ class InboxBloc extends Bloc<InboxEvent, InboxState> {
                 auth: account.jwt!,
                 unreadOnly: !event.showAll,
                 limit: limit,
-                sort: event.commentSortType,
+                sort: event.commentSortType.toLemmyType(),
                 page: 1,
               ),
             );
@@ -92,7 +93,7 @@ class InboxBloc extends Bloc<InboxEvent, InboxState> {
               GetPersonMentions(
                 auth: account.jwt!,
                 unreadOnly: !event.showAll,
-                sort: event.commentSortType,
+                sort: event.commentSortType.toLemmyType(),
                 limit: limit,
                 page: 1,
               ),
@@ -114,7 +115,7 @@ class InboxBloc extends Bloc<InboxEvent, InboxState> {
                 auth: account.jwt!,
                 unreadOnly: !event.showAll,
                 limit: limit,
-                sort: event.commentSortType,
+                sort: event.commentSortType.toLemmyType(),
                 page: 1,
               ),
             );
@@ -122,7 +123,7 @@ class InboxBloc extends Bloc<InboxEvent, InboxState> {
               GetPersonMentions(
                 auth: account.jwt!,
                 unreadOnly: !event.showAll,
-                sort: event.commentSortType,
+                sort: event.commentSortType.toLemmyType(),
                 limit: limit,
                 page: 1,
               ),
@@ -177,7 +178,7 @@ class InboxBloc extends Bloc<InboxEvent, InboxState> {
               auth: account.jwt!,
               unreadOnly: state.showUnreadOnly,
               limit: limit,
-              sort: event.commentSortType,
+              sort: event.commentSortType.toLemmyType(),
               page: state.inboxReplyPage,
             ),
           );
@@ -189,7 +190,7 @@ class InboxBloc extends Bloc<InboxEvent, InboxState> {
             GetPersonMentions(
               auth: account.jwt!,
               unreadOnly: state.showUnreadOnly,
-              sort: event.commentSortType,
+              sort: event.commentSortType.toLemmyType(),
               limit: limit,
               page: state.inboxMentionPage,
             ),

--- a/lib/inbox/pages/inbox_page.dart
+++ b/lib/inbox/pages/inbox_page.dart
@@ -2,10 +2,10 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 
 import 'package:flutter_bloc/flutter_bloc.dart';
-import 'package:thunder/localizations/app_localizations.dart';
-import 'package:lemmy_api_client/v3.dart';
-import 'package:thunder/account/account.dart';
 
+import 'package:thunder/localizations/app_localizations.dart';
+import 'package:thunder/account/account.dart';
+import 'package:thunder/core/enums/comment_sort_type.dart';
 import 'package:thunder/core/singletons/lemmy_client.dart';
 import 'package:thunder/inbox/bloc/inbox_bloc.dart';
 import 'package:thunder/inbox/enums/inbox_type.dart';

--- a/lib/notification/utils/local_notifications.dart
+++ b/lib/notification/utils/local_notifications.dart
@@ -9,12 +9,13 @@ import 'package:flutter/material.dart';
 import 'package:background_fetch/background_fetch.dart';
 import 'package:flutter_local_notifications/flutter_local_notifications.dart';
 import 'package:html/parser.dart';
-import 'package:lemmy_api_client/v3.dart';
+import 'package:lemmy_api_client/v3.dart' hide CommentSortType;
 import 'package:markdown/markdown.dart';
 
 // Project imports
 import 'package:thunder/account/account.dart';
 import 'package:thunder/comment/comment.dart';
+import 'package:thunder/core/enums/comment_sort_type.dart';
 import 'package:thunder/core/enums/full_name.dart';
 import 'package:thunder/core/enums/local_settings.dart';
 import 'package:thunder/core/extensions/comment_reply_view.dart';
@@ -74,7 +75,7 @@ Future<void> pollRepliesAndShowNotifications() async {
         auth: account.jwt!,
         unreadOnly: true,
         limit: 50, // Max allowed by API
-        sort: CommentSortType.old,
+        sort: CommentSortType.old.toLemmyType(),
         page: 1,
       ),
     );

--- a/lib/post/bloc/post_bloc.dart
+++ b/lib/post/bloc/post_bloc.dart
@@ -2,10 +2,11 @@ import 'dart:math';
 
 import 'package:equatable/equatable.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
-import 'package:lemmy_api_client/v3.dart';
+import 'package:lemmy_api_client/v3.dart' hide CommentSortType;
 
 import 'package:thunder/account/account.dart';
 import 'package:thunder/comment/comment.dart';
+import 'package:thunder/core/enums/comment_sort_type.dart';
 import 'package:thunder/core/enums/local_settings.dart';
 import 'package:thunder/core/models/models.dart';
 import 'package:thunder/core/singletons/lemmy_client.dart';
@@ -104,7 +105,7 @@ class PostBloc extends Bloc<PostEvent, PostState> {
         communityId: post?.community?.id,
         maxDepth: COMMENT_MAX_DEPTH,
         postId: post?.id,
-        sort: commentSortType,
+        sort: commentSortType.toLemmyType(),
         limit: COMMENT_LIMIT,
         type: ListingType.all,
         parentId: parentId,
@@ -212,7 +213,7 @@ class PostBloc extends Bloc<PostEvent, PostState> {
           communityId: state.post?.community?.id,
           parentId: event.commentParentId,
           postId: state.post?.id,
-          sort: commentSortType,
+          sort: commentSortType.toLemmyType(),
           limit: COMMENT_LIMIT,
           maxDepth: COMMENT_MAX_DEPTH,
           page: 1,
@@ -256,7 +257,7 @@ class PostBloc extends Bloc<PostEvent, PostState> {
         communityId: state.post?.community?.id,
         postId: state.post?.id,
         parentId: event.commentParentId,
-        sort: commentSortType,
+        sort: commentSortType.toLemmyType(),
         limit: COMMENT_LIMIT,
         maxDepth: COMMENT_MAX_DEPTH,
         page: state.commentPage,

--- a/lib/post/widgets/post_page_app_bar.dart
+++ b/lib/post/widgets/post_page_app_bar.dart
@@ -1,13 +1,13 @@
-import 'package:collection/collection.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 
+import 'package:collection/collection.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
+
+import 'package:thunder/core/enums/comment_sort_type.dart';
 import 'package:thunder/localizations/app_localizations.dart';
-import 'package:lemmy_api_client/src/v3/enums/comment_sort_type.dart';
 import 'package:thunder/core/enums/media_type.dart';
 import 'package:thunder/core/models/models.dart';
-
 import 'package:thunder/core/singletons/lemmy_client.dart';
 import 'package:thunder/post/bloc/post_bloc.dart';
 import 'package:thunder/shared/comment_sort_picker.dart';

--- a/lib/settings/pages/general_settings_page.dart
+++ b/lib/settings/pages/general_settings_page.dart
@@ -1,15 +1,18 @@
 import 'dart:async';
 import 'dart:io';
 
+import 'package:flutter/foundation.dart';
 import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter_local_notifications/flutter_local_notifications.dart';
 
-import 'package:lemmy_api_client/v3.dart';
+import 'package:flutter_local_notifications/flutter_local_notifications.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:android_intent_plus/android_intent.dart';
 import 'package:permission_handler/permission_handler.dart';
-import 'package:flutter/foundation.dart';
+import 'package:unifiedpush/unifiedpush.dart';
+import 'package:version/version.dart';
+
+import 'package:thunder/core/enums/comment_sort_type.dart';
 import 'package:thunder/localizations/app_localizations.dart';
 import 'package:thunder/account/account.dart';
 import 'package:thunder/core/database/database.dart' hide Account;
@@ -17,7 +20,6 @@ import 'package:thunder/core/enums/browser_mode.dart';
 import 'package:thunder/core/enums/enums.dart';
 import 'package:thunder/core/enums/image_caching_mode.dart';
 import 'package:thunder/core/enums/post_sort_type.dart';
-
 import 'package:thunder/core/enums/local_settings.dart';
 import 'package:thunder/notification/enums/notification_type.dart';
 import 'package:thunder/core/singletons/lemmy_client.dart';
@@ -39,8 +41,6 @@ import 'package:thunder/utils/global_context.dart';
 import 'package:thunder/utils/language/language.dart';
 import 'package:thunder/utils/links.dart';
 import 'package:thunder/utils/navigation.dart';
-import 'package:unifiedpush/unifiedpush.dart';
-import 'package:version/version.dart';
 
 class GeneralSettingsPage extends StatefulWidget {
   final LocalSettings? settingToHighlight;
@@ -590,7 +590,7 @@ class _GeneralSettingsPageState extends State<GeneralSettingsPage> with SingleTi
           SliverToBoxAdapter(
             child: ListOption(
               description: l10n.defaultCommentSortType,
-              value: ListPickerItem(label: defaultCommentSortType.value, icon: Icons.local_fire_department_rounded, payload: defaultCommentSortType),
+              value: ListPickerItem(label: defaultCommentSortType.name, icon: Icons.local_fire_department_rounded, payload: defaultCommentSortType),
               options: CommentSortPicker.getCommentSortTypeItems(minimumVersion: Version(0, 19, 0, preRelease: ["rc", "1"])),
               icon: Icons.comment_bank_rounded,
               onChanged: (_) async {},

--- a/lib/shared/comment_sort_picker.dart
+++ b/lib/shared/comment_sort_picker.dart
@@ -1,11 +1,13 @@
 import 'package:flutter/material.dart';
-import 'package:lemmy_api_client/v3.dart';
+
+import 'package:version/version.dart';
+
+import 'package:thunder/core/enums/comment_sort_type.dart';
 import 'package:thunder/core/singletons/lemmy_client.dart';
 import 'package:thunder/shared/picker_item.dart';
 import 'package:thunder/utils/bottom_sheet_list_picker.dart';
 import 'package:thunder/localizations/app_localizations.dart';
 import 'package:thunder/utils/global_context.dart';
-import 'package:version/version.dart';
 
 /// Create a picker which allows selecting a valid comment sort type.
 /// Specify a [minimumVersion] to determine which sort types will be displayed.

--- a/lib/thunder/bloc/thunder_bloc.dart
+++ b/lib/thunder/bloc/thunder_bloc.dart
@@ -1,14 +1,14 @@
+import 'package:flutter/material.dart';
+
 import 'package:bloc/bloc.dart';
 import 'package:equatable/equatable.dart';
 import 'package:bloc_concurrency/bloc_concurrency.dart';
-import 'package:flutter/material.dart';
 import 'package:intl/intl.dart';
-import 'package:lemmy_api_client/v3.dart';
-
 import 'package:stream_transform/stream_transform.dart';
+
 import 'package:thunder/core/enums/action_color.dart';
 import 'package:thunder/core/enums/browser_mode.dart';
-
+import 'package:thunder/core/enums/comment_sort_type.dart';
 import 'package:thunder/core/enums/custom_theme_type.dart';
 import 'package:thunder/core/enums/fab_action.dart';
 import 'package:thunder/core/enums/feed_card_divider_thickness.dart';

--- a/lib/utils/constants.dart
+++ b/lib/utils/constants.dart
@@ -2,8 +2,7 @@
 
 import 'dart:ui';
 
-import 'package:lemmy_api_client/v3.dart';
-
+import 'package:thunder/core/enums/comment_sort_type.dart';
 import 'package:thunder/core/enums/enums.dart';
 import 'package:thunder/core/enums/nested_comment_indicator.dart';
 import 'package:thunder/core/enums/post_sort_type.dart';

--- a/lib/utils/navigation.dart
+++ b/lib/utils/navigation.dart
@@ -5,11 +5,12 @@ import 'package:flutter/material.dart';
 
 import 'package:collection/collection.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
-import 'package:lemmy_api_client/v3.dart' hide ModlogActionType;
+import 'package:lemmy_api_client/v3.dart' hide ModlogActionType, CommentSortType;
 import 'package:swipeable_page_route/swipeable_page_route.dart';
+
+import 'package:thunder/core/enums/comment_sort_type.dart';
 import 'package:thunder/core/enums/full_name.dart';
 import 'package:thunder/localizations/app_localizations.dart';
-
 import 'package:thunder/account/account.dart';
 import 'package:thunder/comment/comment.dart';
 import 'package:thunder/community/bloc/anonymous_subscriptions_bloc.dart';
@@ -498,7 +499,7 @@ void navigateToNotificationReplyPage(BuildContext context, {required int? replyI
   // Load the notifications
   while (!doneFetching) {
     final GetRepliesResponse getRepliesResponse = await (LemmyClient()..changeBaseUrl(account.instance)).lemmyApiV3.run(GetReplies(
-          sort: CommentSortType.new_,
+          sort: CommentSortType.new_.toLemmyType(),
           page: currentPage,
           limit: 50,
           unreadOnly: replyId == null,


### PR DESCRIPTION
## Pull Request Description

This PR creates a new internal enum to handle comment sort types `CommentSortType`, and migrates our usage of `CommentSortType` over to the new enum.

<!--- Please describe what was changed -->

## Issue Being Fixed

<!-- Please describe the problem that is being fixed and, if applicable, reference a GitHub issue -->

Issue Number: N/A

## Screenshots / Recordings

<!-- This section is optional but highly recommended to show off your changes! -->

## Checklist

- [ ] If a new package was added, did you ensure it uses an appropriate license and is actively maintained?
- [ ] Did you use localized strings (and added appropriate descriptions) where applicable?
- [ ] Did you add `semanticLabel`s where applicable for accessibility?
