### PR TITLE
Fix comment metadata disappearing for comments with no children

### DIFF
--- a/lib/comment/widgets/comment_card/comment_card_header.dart
+++ b/lib/comment/widgets/comment_card/comment_card_header.dart
@@ -91,7 +91,7 @@ class CommentCardHeader extends StatelessWidget {
                 ),
                 Row(
                   spacing: 8.0,
-                  children: hidden
+                  children: hidden && (comment.childCount ?? 0) > 0
                       ? [CommentCardHeaderReplyCount(replies: comment.childCount!, hidden: hidden)]
                       : [
                           if (saved == true) Icon(Icons.star_rounded, color: saveColor.color, size: 19.0),


### PR DESCRIPTION
## Pull Request Description

<!--- Please describe what was changed -->

This PR fixes a small regression from #1890 where metadata from comments with no children would get hidden when tapped, even though there was no child comment count to take its place.

## Issue Being Fixed

<!-- Please describe the problem that is being fixed and, if applicable, reference a GitHub issue -->

Issue Number: N/A

## Screenshots / Recordings

<!-- This section is optional but highly recommended to show off your changes! -->

#### Before

https://github.com/user-attachments/assets/95211983-8687-4fd2-9fe0-2a05057b76cc

#### After

https://github.com/user-attachments/assets/5af15718-6716-443e-a46b-93061b9c3146

## Checklist

- [ ] If a new package was added, did you ensure it uses an appropriate license and is actively maintained?
- [ ] Did you use localized strings (and added appropriate descriptions) where applicable?
- [ ] Did you add `semanticLabel`s where applicable for accessibility?
