### PR TITLE
Fix issue with some languages not being applied properly

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -43,6 +43,7 @@ import 'package:thunder/user/bloc/user_bloc.dart';
 import 'package:thunder/utils/cache.dart';
 import 'package:thunder/utils/global_context.dart';
 import 'package:thunder/utils/preferences.dart';
+import 'package:thunder/utils/language/language.dart';
 
 late AppDatabase database;
 
@@ -250,7 +251,7 @@ class _ThunderAppState extends State<ThunderApp> {
                 ),
               );
 
-              Locale? locale = AppLocalizations.supportedLocales.where((Locale locale) => locale.languageCode == thunderBloc.state.appLanguageCode).firstOrNull;
+              Locale? locale = LanguageLocal.parseLanguageTag(thunderBloc.state.appLanguageCode);
 
               return OverlaySupport.global(
                 child: AnnotatedRegion<SystemUiOverlayStyle>(

--- a/lib/settings/pages/general_settings_page.dart
+++ b/lib/settings/pages/general_settings_page.dart
@@ -166,7 +166,7 @@ class _GeneralSettingsPageState extends State<GeneralSettingsPage> with SingleTi
         setState(() => defaultCommentSortType = CommentSortType.values.byName(value ?? DEFAULT_COMMENT_SORT_TYPE.name));
         break;
       case LocalSettings.appLanguageCode:
-        await prefs.setString(LocalSettings.appLanguageCode.name, value.languageCode);
+        await prefs.setString(LocalSettings.appLanguageCode.name, value.toLanguageTag());
         setState(() => currentLocale = value);
         break;
       case LocalSettings.useProfilePictureForDrawer:
@@ -282,7 +282,11 @@ class _GeneralSettingsPageState extends State<GeneralSettingsPage> with SingleTi
       }
 
       defaultCommentSortType = CommentSortType.values.byName(prefs.getString(LocalSettings.defaultCommentSortType.name) ?? DEFAULT_COMMENT_SORT_TYPE.name);
-      currentLocale = Localizations.localeOf(context);
+
+      // Load saved locale from preferences, if not found, fallback to system locale
+      Locale? parsedLocale = LanguageLocal.parseLanguageTag(prefs.getString(LocalSettings.appLanguageCode.name));
+      currentLocale = parsedLocale ?? Localizations.localeOf(context);
+
       useProfilePictureForDrawer = prefs.getBool(LocalSettings.useProfilePictureForDrawer.name) ?? false;
 
       hideNsfwPosts = prefs.getBool(LocalSettings.hideNsfwPosts.name) ?? false;
@@ -459,7 +463,7 @@ class _GeneralSettingsPageState extends State<GeneralSettingsPage> with SingleTi
             child: ListOption(
               description: l10n.appLanguage,
               bottomSheetHeading: Align(alignment: Alignment.centerLeft, child: Text(l10n.translationsMayNotBeComplete)),
-              value: ListPickerItem(label: currentLocale.languageCode, icon: Icons.language_rounded, payload: currentLocale),
+              value: ListPickerItem(label: LanguageLocal.getDisplayLanguage(currentLocale.languageCode, currentLocale.toLanguageTag()), icon: Icons.language_rounded, payload: currentLocale),
               options: supportedLocales.map((e) => ListPickerItem(label: LanguageLocal.getDisplayLanguage(e.languageCode, e.toLanguageTag()), icon: Icons.language_rounded, payload: e)).toList(),
               icon: Icons.language_rounded,
               onChanged: (ListPickerItem<Locale> value) async {

--- a/lib/utils/language/language.dart
+++ b/lib/utils/language/language.dart
@@ -1,3 +1,7 @@
+import 'package:flutter/material.dart';
+
+import 'package:thunder/localizations/app_localizations.dart';
+
 class LanguageLocal {
   static String getDisplayLanguage(key, String? code) {
     final languageLabels = {
@@ -189,6 +193,41 @@ class LanguageLocal {
       return "${languageLabels[key]?["nativeName"]}${code != null ? " ($code)" : ""}";
     } else {
       throw Exception("Language key incorrect");
+    }
+  }
+
+  /// Parses a locale string (e.g., "en-AU") and finds the matching supported locale.
+  ///
+  /// This function handles both full locale strings (e.g., "en-AU") and simple language codes (e.g., "en").
+  /// It first tries to find an exact match for language + country, then falls back to language-only matches.
+  ///
+  /// Returns the matching Locale if found, null otherwise.
+  static Locale? parseLanguageTag(String? languageTag) {
+    if (languageTag == null || languageTag.isEmpty) {
+      return null;
+    }
+
+    try {
+      List<String> parts = languageTag.split('-');
+      Locale targetLocale;
+
+      if (parts.length >= 2) {
+        targetLocale = Locale(parts[0], parts[1]);
+      } else {
+        targetLocale = Locale(parts[0]);
+      }
+
+      // First, try to find an exact match for language + country
+      Locale? exactMatch = AppLocalizations.supportedLocales.where((Locale locale) => locale.languageCode == targetLocale.languageCode && locale.countryCode == targetLocale.countryCode).firstOrNull;
+
+      if (exactMatch != null) {
+        return exactMatch;
+      }
+
+      // If no exact match found, try matching just the language code
+      return AppLocalizations.supportedLocales.where((Locale locale) => locale.languageCode == targetLocale.languageCode).firstOrNull;
+    } catch (e) {
+      return null;
     }
   }
 }


### PR DESCRIPTION
## Pull Request Description

This PR fixes an issue where some languages (with country codes) were not being applied properly. After some investigation, I realized that Thunder was only saving the language code (e.g., `en`) rather than the full language tag (e.g., `en-AU`).

To resolve this, I've:
- Adjusted the logic to save the full language tag rather than just the language code
- Added new helper function to parse language tags (e.g., `en-GB`) into the proper locale. This function works with both `en` and `en-GB` variants!

<!--- Please describe what was changed -->

## Issue Being Fixed

<!-- Please describe the problem that is being fixed and, if applicable, reference a GitHub issue -->

Issue Number: https://lemmy.world/post/31648550

## Screenshots / Recordings

<!-- This section is optional but highly recommended to show off your changes! -->

## Checklist

- [ ] If a new package was added, did you ensure it uses an appropriate license and is actively maintained?
- [ ] Did you use localized strings (and added appropriate descriptions) where applicable?
- [ ] Did you add `semanticLabel`s where applicable for accessibility?
