### PR TITLE
Improve comment header overflow issues

### DIFF
--- a/lib/comment/widgets/comment_card/comment_card_header.dart
+++ b/lib/comment/widgets/comment_card/comment_card_header.dart
@@ -64,33 +64,46 @@ class CommentCardHeader extends StatelessWidget {
 
     final userGroups = _getUserGroups(accountId);
 
-    return Padding(
-      padding: EdgeInsets.fromLTRB(userGroups.isNotEmpty ? 8.0 : 8.0, 10.0, 8.0, 10.0),
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          Row(
-            spacing: 8.0,
-            mainAxisSize: MainAxisSize.min,
-            children: [
-              UserChip(
-                user: ThunderUser(comment.creator!),
-                personAvatar: UserAvatar(user: ThunderUser(comment.creator!), radius: 10, thumbnailSize: 20, format: 'png'),
-                userGroups: userGroups,
-                includeInstance: commentShowUserInstance,
-                ignorePointerEvents: hidden && collapseParentCommentOnGesture,
-                opacity: 1.0,
-              ),
-              CommentCardHeaderScore(score: comment.score!, upvotes: comment.upvotes!, downvotes: comment.downvotes!, voteType: comment.myVote),
-              Spacer(flex: 1),
-              CommentCardHeaderReplyCount(replies: comment.childCount!, hidden: hidden),
-              if (saved == true) Icon(Icons.star_rounded, color: saveColor.color, size: 19.0),
-              if (updated != null) Icon(Icons.create_rounded, color: theme.colorScheme.onSurface.withValues(alpha: 0.75), size: 16.0),
-              CommentCardHeaderDate(created: created, updated: updated),
-            ],
-          ),
-          UserLabelChip(username: UserLabel.usernameFromParts(comment.creator!.name, comment.creator!.actorId))
-        ],
+    return LayoutBuilder(
+      builder: (context, constraints) => Padding(
+        padding: EdgeInsets.fromLTRB(userGroups.isNotEmpty ? 8.0 : 8.0, 10.0, 8.0, 10.0),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Row(
+              spacing: 8.0,
+              mainAxisAlignment: MainAxisAlignment.spaceBetween,
+              children: [
+                Row(
+                  spacing: 8.0,
+                  children: [
+                    UserChip(
+                      user: ThunderUser(comment.creator!),
+                      personAvatar: UserAvatar(user: ThunderUser(comment.creator!), radius: 10, thumbnailSize: 20, format: 'png'),
+                      userGroups: userGroups,
+                      includeInstance: commentShowUserInstance,
+                      ignorePointerEvents: hidden && collapseParentCommentOnGesture,
+                      opacity: 1.0,
+                      constraints: constraints,
+                    ),
+                    CommentCardHeaderScore(score: comment.score!, upvotes: comment.upvotes!, downvotes: comment.downvotes!, voteType: comment.myVote),
+                  ],
+                ),
+                Row(
+                  spacing: 8.0,
+                  children: hidden
+                      ? [CommentCardHeaderReplyCount(replies: comment.childCount!, hidden: hidden)]
+                      : [
+                          if (saved == true) Icon(Icons.star_rounded, color: saveColor.color, size: 19.0),
+                          if (updated != null) Icon(Icons.create_rounded, color: theme.colorScheme.onSurface.withValues(alpha: 0.75), size: 16.0),
+                          CommentCardHeaderDate(created: created, updated: updated),
+                        ],
+                )
+              ],
+            ),
+            UserLabelChip(username: UserLabel.usernameFromParts(comment.creator!.name, comment.creator!.actorId))
+          ],
+        ),
       ),
     );
   }

--- a/lib/shared/chips/user_chip.dart
+++ b/lib/shared/chips/user_chip.dart
@@ -27,6 +27,7 @@ class UserChip extends StatelessWidget {
     this.userGroups = const [],
     this.opacity = 1.0,
     this.ignorePointerEvents = false,
+    this.constraints,
   });
 
   /// The user to display information for
@@ -47,6 +48,9 @@ class UserChip extends StatelessWidget {
 
   /// Whether or not to disable the touch events (e.g., navigating to user page)
   final bool ignorePointerEvents;
+
+  /// The constraints for the user chip
+  final BoxConstraints? constraints;
 
   @override
   Widget build(BuildContext context) {
@@ -80,14 +84,17 @@ class UserChip extends StatelessWidget {
                 mainAxisSize: MainAxisSize.min,
                 children: [
                   if (showUserAvatar && personAvatar != null && user.icon != null) Padding(padding: const EdgeInsets.only(top: 3, bottom: 3, right: 3), child: personAvatar!),
-                  UserFullNameWidget(
-                    context,
-                    user.username,
-                    user.displayName,
-                    fetchInstanceNameFromUrl(user.url),
-                    includeInstance: includeInstance,
-                    fontScale: state.metadataFontSizeScale,
-                    transformColor: (c) => userGroups.isNotEmpty ? theme.textTheme.bodyMedium?.color : c?.withValues(alpha: opacity),
+                  ConstrainedBox(
+                    constraints: BoxConstraints(maxWidth: (constraints?.maxWidth ?? MediaQuery.sizeOf(context).width) * 0.55),
+                    child: UserFullNameWidget(
+                      context,
+                      user.username,
+                      user.displayName,
+                      fetchInstanceNameFromUrl(user.url),
+                      includeInstance: includeInstance,
+                      fontScale: state.metadataFontSizeScale,
+                      transformColor: (c) => userGroups.isNotEmpty ? theme.textTheme.bodyMedium?.color : c?.withValues(alpha: opacity),
+                    ),
                   ),
                   if (userGroups.isNotEmpty) const SizedBox(width: 2.0),
                   if (userGroups.contains(UserType.op))


### PR DESCRIPTION
## Pull Request Description

> Review with whitespace off

This PR attempts to improve the overflow issue on comment headers with long usernames. A few things have been adjusted to fix this issue:
- Added a constraint to the maximum size of the user chip - allowing the maximum width to take up to 55% of the width of the header. This value was chosen after doing some trial and error and we can further adjust this value in the future!
- When a comment is collapsed, the save, edit, and date information will be hidden as well to make space for the comment reply widget

Note: this does not completely eliminate the issue as there can still be edge cases where some overflow is observed. However, I do think that this should fix the vast majority of instances!

<!--- Please describe what was changed -->

## Issue Being Fixed

<!-- Please describe the problem that is being fixed and, if applicable, reference a GitHub issue -->

Issue Number: #976, https://lemmy.world/post/31701998

## Screenshots / Recordings

For the sake of reproduction, I've increased the system font size in the demo videos.

https://github.com/user-attachments/assets/62099398-5df4-42c1-b165-998f743af456

<!-- This section is optional but highly recommended to show off your changes! -->

## Checklist

- [ ] If a new package was added, did you ensure it uses an appropriate license and is actively maintained?
- [ ] Did you use localized strings (and added appropriate descriptions) where applicable?
- [ ] Did you add `semanticLabel`s where applicable for accessibility?
