### PR TITLE
Fix inconsistent comment refresh logic when navigating from inbox

### DIFF
--- a/lib/post/pages/post_page.dart
+++ b/lib/post/pages/post_page.dart
@@ -327,7 +327,12 @@ class _PostPageState extends State<PostPage> {
           return RefreshIndicator(
             onRefresh: () async {
               HapticFeedback.mediumImpact();
-              context.read<PostBloc>().add(GetPostEvent(post: widget.initialPost, selectedCommentPath: widget.commentPath, highlightedCommentId: widget.highlightedCommentId));
+              if (this.highlightedCommentId != null) {
+                // If we're viewing a specific comment thread, refresh with that context unless "View All Comments" is pressed
+                context.read<PostBloc>().add(GetPostEvent(post: widget.initialPost, selectedCommentPath: widget.commentPath, highlightedCommentId: widget.highlightedCommentId));
+              } else {
+                context.read<PostBloc>().add(GetPostEvent(post: widget.initialPost));
+              }
             },
             edgeOffset: MediaQuery.of(context).padding.top + APP_BAR_HEIGHT, // This offset is placed to allow the correct positioning of the refresh indicator
             child: Scaffold(
@@ -423,13 +428,22 @@ class _PostPageState extends State<PostPage> {
                                       centered: combineNavAndFab,
                                       onPressed: () {
                                         HapticFeedback.mediumImpact();
-                                        PostFabAction.refresh.execute(
-                                          context: context,
-                                          post: state.post,
-                                          postId: state.post?.id,
-                                          highlightedCommentId: state.highlightedCommentId,
-                                          selectedCommentPath: state.selectedCommentPath,
-                                        );
+                                        if (this.highlightedCommentId != null) {
+                                          // If we're viewing a specific comment thread, refresh with that context unless "View All Comments" is pressed
+                                          PostFabAction.refresh.execute(
+                                            context: context,
+                                            post: state.post,
+                                            postId: state.post?.id,
+                                            highlightedCommentId: widget.highlightedCommentId,
+                                            selectedCommentPath: widget.commentPath,
+                                          );
+                                        } else {
+                                          PostFabAction.refresh.execute(
+                                            context: context,
+                                            post: state.post,
+                                            postId: state.post?.id,
+                                          );
+                                        }
                                       },
                                       title: PostFabAction.refresh.getTitle(context),
                                       icon: Icon(
@@ -522,6 +536,8 @@ class _PostPageState extends State<PostPage> {
                           },
                           onUserChanged: () => userChanged = true,
                           onPostChanged: (post) => context.read<PostBloc>().add(GetPostEvent(post: post)),
+                          highlightedCommentId: this.highlightedCommentId,
+                          commentPath: widget.commentPath,
                         ),
                         if (state.status == PostStatus.initial || state.status == PostStatus.loading)
                           const SliverFillRemaining(
@@ -540,13 +556,18 @@ class _PostPageState extends State<PostPage> {
                                     (
                                       text: l10n.retry,
                                       action: () {
-                                        context.read<PostBloc>().add(
-                                              GetPostEvent(
-                                                post: widget.initialPost,
-                                                selectedCommentPath: widget.commentPath,
-                                                highlightedCommentId: widget.highlightedCommentId,
-                                              ),
-                                            );
+                                        if (this.highlightedCommentId != null) {
+                                          // If we're viewing a specific comment thread, retry with that context unless "View All Comments" is pressed
+                                          context.read<PostBloc>().add(
+                                                GetPostEvent(
+                                                  post: widget.initialPost,
+                                                  selectedCommentPath: widget.commentPath,
+                                                  highlightedCommentId: widget.highlightedCommentId,
+                                                ),
+                                              );
+                                        } else {
+                                          context.read<PostBloc>().add(GetPostEvent(post: widget.initialPost));
+                                        }
                                       },
                                       loading: false,
                                     ),

--- a/lib/post/widgets/post_page_app_bar.dart
+++ b/lib/post/widgets/post_page_app_bar.dart
@@ -41,6 +41,12 @@ class PostPageAppBar extends StatelessWidget {
   /// Callback for when the post changes
   final void Function(ThunderPost post)? onPostChanged;
 
+  /// The ID of the comment that should be highlighted
+  final int? highlightedCommentId;
+
+  /// The path of the comment that should be highlighted
+  final String? commentPath;
+
   const PostPageAppBar({
     super.key,
     this.viewSource = false,
@@ -50,6 +56,8 @@ class PostPageAppBar extends StatelessWidget {
     this.onSelectText,
     this.onUserChanged,
     this.onPostChanged,
+    this.highlightedCommentId,
+    this.commentPath,
   });
 
   @override
@@ -72,6 +80,8 @@ class PostPageAppBar extends StatelessWidget {
           onSelectText: onSelectText,
           onUserChanged: onUserChanged,
           onPostChanged: onPostChanged,
+          highlightedCommentId: highlightedCommentId,
+          commentPath: commentPath,
         )
       ],
     );
@@ -152,6 +162,12 @@ class PostAppBarActions extends StatelessWidget {
   /// Callback for when the post changes
   final void Function(ThunderPost post)? onPostChanged;
 
+  /// The ID of the comment that should be highlighted
+  final int? highlightedCommentId;
+
+  /// The path of the comment that should be highlighted
+  final String? commentPath;
+
   const PostAppBarActions({
     super.key,
     this.viewSource = false,
@@ -161,6 +177,8 @@ class PostAppBarActions extends StatelessWidget {
     this.onSelectText,
     this.onUserChanged,
     this.onPostChanged,
+    this.highlightedCommentId,
+    this.commentPath,
   });
 
   @override
@@ -175,7 +193,14 @@ class PostAppBarActions extends StatelessWidget {
           onPressed: () async {
             HapticFeedback.mediumImpact();
             await onReset?.call();
-            if (context.mounted) context.read<PostBloc>().add(GetPostEvent(post: state.post));
+            if (context.mounted) {
+              if (highlightedCommentId != null) {
+                // If we're viewing a specific comment thread, refresh with that context unless "View All Comments" is pressed
+                context.read<PostBloc>().add(GetPostEvent(post: state.post, selectedCommentPath: commentPath, highlightedCommentId: highlightedCommentId));
+              } else {
+                context.read<PostBloc>().add(GetPostEvent(post: state.post));
+              }
+            }
           },
         ),
         IconButton(


### PR DESCRIPTION
## Pull Request Description

This PR fixes an issue where the refresh logic on the post page was inconsistent when navigating from the inbox. With this fix:
- All refresh actions should now account for whether the post is being viewed in a comment context (e.g., when "View all comments" is displayed).
- If "View all comments" is available, then any refresh will re-fetch the post with the specific comment.
- Once "View all comments" is tapped, then any refresh will fetch the post with all the comments as usual.

<!--- Please describe what was changed -->

## Issue Being Fixed

<!-- Please describe the problem that is being fixed and, if applicable, reference a GitHub issue -->

Issue Number: #1893

## Screenshots / Recordings

https://github.com/user-attachments/assets/8b58c0da-c12c-4173-8c60-d5cd46a129db

<!-- This section is optional but highly recommended to show off your changes! -->

## Checklist

- [ ] If a new package was added, did you ensure it uses an appropriate license and is actively maintained?
- [ ] Did you use localized strings (and added appropriate descriptions) where applicable?
- [ ] Did you add `semanticLabel`s where applicable for accessibility?
