### PR TITLE
Fix issues with anonymous subscriptions not working properly

### DIFF
--- a/lib/community/bloc/anonymous_subscriptions_bloc.dart
+++ b/lib/community/bloc/anonymous_subscriptions_bloc.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+
 import 'package:bloc/bloc.dart';
 import 'package:bloc_concurrency/bloc_concurrency.dart';
 import 'package:equatable/equatable.dart';
@@ -20,52 +21,68 @@ EventTransformer<E> throttleDroppable<E>(Duration duration) {
 class AnonymousSubscriptionsBloc extends Bloc<AnonymousSubscriptionsEvent, AnonymousSubscriptionsState> {
   AnonymousSubscriptionsBloc() : super(const AnonymousSubscriptionsState()) {
     on<GetSubscribedCommunitiesEvent>(_getSubscribedCommunities, transformer: throttleDroppable(throttleDuration));
-
-    on<AddSubscriptionsEvent>(_addSubscriptions, transformer: throttleDroppable(throttleDuration));
-
-    on<DeleteSubscriptionsEvent>(_deleteSubscriptions, transformer: throttleDroppable(throttleDuration));
+    on<AddSubscriptionsEvent>(_addSubscriptions);
+    on<DeleteSubscriptionsEvent>(_deleteSubscriptions);
   }
 
   FutureOr<void> _deleteSubscriptions(DeleteSubscriptionsEvent event, Emitter<AnonymousSubscriptionsState> emit) async {
     try {
-      await AnonymousSubscriptions.deleteCommunities(event.ids);
-      emit(state.copyWith(
-        status: AnonymousSubscriptionsStatus.success,
-        subscriptions: [...state.subscriptions]..removeWhere((e) => event.ids.contains(e.id)),
-        ids: {...state.ids}..removeAll(event.ids),
-      ));
-      emit(state.copyWith(status: AnonymousSubscriptionsStatus.success));
+      await AnonymousSubscriptions.deleteCommunities(event.urls);
+
+      emit(
+        state.copyWith(
+          status: AnonymousSubscriptionsStatus.success,
+          subscriptions: [...state.subscriptions]..removeWhere((e) => event.urls.contains(e.url)),
+          urls: {...state.urls}..removeAll(event.urls),
+        ),
+      );
     } catch (e) {
-      emit(state.copyWith(status: AnonymousSubscriptionsStatus.failure, errorMessage: e.toString()));
+      emit(state.copyWith(status: AnonymousSubscriptionsStatus.failure, message: e.toString()));
     }
   }
 
   FutureOr<void> _addSubscriptions(AddSubscriptionsEvent event, Emitter<AnonymousSubscriptionsState> emit) async {
     try {
-      await insertSubscriptions(event.communities);
+      // Filter out already subscribed communities
+      final communities = event.communities.where((community) => !state.urls.contains(community.url)).toList();
+      if (communities.isEmpty) return;
+
+      await insertSubscriptions(communities.toSet());
+
       emit(
         state.copyWith(
           status: AnonymousSubscriptionsStatus.success,
-          subscriptions: [...state.subscriptions, ...event.communities],
-          ids: {...state.ids}..addAll(event.communities.map((e) => e.id)),
+          subscriptions: [...state.subscriptions, ...communities],
+          urls: {...state.urls}..addAll(communities.map((e) => e.url)),
         ),
       );
     } catch (e) {
-      emit(state.copyWith(status: AnonymousSubscriptionsStatus.failure, errorMessage: e.toString()));
+      emit(state.copyWith(status: AnonymousSubscriptionsStatus.failure, message: e.toString()));
     }
   }
 
   Future<void> _getSubscribedCommunities(GetSubscribedCommunitiesEvent event, Emitter<AnonymousSubscriptionsState> emit) async {
-    emit(const AnonymousSubscriptionsState(status: AnonymousSubscriptionsStatus.loading));
+    emit(state.copyWith(status: AnonymousSubscriptionsStatus.loading));
+
     try {
       List<ThunderCommunity> subscribedCommunities = await getSubscriptions();
-      emit(state.copyWith(
-        status: AnonymousSubscriptionsStatus.success,
-        subscriptions: subscribedCommunities,
-        ids: subscribedCommunities.map((e) => e.id).toSet(),
-      ));
+
+      // Filter out duplicate communities based on URL
+      Map<String, ThunderCommunity> communities = {};
+
+      for (final community in subscribedCommunities) {
+        communities[community.url] = community;
+      }
+
+      emit(
+        state.copyWith(
+          status: AnonymousSubscriptionsStatus.success,
+          subscriptions: communities.values.toList(),
+          urls: communities.keys.toSet(),
+        ),
+      );
     } catch (e) {
-      emit(state.copyWith(status: AnonymousSubscriptionsStatus.failure, errorMessage: e.toString()));
+      emit(state.copyWith(status: AnonymousSubscriptionsStatus.failure, message: e.toString()));
     }
   }
 }

--- a/lib/community/bloc/anonymous_subscriptions_event.dart
+++ b/lib/community/bloc/anonymous_subscriptions_event.dart
@@ -7,16 +7,21 @@ abstract class AnonymousSubscriptionsEvent extends Equatable {
   List<Object> get props => [];
 }
 
+/// Gets the subscribed communities from the local subscriptions
 class GetSubscribedCommunitiesEvent extends AnonymousSubscriptionsEvent {}
 
+/// Adds a given set of communities to the local subscriptions
 class AddSubscriptionsEvent extends AnonymousSubscriptionsEvent {
+  /// The communities to add
   final Set<ThunderCommunity> communities;
 
   const AddSubscriptionsEvent({required this.communities});
 }
 
+/// Deletes a given set of subscriptions by their actor ids
 class DeleteSubscriptionsEvent extends AnonymousSubscriptionsEvent {
-  final Set<int> ids;
+  /// The actor ids of the communities to delete
+  final Set<String> urls;
 
-  const DeleteSubscriptionsEvent({required this.ids});
+  const DeleteSubscriptionsEvent({required this.urls});
 }

--- a/lib/community/bloc/anonymous_subscriptions_state.dart
+++ b/lib/community/bloc/anonymous_subscriptions_state.dart
@@ -6,29 +6,36 @@ class AnonymousSubscriptionsState extends Equatable {
   const AnonymousSubscriptionsState({
     this.status = AnonymousSubscriptionsStatus.initial,
     this.subscriptions = const [],
-    this.ids = const {},
-    this.errorMessage,
+    this.urls = const {},
+    this.message,
   });
 
+  /// Status of the bloc
   final AnonymousSubscriptionsStatus status;
-  final String? errorMessage;
+
+  /// Error message
+  final String? message;
+
+  /// List of subscribed communities
   final List<ThunderCommunity> subscriptions;
-  final Set<int> ids;
+
+  /// Set of community actor ids (e.g., https://lemmy.ml/c/lemmy)
+  final Set<String> urls;
 
   AnonymousSubscriptionsState copyWith({
     AnonymousSubscriptionsStatus? status,
     List<ThunderCommunity>? subscriptions,
-    Set<int>? ids,
-    String? errorMessage,
+    Set<String>? urls,
+    String? message,
   }) {
     return AnonymousSubscriptionsState(
       status: status ?? this.status,
-      ids: ids ?? this.ids,
+      urls: urls ?? this.urls,
       subscriptions: subscriptions ?? this.subscriptions,
-      errorMessage: errorMessage ?? this.errorMessage,
+      message: message ?? this.message,
     );
   }
 
   @override
-  List<Object?> get props => [status, subscriptions, ids, errorMessage];
+  List<Object?> get props => [status, subscriptions, urls, message];
 }

--- a/lib/community/helpers/anonymous_subscriptions_helper.dart
+++ b/lib/community/helpers/anonymous_subscriptions_helper.dart
@@ -31,6 +31,7 @@ extension on LocalCommunity {
         postingRestrictedToMods: false,
         instanceId: -1,
       ),
+      subscribed: SubscribedType.subscribed, // Will always be subscribed
     );
   }
 }

--- a/lib/community/models/anonymous_subscriptions.dart
+++ b/lib/community/models/anonymous_subscriptions.dart
@@ -41,9 +41,9 @@ class AnonymousSubscriptions {
     }
   }
 
-  static Future<void> deleteCommunities(Set<int> ids) async {
+  static Future<void> deleteCommunities(Set<String> urls) async {
     try {
-      await (database.delete(database.localSubscriptions)..where((t) => t.id.isIn(ids))).go();
+      await (database.delete(database.localSubscriptions)..where((t) => t.actorId.isIn(urls))).go();
     } catch (e) {
       debugPrint(e.toString());
     }
@@ -52,7 +52,7 @@ class AnonymousSubscriptions {
   static Future<List<LocalCommunity>> getSubscribedCommunities() async {
     try {
       return (await database.localSubscriptions.all().get())
-          .map((favorite) => LocalCommunity(id: favorite.id, name: favorite.name, title: favorite.title, actorId: favorite.actorId, icon: favorite.icon))
+          .map((community) => LocalCommunity(id: community.id, name: community.name, title: community.title, actorId: community.actorId, icon: community.icon))
           .toList();
     } catch (e) {
       debugPrint(e.toString());

--- a/lib/community/widgets/community_drawer.dart
+++ b/lib/community/widgets/community_drawer.dart
@@ -95,13 +95,14 @@ class _CommunityDrawerState extends State<CommunityDrawer> {
                               minimumSize: const Size.fromHeight(50),
                               backgroundColor: isCommunitySelected ? theme.colorScheme.primaryContainer.withValues(alpha: 0.25) : Colors.transparent,
                             ),
-                            onPressed: () {
+                            onPressed: () async {
                               Navigator.of(context).pop();
                               context.read<FeedBloc>().add(
                                     FeedFetchedEvent(
                                       feedType: FeedType.community,
                                       sortType: profileState.getSiteResponse?.myUser?.localUserView.localUser.defaultSortType ?? thunderState.sortTypeForInstance,
-                                      communityId: community.id,
+                                      communityId: isLoggedIn ? community.id : null,
+                                      communityName: !isLoggedIn ? await getLemmyCommunity(community.url) : null,
                                       reset: true,
                                       showHidden: thunderState.showHiddenPosts,
                                     ),

--- a/lib/community/widgets/community_header/community_header_actions.dart
+++ b/lib/community/widgets/community_header/community_header_actions.dart
@@ -253,8 +253,8 @@ class _AnonymousSubscriptionChip extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final l10n = GlobalContext.l10n;
-    final subscriptions = context.watch<AnonymousSubscriptionsBloc>().state.ids;
-    final isSubscribed = subscriptions.contains(community.id);
+    final subscriptions = context.watch<AnonymousSubscriptionsBloc>().state.urls;
+    final isSubscribed = subscriptions.contains(community.url);
 
     return ThunderActionChip(
       icon: isSubscribed ? Icons.remove_circle_outline_rounded : Icons.add_circle_outline_rounded,
@@ -263,7 +263,7 @@ class _AnonymousSubscriptionChip extends StatelessWidget {
         HapticFeedback.mediumImpact();
 
         if (isSubscribed) {
-          context.read<AnonymousSubscriptionsBloc>().add(DeleteSubscriptionsEvent(ids: {community.id}));
+          context.read<AnonymousSubscriptionsBloc>().add(DeleteSubscriptionsEvent(urls: {community.url}));
           showSnackbar(l10n.unsubscribed);
         } else {
           context.read<AnonymousSubscriptionsBloc>().add(AddSubscriptionsEvent(communities: {community}));

--- a/lib/community/widgets/community_list_entry.dart
+++ b/lib/community/widgets/community_list_entry.dart
@@ -1,9 +1,12 @@
 import 'package:flutter/material.dart';
 
+import 'package:collection/collection.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:lemmy_api_client/v3.dart';
-import 'package:thunder/localizations/app_localizations.dart';
 
+import 'package:thunder/community/bloc/anonymous_subscriptions_bloc.dart';
+import 'package:thunder/community/bloc/community_bloc.dart';
+import 'package:thunder/community/enums/community_action.dart';
 import 'package:thunder/account/account.dart';
 import 'package:thunder/core/enums/full_name.dart';
 import 'package:thunder/core/models/models.dart';
@@ -12,31 +15,18 @@ import 'package:thunder/feed/view/feed_page.dart';
 import 'package:thunder/shared/avatars/community_avatar.dart';
 import 'package:thunder/shared/full_name_widgets.dart';
 import 'package:thunder/shared/snackbar.dart';
+import 'package:thunder/utils/global_context.dart';
 import 'package:thunder/utils/instance.dart';
 import 'package:thunder/utils/navigation.dart';
 import 'package:thunder/utils/numbers.dart';
 
-class CommunityListEntry extends StatelessWidget {
+/// A widget that displays a given community's information. This widget is generally used in a list.
+class CommunityListEntry extends StatefulWidget {
   /// The community to display.
   final ThunderCommunity community;
 
-  /// Whether the user is logged in.
-  final bool isUserLoggedIn;
-
-  /// The current user subscriptions.
-  final Set<int>? currentSubscriptions;
-
   /// Whether to indicate that the community is a favorite.
   final bool indicateFavorites;
-
-  /// Callback function that occurs when the favorite status is requested.
-  final bool Function(BuildContext context, ThunderCommunity community)? getFavoriteStatus;
-
-  /// Callback function that occurs when the subscription status is requested.
-  final SubscribedType Function(bool isUserLoggedIn, ThunderCommunity community, Set<int>? currentSubscriptions)? getCurrentSubscriptionStatus;
-
-  /// Callback function that occurs when the subscribe icon is pressed.
-  final void Function(bool isUserLoggedIn, BuildContext context, ThunderCommunity community)? onSubscribeIconPressed;
 
   /// Whether the community should be resolved to a different instance
   final String? resolutionInstance;
@@ -44,105 +34,133 @@ class CommunityListEntry extends StatelessWidget {
   const CommunityListEntry({
     super.key,
     required this.community,
-    required this.isUserLoggedIn,
-    this.currentSubscriptions,
     this.indicateFavorites = true,
     this.resolutionInstance,
-    this.getFavoriteStatus,
-    this.getCurrentSubscriptionStatus,
-    this.onSubscribeIconPressed,
   });
 
   @override
-  Widget build(BuildContext context) {
-    final l10n = AppLocalizations.of(context)!;
-    assert(community.subscribers != null);
+  State<CommunityListEntry> createState() => _CommunityListEntryState();
+}
 
-    String subscriptionButtonLabel = switch (getCurrentSubscriptionStatus?.call(isUserLoggedIn, community, currentSubscriptions)) {
+class _CommunityListEntryState extends State<CommunityListEntry> {
+  void onSubscribe(bool subscribed, bool isUserLoggedIn) {
+    if (isUserLoggedIn) {
+      context.read<CommunityBloc>().add(CommunityActionEvent(communityAction: CommunityAction.follow, communityId: widget.community.id, value: !subscribed));
+    } else {
+      if (!subscribed) {
+        context.read<AnonymousSubscriptionsBloc>().add(AddSubscriptionsEvent(communities: {widget.community}));
+        context.read<AnonymousSubscriptionsBloc>().add(GetSubscribedCommunitiesEvent());
+      } else {
+        context.read<AnonymousSubscriptionsBloc>().add(DeleteSubscriptionsEvent(urls: {widget.community.url}));
+      }
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final l10n = GlobalContext.l10n;
+    final isUserLoggedIn = context.select<ProfileBloc, bool>((bloc) => bloc.state.isLoggedIn);
+
+    ThunderCommunity community;
+
+    // Fetch the community from the user's subscriptions or anonymous subscriptions if possible
+    if (isUserLoggedIn) {
+      final subscriptions = context.select<ProfileBloc, List<ThunderCommunity>>((bloc) => bloc.state.subscriptions);
+      community = subscriptions.firstWhereOrNull((c) => c.url == widget.community.url) ?? widget.community;
+    } else {
+      final subscriptions = context.select<AnonymousSubscriptionsBloc, List<ThunderCommunity>>((bloc) => bloc.state.subscriptions);
+      community = subscriptions.firstWhereOrNull((c) => c.url == widget.community.url) ?? widget.community;
+    }
+
+    final favourited = context.select<ProfileBloc, bool>((bloc) => bloc.state.favorites.any((c) => c.url == community.url));
+
+    String subscriptionButtonLabel = switch (community.subscribed) {
       SubscribedType.notSubscribed => l10n.subscribe,
       SubscribedType.pending => l10n.unsubscribePending,
       SubscribedType.subscribed => l10n.unsubscribe,
       _ => '',
     };
 
-    return Tooltip(
-      excludeFromSemantics: true,
-      message: '${community.title}\n${generateCommunityFullName(
-        context,
-        community.name,
-        community.title,
-        fetchInstanceNameFromUrl(community.url),
-      )}',
-      preferBelow: false,
-      child: ListTile(
-        leading: CommunityAvatar(community: community, radius: 25),
-        title: Text(community.title, overflow: TextOverflow.ellipsis),
-        subtitle: Row(
-          children: [
-            Flexible(
-              child: CommunityFullNameWidget(
-                context,
-                community.name,
-                community.title,
-                fetchInstanceNameFromUrl(community.url),
-                // Override because we're showing display name above
-                useDisplayName: false,
-              ),
-            ),
-            Text(
-              ' · ${formatLongNumber(community.subscribers!)}',
-              semanticsLabel: l10n.countSubscribers(community.subscribers!),
-            ),
-            const SizedBox(width: 4),
-            const Icon(Icons.people_rounded, size: 16.0),
-            if (indicateFavorites &&
-                getFavoriteStatus?.call(context, community) == true &&
-                getCurrentSubscriptionStatus?.call(isUserLoggedIn, community, currentSubscriptions) == SubscribedType.subscribed) ...const [
-              Text(' · '),
-              Icon(Icons.star_rounded, size: 15),
-            ]
-          ],
-        ),
-        trailing: getCurrentSubscriptionStatus == null
-            ? null
-            : IconButton(
-                onPressed: () {
-                  SubscribedType? subscriptionStatus = getCurrentSubscriptionStatus!(isUserLoggedIn, community, currentSubscriptions);
-                  onSubscribeIconPressed?.call(isUserLoggedIn, context, community);
-                  showSnackbar(subscriptionStatus == SubscribedType.notSubscribed ? l10n.addedCommunityToSubscriptions : l10n.removedCommunityFromSubscriptions);
-                  context.read<ProfileBloc>().add(const FetchProfileSubscriptions());
-                },
-                icon: Semantics(
-                  label: subscriptionButtonLabel,
-                  child: Icon(
-                    switch (getCurrentSubscriptionStatus!(isUserLoggedIn, community, currentSubscriptions)) {
-                      SubscribedType.notSubscribed => Icons.add_circle_outline_rounded,
-                      SubscribedType.pending => Icons.pending_outlined,
-                      SubscribedType.subscribed => Icons.remove_circle_outline_rounded,
-                    },
-                  ),
+    return BlocListener<CommunityBloc, CommunityState>(
+      listener: (context, state) {
+        if (state.status == CommunityStatus.success) context.read<ProfileBloc>().add(const FetchProfileSubscriptions());
+      },
+      child: Tooltip(
+        excludeFromSemantics: true,
+        message: '${widget.community.title}\n${generateCommunityFullName(
+          context,
+          widget.community.name,
+          widget.community.title,
+          fetchInstanceNameFromUrl(widget.community.url),
+        )}',
+        preferBelow: false,
+        child: ListTile(
+          leading: CommunityAvatar(community: widget.community, radius: 25),
+          title: Text(widget.community.title, overflow: TextOverflow.ellipsis),
+          subtitle: Row(
+            children: [
+              Flexible(
+                child: CommunityFullNameWidget(
+                  context,
+                  widget.community.name,
+                  widget.community.title,
+                  fetchInstanceNameFromUrl(widget.community.url),
+                  // Override because we're showing display name above
+                  useDisplayName: false,
                 ),
-                tooltip: subscriptionButtonLabel,
-                visualDensity: VisualDensity.compact,
               ),
-        onTap: () async {
-          int? communityId = community.id;
+              Text(
+                ' · ${formatLongNumber(widget.community.subscribers!)}',
+                semanticsLabel: l10n.countSubscribers(widget.community.subscribers!),
+              ),
+              const SizedBox(width: 4),
+              const Icon(Icons.people_rounded, size: 16.0),
+              if (widget.indicateFavorites && favourited && community.subscribed == SubscribedType.subscribed) ...const [
+                Text(' · '),
+                Icon(Icons.star_rounded, size: 15),
+              ]
+            ],
+          ),
+          trailing: widget.resolutionInstance == null
+              ? IconButton(
+                  onPressed: () {
+                    onSubscribe(community.subscribed != SubscribedType.notSubscribed, isUserLoggedIn);
+                    showSnackbar(community.subscribed == SubscribedType.notSubscribed ? l10n.addedCommunityToSubscriptions : l10n.removedCommunityFromSubscriptions);
+                  },
+                  icon: Semantics(
+                    label: subscriptionButtonLabel,
+                    child: Icon(
+                      switch (community.subscribed) {
+                        SubscribedType.notSubscribed => Icons.add_circle_outline_rounded,
+                        SubscribedType.pending => Icons.pending_outlined,
+                        SubscribedType.subscribed => Icons.remove_circle_outline_rounded,
+                        _ => Icons.add_circle_outline_rounded,
+                      },
+                    ),
+                  ),
+                  tooltip: subscriptionButtonLabel,
+                  visualDensity: VisualDensity.compact,
+                )
+              : null,
+          onTap: () async {
+            int? communityId = widget.community.id;
 
-          if (resolutionInstance != null) {
-            try {
-              final lemmy = (LemmyClient()..changeBaseUrl(resolutionInstance!)).lemmyApiV3;
-              final response = await lemmy.run(ResolveObject(q: community.url));
+            if (widget.resolutionInstance != null) {
+              try {
+                final lemmy = (LemmyClient()..changeBaseUrl(widget.resolutionInstance!)).lemmyApiV3;
+                final response = await lemmy.run(ResolveObject(q: widget.community.url));
 
-              communityId = response.community?.community.id;
-            } catch (e) {
-              // If we can't find it, then we'll get a standard error message about communityId being un-navigable
+                communityId = response.community?.community.id;
+              } catch (e) {
+                // If we can't find it, then we'll get a standard error message about communityId being un-navigable
+              }
             }
-          }
 
-          if (context.mounted) {
-            navigateToFeedPage(context, feedType: FeedType.community, communityId: communityId);
-          }
-        },
+            if (context.mounted) {
+              navigateToFeedPage(context, feedType: FeedType.community, communityId: communityId);
+            }
+          },
+        ),
       ),
     );
   }

--- a/lib/instance/pages/instance_page.dart
+++ b/lib/instance/pages/instance_page.dart
@@ -312,13 +312,7 @@ class _InstancePageState extends State<InstancePage> {
                                 final community = state.communities?[index];
 
                                 return Material(
-                                  child: community != null
-                                      ? CommunityListEntry(
-                                          community: community,
-                                          isUserLoggedIn: false,
-                                          resolutionInstance: state.resolutionInstance,
-                                        )
-                                      : Container(),
+                                  child: community != null ? CommunityListEntry(community: community, resolutionInstance: state.resolutionInstance) : Container(),
                                 );
                               },
                             ),

--- a/lib/search/pages/search_page.dart
+++ b/lib/search/pages/search_page.dart
@@ -2,7 +2,6 @@ import 'dart:async';
 import 'dart:io';
 
 import 'package:back_button_interceptor/back_button_interceptor.dart';
-import 'package:collection/collection.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
@@ -65,8 +64,6 @@ class _SearchPageState extends State<SearchPage> with AutomaticKeepAliveClientMi
   SortType sortType = SortType.active;
   IconData? sortTypeIcon;
   String? sortTypeLabel;
-  final Set<ThunderCommunity> newAnonymousSubscriptions = {};
-  final Set<int> removedSubs = {};
   int _previousFocusSearchId = 0;
   final searchTextFieldFocus = FocusNode();
   int? _previousUserId;
@@ -114,12 +111,6 @@ class _SearchPageState extends State<SearchPage> with AutomaticKeepAliveClientMi
     _scrollController.dispose();
 
     super.dispose();
-  }
-
-  @override
-  void deactivate() {
-    _saveToDB();
-    super.deactivate();
   }
 
   FutureOr<bool> _handleBackButtonPress(bool stopDefaultButtonEvent, RouteInfo info) async {
@@ -526,17 +517,7 @@ class _SearchPageState extends State<SearchPage> with AutomaticKeepAliveClientMi
                           itemCount: context.read<ProfileBloc>().state.favorites.length,
                           itemBuilder: (BuildContext context, int index) {
                             final community = context.read<ProfileBloc>().state.favorites[index];
-                            final subscriptions = context.read<AnonymousSubscriptionsBloc>().state.ids;
-
-                            return CommunityListEntry(
-                              community: community,
-                              isUserLoggedIn: isUserLoggedIn,
-                              currentSubscriptions: subscriptions,
-                              indicateFavorites: false,
-                              getFavoriteStatus: _getFavoriteStatus,
-                              getCurrentSubscriptionStatus: _getCurrentSubscriptionStatus,
-                              onSubscribeIconPressed: _onSubscribeIconPressed,
-                            );
+                            return CommunityListEntry(community: community, indicateFavorites: false);
                           },
                         ),
                         const SizedBox(height: 20),
@@ -554,16 +535,7 @@ class _SearchPageState extends State<SearchPage> with AutomaticKeepAliveClientMi
                         itemCount: state.trendingCommunities!.length,
                         itemBuilder: (BuildContext context, int index) {
                           final community = state.trendingCommunities![index];
-                          final subscriptions = context.read<AnonymousSubscriptionsBloc>().state.ids;
-
-                          return CommunityListEntry(
-                            community: community,
-                            isUserLoggedIn: isUserLoggedIn,
-                            currentSubscriptions: subscriptions,
-                            getFavoriteStatus: _getFavoriteStatus,
-                            getCurrentSubscriptionStatus: _getCurrentSubscriptionStatus,
-                            onSubscribeIconPressed: _onSubscribeIconPressed,
-                          );
+                          return CommunityListEntry(community: community);
                         },
                       ),
                       const SizedBox(height: 5),
@@ -668,16 +640,7 @@ class _SearchPageState extends State<SearchPage> with AutomaticKeepAliveClientMi
                       : Container();
                 } else {
                   final community = state.communities![index];
-                  final subscriptions = context.read<AnonymousSubscriptionsBloc>().state.ids;
-
-                  return CommunityListEntry(
-                    community: community,
-                    isUserLoggedIn: isUserLoggedIn,
-                    currentSubscriptions: subscriptions,
-                    getFavoriteStatus: _getFavoriteStatus,
-                    getCurrentSubscriptionStatus: _getCurrentSubscriptionStatus,
-                    onSubscribeIconPressed: _onSubscribeIconPressed,
-                  );
+                  return CommunityListEntry(community: community);
                 }
               },
             ),
@@ -804,11 +767,6 @@ class _SearchPageState extends State<SearchPage> with AutomaticKeepAliveClientMi
     }
   }
 
-  bool _getFavoriteStatus(BuildContext context, ThunderCommunity community) {
-    final state = context.read<ProfileBloc>().state;
-    return state.favorites.any((c) => c.id == community.id);
-  }
-
   void showSortBottomSheet(BuildContext context) {
     final AppLocalizations l10n = AppLocalizations.of(context)!;
 
@@ -833,51 +791,6 @@ class _SearchPageState extends State<SearchPage> with AutomaticKeepAliveClientMi
         minimumVersion: LemmyClient.instance.version,
       ),
     );
-  }
-
-  SubscribedType _getCurrentSubscriptionStatus(bool isUserLoggedIn, ThunderCommunity community, Set<int>? currentSubscriptions) {
-    assert(community.subscribed != null);
-    if (isUserLoggedIn) return community.subscribed!;
-
-    bool isSubscribed =
-        newAnonymousSubscriptions.firstWhereOrNull((c) => c.id == community.id) != null || (currentSubscriptions?.contains(community.id) == true && !removedSubs.contains(community.id));
-
-    return isSubscribed ? SubscribedType.subscribed : SubscribedType.notSubscribed;
-  }
-
-  void _onSubscribeIconPressed(bool isUserLoggedIn, BuildContext context, ThunderCommunity community) {
-    if (isUserLoggedIn) {
-      context.read<SearchBloc>().add(ChangeCommunitySubsciptionStatusEvent(
-            communityId: community.id,
-            follow: community.subscribed == SubscribedType.notSubscribed ? true : false,
-            query: _controller.text,
-          ));
-      return;
-    }
-
-    Set<int> currentSubscriptions = context.read<AnonymousSubscriptionsBloc>().state.ids;
-
-    setState(() {
-      if (currentSubscriptions.contains(community.id) && !removedSubs.contains(community.id)) {
-        removedSubs.add(community.id);
-      } else if (newAnonymousSubscriptions.map((c) => c.id).contains(community.id)) {
-        newAnonymousSubscriptions.removeWhere((c) => c.id == community.id);
-      } else if (removedSubs.contains(community.id)) {
-        removedSubs.remove(community.id);
-      } else {
-        newAnonymousSubscriptions.add(community);
-      }
-    });
-    return;
-  }
-
-  void _saveToDB() {
-    if (newAnonymousSubscriptions.isNotEmpty) {
-      context.read<AnonymousSubscriptionsBloc>().add(AddSubscriptionsEvent(communities: newAnonymousSubscriptions));
-    }
-    if (removedSubs.isNotEmpty) {
-      context.read<AnonymousSubscriptionsBloc>().add(DeleteSubscriptionsEvent(ids: removedSubs));
-    }
   }
 
   MetaSearchType _getSearchTypeToUse() {


### PR DESCRIPTION
## Pull Request Description

This PR fixes a few issues with anonymous subscriptions:
- Navigating to the community via the drawer would either not navigate to the proper community or throw an error
- Some communities would show duplicate entries in the drawer
- General issues when attempting to subscribe to communities via the Search page

I've refactored the anonymous subscription logic to use the actor URL rather than the community's id. As a result of this, I've also refactored `CommunityListEntry` and moved the subscription related logic into the widget rather than in the parent search widget.

<!--- Please describe what was changed -->

## Issue Being Fixed

<!-- Please describe the problem that is being fixed and, if applicable, reference a GitHub issue -->

Issue Number: https://lemmy.world/post/31803600

## Screenshots / Recordings

<!-- This section is optional but highly recommended to show off your changes! -->

## Checklist

- [ ] If a new package was added, did you ensure it uses an appropriate license and is actively maintained?
- [ ] Did you use localized strings (and added appropriate descriptions) where applicable?
- [ ] Did you add `semanticLabel`s where applicable for accessibility?
