### PR TITLE
Migrate post-related actions to post repository

### DIFF
--- a/lib/core/singletons/lemmy_client.dart
+++ b/lib/core/singletons/lemmy_client.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:lemmy_api_client/v3.dart' hide CommentSortType;
 import 'package:version/version.dart';
 
@@ -8,13 +10,24 @@ import 'package:thunder/core/enums/post_sort_type.dart';
 class LemmyClient {
   LemmyApiV3 lemmyApiV3 = const LemmyApiV3('');
 
+  // Stream controller for broadcasting client changes
+  static final StreamController<LemmyApiV3> _clientChangeController = StreamController<LemmyApiV3>.broadcast();
+
+  // Stream that other widgets can listen to for client changes
+  static Stream<LemmyApiV3> get onClientChanged => _clientChangeController.stream;
+
   LemmyClient();
 
   LemmyClient._initialize();
 
   void changeBaseUrl(String baseUrl) {
     lemmyApiV3 = LemmyApiV3(baseUrl, debug: true);
+    _clientChangeController.add(lemmyApiV3); // Broadcast the new client to all listeners
     _populateSiteInfo(); // Do NOT await this. Let it populate in the background.
+  }
+
+  static void dispose() {
+    _clientChangeController.close();
   }
 
   static final LemmyClient _instance = LemmyClient._initialize();

--- a/lib/feed/bloc/feed_bloc.dart
+++ b/lib/feed/bloc/feed_bloc.dart
@@ -14,6 +14,7 @@ import 'package:thunder/feed/utils/community.dart';
 import 'package:thunder/feed/utils/post.dart';
 import 'package:thunder/feed/view/feed_page.dart';
 import 'package:thunder/post/enums/post_action.dart';
+import 'package:thunder/post/repository/post_repository.dart';
 import 'package:thunder/post/utils/post.dart';
 import 'package:thunder/utils/error_messages.dart';
 
@@ -29,9 +30,11 @@ EventTransformer<E> throttleDroppable<E>(Duration duration) {
 }
 
 class FeedBloc extends Bloc<FeedEvent, FeedState> {
-  final LemmyClient lemmyClient;
+  late PostRepository repository;
 
-  FeedBloc({required this.lemmyClient}) : super(const FeedState()) {
+  FeedBloc({PostRepository? repository}) : super(const FeedState()) {
+    this.repository = repository ?? LemmyPostRepository(client: LemmyClient.instance.lemmyApiV3);
+
     /// Handles resetting the feed to its initial state
     on<ResetFeedEvent>(
       _onResetFeed,
@@ -169,7 +172,7 @@ class FeedBloc extends Bloc<FeedEvent, FeedState> {
           emit(state.copyWith(status: FeedStatus.success));
           emit(state.copyWith(status: FeedStatus.fetching));
 
-          updatedPost = await votePost(post, event.value);
+          updatedPost = await repository.vote(post, event.value);
           state.posts[existingPostIndex] = updatedPost;
 
           emit(state.copyWith(status: FeedStatus.success));
@@ -191,7 +194,7 @@ class FeedBloc extends Bloc<FeedEvent, FeedState> {
           emit(state.copyWith(status: FeedStatus.success));
           emit(state.copyWith(status: FeedStatus.fetching));
 
-          updatedPost = await savePost(post, event.value);
+          updatedPost = await repository.save(post, event.value);
           state.posts[existingPostIndex] = updatedPost;
 
           emit(state.copyWith(status: FeedStatus.success));
@@ -218,7 +221,7 @@ class FeedBloc extends Bloc<FeedEvent, FeedState> {
           emit(state.copyWith(status: FeedStatus.success));
           emit(state.copyWith(status: FeedStatus.fetching));
 
-          bool success = await markPostAsRead(post.id, event.value);
+          bool success = await repository.read(post.id, event.value);
           if (success) return emit(state.copyWith(status: FeedStatus.success));
 
           // Restore the original post contents if not successful
@@ -258,7 +261,7 @@ class FeedBloc extends Bloc<FeedEvent, FeedState> {
             emit(state.copyWith(status: FeedStatus.success));
             emit(state.copyWith(status: FeedStatus.fetching));
 
-            List<int> failed = await markPostsAsRead(postIds, event.value);
+            List<int> failed = await repository.readMultiple(postIds, event.value);
             if (failed.isEmpty) return emit(state.copyWith(status: FeedStatus.success));
 
             // Restore the original post contents if not successful
@@ -288,7 +291,7 @@ class FeedBloc extends Bloc<FeedEvent, FeedState> {
           emit(state.copyWith(status: FeedStatus.success));
           emit(state.copyWith(status: FeedStatus.fetching));
 
-          bool success = await markPostAsHidden(post.id, event.value);
+          bool success = await repository.hide(post.id, event.value);
           if (success) return emit(state.copyWith(status: FeedStatus.success));
 
           // Restore the original post contents if not successful
@@ -312,7 +315,7 @@ class FeedBloc extends Bloc<FeedEvent, FeedState> {
           emit(state.copyWith(status: FeedStatus.success));
           emit(state.copyWith(status: FeedStatus.fetching));
 
-          bool success = await deletePost(post.id, event.value);
+          bool success = await repository.delete(post.id, event.value);
           if (success) return emit(state.copyWith(status: FeedStatus.success));
 
           // Restore the original post contents if not successful
@@ -328,7 +331,7 @@ class FeedBloc extends Bloc<FeedEvent, FeedState> {
         final post = state.posts[existingPostIndex];
 
         try {
-          await reportPost(post.id, event.value);
+          await repository.report(post.id, event.value);
           return emit(state.copyWith(status: FeedStatus.success));
         } catch (e) {
           return emit(state.copyWith(status: FeedStatus.failure));
@@ -346,7 +349,7 @@ class FeedBloc extends Bloc<FeedEvent, FeedState> {
           emit(state.copyWith(status: FeedStatus.success));
           emit(state.copyWith(status: FeedStatus.fetching));
 
-          bool success = await lockPost(post.id, event.value);
+          bool success = await repository.lock(post.id, event.value);
           if (success) return emit(state.copyWith(status: FeedStatus.success));
 
           // Restore the original post contents if not successful
@@ -370,7 +373,7 @@ class FeedBloc extends Bloc<FeedEvent, FeedState> {
           emit(state.copyWith(status: FeedStatus.success));
           emit(state.copyWith(status: FeedStatus.fetching));
 
-          bool success = await pinPostToCommunity(post.id, event.value);
+          bool success = await repository.pinCommunity(post.id, event.value);
           if (success) return emit(state.copyWith(status: FeedStatus.success));
 
           // Restore the original post contents if not successful
@@ -394,7 +397,7 @@ class FeedBloc extends Bloc<FeedEvent, FeedState> {
           emit(state.copyWith(status: FeedStatus.success));
           emit(state.copyWith(status: FeedStatus.fetching));
 
-          bool success = await removePost(post.id, event.value['remove'], event.value['reason']);
+          bool success = await repository.remove(post.id, event.value['remove'], event.value['reason']);
           if (success) return emit(state.copyWith(status: FeedStatus.success));
 
           // Restore the original post contents if not successful
@@ -653,7 +656,7 @@ class FeedBloc extends Bloc<FeedEvent, FeedState> {
     emit(state.copyWith(status: FeedStatus.fetching));
 
     try {
-      PostView postView = await createPost(
+      final post = await repository.create(
         communityId: event.communityId,
         name: event.name,
         body: event.body,
@@ -661,12 +664,9 @@ class FeedBloc extends Bloc<FeedEvent, FeedState> {
         nsfw: event.nsfw,
       );
 
-      // Parse the newly created post
-      List<ThunderPost> formattedPost = await parsePosts([postView]);
-
       // Add the post to the state
       List<ThunderPost> updatedPosts = List.from(state.posts);
-      updatedPosts.insert(0, formattedPost[0]);
+      updatedPosts.insert(0, post);
 
       emit(state.copyWith(status: FeedStatus.success, posts: updatedPosts));
     } catch (e) {

--- a/lib/feed/utils/post.dart
+++ b/lib/feed/utils/post.dart
@@ -1,18 +1,16 @@
 import 'package:flutter/foundation.dart';
+
 import 'package:lemmy_api_client/v3.dart';
 
 import 'package:thunder/account/account.dart';
 import 'package:thunder/core/enums/enums.dart';
 import 'package:thunder/core/enums/local_settings.dart';
 import 'package:thunder/core/enums/post_sort_type.dart';
-import 'package:thunder/core/enums/subscription_status.dart';
 import 'package:thunder/core/models/models.dart';
 import 'package:thunder/core/singletons/lemmy_client.dart';
 import 'package:thunder/core/singletons/preferences.dart';
 import 'package:thunder/feed/enums/feed_type_subview.dart';
-import 'package:thunder/localizations/app_localizations.dart';
 import 'package:thunder/post/utils/post.dart';
-import 'package:thunder/utils/global_context.dart';
 
 /// Helper function which handles the logic of fetching items for the feed from the API
 /// This includes posts and user information (posts/comments)
@@ -128,142 +126,4 @@ Future<Map<String, dynamic>> fetchFeedItems({
   }
 
   return {'posts': posts, 'comments': comments, 'hasReachedPostsEnd': hasReachedPostsEnd, 'hasReachedCommentsEnd': hasReachedCommentsEnd, 'currentPage': currentPage};
-}
-
-/// Logic to create a post
-Future<PostView> createPost({
-  required int communityId,
-  required String name,
-  String? body,
-  String? url,
-  String? customThumbnail,
-  String? altText,
-  bool? nsfw,
-  int? postIdBeingEdited,
-  int? languageId,
-}) async {
-  final l10n = AppLocalizations.of(GlobalContext.context)!;
-  final account = await fetchActiveProfile();
-  if (account.anonymous) throw Exception(l10n.userNotLoggedIn);
-
-  LemmyApiV3 lemmy = LemmyClient.instance.lemmyApiV3;
-
-  PostResponse postResponse;
-  if (postIdBeingEdited != null) {
-    postResponse = await lemmy.run(EditPost(
-      auth: account.jwt!,
-      name: name,
-      body: body,
-      url: url?.isEmpty == true ? null : url,
-      customThumbnail: customThumbnail?.isEmpty == true ? null : customThumbnail,
-      altText: altText?.isEmpty == true ? null : altText,
-      nsfw: nsfw,
-      postId: postIdBeingEdited,
-      languageId: languageId,
-    ));
-  } else {
-    postResponse = await lemmy.run(CreatePost(
-      auth: account.jwt!,
-      communityId: communityId,
-      name: name,
-      body: body,
-      url: url?.isEmpty == true ? null : url,
-      customThumbnail: customThumbnail?.isEmpty == true ? null : customThumbnail,
-      altText: altText?.isEmpty == true ? null : altText,
-      nsfw: nsfw,
-      languageId: languageId,
-    ));
-  }
-
-  return postResponse.postView;
-}
-
-/// Creates a placeholder post from the given parameters. This is mainly used to display a preview of the post
-/// with the applied settings on Settings -> Appearance -> Posts page.
-Future<ThunderPost?> createExamplePost({
-  String? postTitle,
-  String? postUrl,
-  String? postBody,
-  String? postThumbnailUrl,
-  String? postAltText,
-  bool? locked,
-  bool? nsfw,
-  bool? pinned,
-  String? personName,
-  String? personDisplayName,
-  String? personInstance,
-  String? communityName,
-  String? instanceUrl,
-  int? commentCount,
-  int? scoreCount,
-  bool? saved,
-  bool? read,
-}) async {
-  PostView postView = PostView(
-    post: Post(
-      id: 1,
-      name: postTitle ?? 'Example Title',
-      url: postUrl,
-      body: postBody,
-      thumbnailUrl: postThumbnailUrl,
-      altText: postAltText,
-      creatorId: 1,
-      communityId: 1,
-      removed: false,
-      locked: locked ?? false,
-      published: DateTime.now(),
-      deleted: false,
-      nsfw: nsfw ?? false,
-      apId: '',
-      local: false,
-      languageId: 0,
-      featuredCommunity: pinned ?? false,
-      featuredLocal: false,
-    ),
-    creator: Person(
-      id: 1,
-      name: personName ?? 'Example Username',
-      displayName: personDisplayName ?? 'Example Name',
-      banned: false,
-      published: DateTime.now(),
-      actorId: 'https://$personInstance/u/$personName',
-      local: false,
-      deleted: false,
-      botAccount: false,
-      instanceId: 1,
-    ),
-    community: Community(
-      id: 1,
-      name: communityName ?? 'Example Community',
-      title: '',
-      removed: false,
-      published: DateTime.now(),
-      deleted: false,
-      nsfw: false,
-      actorId: instanceUrl ?? 'https://thunder.lemmy',
-      local: false,
-      hidden: false,
-      postingRestrictedToMods: false,
-      instanceId: 1,
-    ),
-    creatorBannedFromCommunity: false,
-    counts: PostAggregates(
-      id: 1,
-      postId: 1,
-      comments: commentCount ?? 0,
-      score: scoreCount ?? 0,
-      upvotes: 0,
-      downvotes: 0,
-      published: DateTime.now(),
-    ),
-    subscribed: SubscriptionStatus.notSubscribed.toLemmyType(),
-    saved: saved ?? false,
-    read: read ?? false,
-    creatorBlocked: false,
-    unreadComments: 0,
-  );
-
-  List<ThunderPost> posts = await parsePosts([postView]);
-
-  return Future.value(posts.firstOrNull);
 }

--- a/lib/feed/view/feed_page.dart
+++ b/lib/feed/view/feed_page.dart
@@ -1,8 +1,9 @@
 import 'dart:async';
 
-import 'package:back_button_interceptor/back_button_interceptor.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
+
+import 'package:back_button_interceptor/back_button_interceptor.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 
 import 'package:thunder/account/account.dart';
@@ -12,7 +13,6 @@ import 'package:thunder/core/enums/enums.dart';
 import 'package:thunder/core/enums/local_settings.dart';
 import 'package:thunder/core/enums/post_sort_type.dart';
 import 'package:thunder/core/models/models.dart';
-import 'package:thunder/core/singletons/lemmy_client.dart';
 import 'package:thunder/feed/bloc/feed_bloc.dart';
 import 'package:thunder/feed/enums/feed_type_subview.dart';
 import 'package:thunder/feed/utils/utils.dart';
@@ -138,7 +138,7 @@ class _FeedPageState extends State<FeedPage> with AutomaticKeepAliveClientMixin<
     }
 
     return BlocProvider<FeedBloc>(
-      create: (_) => FeedBloc(lemmyClient: LemmyClient.instance)
+      create: (_) => FeedBloc()
         ..add(FeedFetchedEvent(
           feedType: widget.feedType,
           feedListType: widget.feedListType,

--- a/lib/instance/pages/instance_page.dart
+++ b/lib/instance/pages/instance_page.dart
@@ -1,7 +1,9 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
+
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:lemmy_api_client/v3.dart';
+
 import 'package:thunder/account/account.dart';
 import 'package:thunder/comment/comment.dart';
 import 'package:thunder/community/widgets/community_list_entry.dart';
@@ -14,6 +16,7 @@ import 'package:thunder/instance/bloc/instance_bloc.dart';
 import 'package:thunder/instance/cubit/instance_page_cubit.dart';
 import 'package:thunder/instance/enums/instance_action.dart';
 import 'package:thunder/instance/widgets/instance_view.dart';
+import 'package:thunder/post/repository/post_repository.dart';
 import 'package:thunder/utils/constants.dart';
 import 'package:thunder/utils/navigation.dart';
 import 'package:thunder/shared/chips/thunder_action_chip.dart';
@@ -106,7 +109,9 @@ class _InstancePageState extends State<InstancePage> {
             ),
           ),
           BlocProvider.value(
-            value: FeedBloc(lemmyClient: LemmyClient()..changeBaseUrl(fetchInstanceNameFromUrl(widget.getSiteResponse.siteView.site.actorId)!)),
+            value: FeedBloc(
+              repository: LemmyPostRepository(client: LemmyApiV3(fetchInstanceNameFromUrl(widget.getSiteResponse.siteView.site.actorId)!)),
+            ),
           ),
         ],
         child: BlocConsumer<InstancePageCubit, InstancePageState>(
@@ -193,10 +198,9 @@ class _InstancePageState extends State<InstancePage> {
                                 ThunderPopupMenuItem(
                                   onTap: () async {
                                     HapticFeedback.mediumImpact();
-                                    FeedBloc feedBloc = context.read<FeedBloc>();
                                     navigateToModlogPage(
                                       context,
-                                      lemmyClient: feedBloc.lemmyClient,
+                                      lemmyClient: LemmyClient()..changeBaseUrl(fetchInstanceNameFromUrl(widget.getSiteResponse.siteView.site.actorId)!),
                                       subtitle: fetchInstanceNameFromUrl(widget.getSiteResponse.siteView.site.actorId) ?? '',
                                     );
                                   },

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -127,6 +127,9 @@ class _ThunderAppState extends State<ThunderApp> {
 
   PageController thunderPageController = PageController(initialPage: 0);
 
+  /// The global post repository
+  PostRepository? _postRepository;
+
   @override
   void initState() {
     super.initState();
@@ -158,13 +161,24 @@ class _ThunderAppState extends State<ThunderApp> {
   void dispose() {
     super.dispose();
     notificationsStreamController.close();
+
+    // Clean up repositories that are listening to the LemmyClient stream
+    _postRepository?.dispose();
+
+    // Dispose the LemmyClient stream controller
+    LemmyClient.dispose();
   }
 
   @override
   Widget build(BuildContext context) {
     return MultiRepositoryProvider(
       providers: [
-        RepositoryProvider(create: (context) => LemmyPostRepository(client: LemmyClient.instance.lemmyApiV3)),
+        RepositoryProvider<PostRepository>(
+          create: (context) {
+            _postRepository = LemmyPostRepository(client: LemmyClient.instance.lemmyApiV3);
+            return _postRepository!;
+          },
+        ),
       ],
       child: MultiBlocProvider(
         providers: [

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -37,6 +37,7 @@ import 'package:thunder/core/theme/bloc/theme_bloc.dart';
 import 'package:thunder/instance/bloc/instance_bloc.dart';
 import 'package:thunder/notification/notifications.dart';
 import 'package:thunder/notification/shared/notification_server.dart';
+import 'package:thunder/post/repository/post_repository.dart';
 import 'package:thunder/thunder/cubits/notifications_cubit/notifications_cubit.dart';
 import 'package:thunder/thunder/thunder.dart';
 import 'package:thunder/user/bloc/user_bloc.dart';
@@ -161,127 +162,132 @@ class _ThunderAppState extends State<ThunderApp> {
 
   @override
   Widget build(BuildContext context) {
-    return MultiBlocProvider(
+    return MultiRepositoryProvider(
       providers: [
-        BlocProvider(
-          create: (context) => ThemeBloc(),
-        ),
-        BlocProvider(create: (context) => ProfileBloc()),
-        BlocProvider(
-          create: (context) => DeepLinksCubit(),
-        ),
-        BlocProvider(
-          create: (context) => NotificationsCubit(notificationsStream: notificationsStreamController.stream),
-        ),
-        BlocProvider(
-          create: (context) => ThunderBloc(),
-        ),
-        BlocProvider(
-          create: (context) => AnonymousSubscriptionsBloc(),
-        ),
-        BlocProvider(
-          create: (context) => CommunityBloc(lemmyClient: LemmyClient.instance),
-        ),
-        BlocProvider(
-          create: (context) => InstanceBloc(lemmyClient: LemmyClient.instance),
-        ),
-        BlocProvider(
-          create: (context) => UserBloc(lemmyClient: LemmyClient.instance),
-        ),
-        BlocProvider(
-          create: (context) => NetworkCheckerCubit()..getConnectionType(),
-        )
+        RepositoryProvider(create: (context) => LemmyPostRepository(client: LemmyClient.instance.lemmyApiV3)),
       ],
-      child: BlocBuilder<ThemeBloc, ThemeState>(
-        builder: (context, state) {
-          final ThunderBloc thunderBloc = context.watch<ThunderBloc>();
+      child: MultiBlocProvider(
+        providers: [
+          BlocProvider(
+            create: (context) => ThemeBloc(),
+          ),
+          BlocProvider(create: (context) => ProfileBloc()),
+          BlocProvider(
+            create: (context) => DeepLinksCubit(),
+          ),
+          BlocProvider(
+            create: (context) => NotificationsCubit(notificationsStream: notificationsStreamController.stream),
+          ),
+          BlocProvider(
+            create: (context) => ThunderBloc(),
+          ),
+          BlocProvider(
+            create: (context) => AnonymousSubscriptionsBloc(),
+          ),
+          BlocProvider(
+            create: (context) => CommunityBloc(lemmyClient: LemmyClient.instance),
+          ),
+          BlocProvider(
+            create: (context) => InstanceBloc(lemmyClient: LemmyClient.instance),
+          ),
+          BlocProvider(
+            create: (context) => UserBloc(lemmyClient: LemmyClient.instance),
+          ),
+          BlocProvider(
+            create: (context) => NetworkCheckerCubit()..getConnectionType(),
+          )
+        ],
+        child: BlocBuilder<ThemeBloc, ThemeState>(
+          builder: (context, state) {
+            final ThunderBloc thunderBloc = context.watch<ThunderBloc>();
 
-          if (state.status == ThemeStatus.initial) {
-            context.read<ThemeBloc>().add(ThemeChangeEvent());
-          }
+            if (state.status == ThemeStatus.initial) {
+              context.read<ThemeBloc>().add(ThemeChangeEvent());
+            }
 
-          return DynamicColorBuilder(
-            builder: (lightColorScheme, darkColorScheme) {
-              FlexScheme scheme = FlexScheme.values.byName(state.selectedTheme.name);
+            return DynamicColorBuilder(
+              builder: (lightColorScheme, darkColorScheme) {
+                FlexScheme scheme = FlexScheme.values.byName(state.selectedTheme.name);
 
-              Color? darkThemeSurfaceColor = state.themeType == ThemeType.pureBlack ? null : Colors.black.lighten(8);
+                Color? darkThemeSurfaceColor = state.themeType == ThemeType.pureBlack ? null : Colors.black.lighten(8);
 
-              ThemeData theme = FlexThemeData.light(scheme: scheme);
-              ThemeData darkTheme = FlexThemeData.dark(
-                scheme: scheme,
-                darkIsTrueBlack: state.themeType == ThemeType.pureBlack,
-                surface: darkThemeSurfaceColor,
-                scaffoldBackground: darkThemeSurfaceColor,
-                appBarBackground: darkThemeSurfaceColor,
-              );
-
-              // Enable Material You theme
-              if (state.useMaterialYouTheme == true) {
-                theme = ThemeData(
-                  colorScheme: lightColorScheme,
-                );
-
-                darkTheme = FlexThemeData.dark(
-                  colorScheme: darkColorScheme,
+                ThemeData theme = FlexThemeData.light(scheme: scheme);
+                ThemeData darkTheme = FlexThemeData.dark(
+                  scheme: scheme,
                   darkIsTrueBlack: state.themeType == ThemeType.pureBlack,
+                  surface: darkThemeSurfaceColor,
+                  scaffoldBackground: darkThemeSurfaceColor,
+                  appBarBackground: darkThemeSurfaceColor,
                 );
-              }
 
-              // Set the page transitions
-              const PageTransitionsTheme pageTransitionsTheme = PageTransitionsTheme(builders: {
-                TargetPlatform.android: CupertinoPageTransitionsBuilder(),
-                TargetPlatform.iOS: CupertinoPageTransitionsBuilder(),
-              });
+                // Enable Material You theme
+                if (state.useMaterialYouTheme == true) {
+                  theme = ThemeData(
+                    colorScheme: lightColorScheme,
+                  );
 
-              // Customize our themes with the aforementinoed page transitions, as well as some custom styling
-              theme = theme.copyWith(
-                pageTransitionsTheme: pageTransitionsTheme,
-                inputDecorationTheme: InputDecorationTheme(
-                  hintStyle: TextStyle(
-                    color: lightColorScheme?.onSurface.withValues(alpha: 0.6),
+                  darkTheme = FlexThemeData.dark(
+                    colorScheme: darkColorScheme,
+                    darkIsTrueBlack: state.themeType == ThemeType.pureBlack,
+                  );
+                }
+
+                // Set the page transitions
+                const PageTransitionsTheme pageTransitionsTheme = PageTransitionsTheme(builders: {
+                  TargetPlatform.android: CupertinoPageTransitionsBuilder(),
+                  TargetPlatform.iOS: CupertinoPageTransitionsBuilder(),
+                });
+
+                // Customize our themes with the aforementinoed page transitions, as well as some custom styling
+                theme = theme.copyWith(
+                  pageTransitionsTheme: pageTransitionsTheme,
+                  inputDecorationTheme: InputDecorationTheme(
+                    hintStyle: TextStyle(
+                      color: lightColorScheme?.onSurface.withValues(alpha: 0.6),
+                    ),
                   ),
-                ),
-              );
-              darkTheme = darkTheme.copyWith(
-                pageTransitionsTheme: pageTransitionsTheme,
-                inputDecorationTheme: InputDecorationTheme(
-                  hintStyle: TextStyle(
-                    color: darkColorScheme?.onSurface.withValues(alpha: 0.6),
+                );
+                darkTheme = darkTheme.copyWith(
+                  pageTransitionsTheme: pageTransitionsTheme,
+                  inputDecorationTheme: InputDecorationTheme(
+                    hintStyle: TextStyle(
+                      color: darkColorScheme?.onSurface.withValues(alpha: 0.6),
+                    ),
                   ),
-                ),
-              );
+                );
 
-              Locale? locale = LanguageLocal.parseLanguageTag(thunderBloc.state.appLanguageCode);
+                Locale? locale = LanguageLocal.parseLanguageTag(thunderBloc.state.appLanguageCode);
 
-              return OverlaySupport.global(
-                child: AnnotatedRegion<SystemUiOverlayStyle>(
-                  // Set navigation bar color on Android to be transparent
-                  value: FlexColorScheme.themedSystemNavigationBar(context, systemNavBarStyle: FlexSystemNavBarStyle.transparent),
-                  child: MaterialApp(
-                    title: 'Thunder',
-                    locale: locale,
-                    localizationsDelegates: const [
-                      ...AppLocalizations.localizationsDelegates,
-                      MaterialLocalizationsEo.delegate,
-                      CupertinoLocalizationsEo.delegate,
-                    ],
-                    supportedLocales: const [
-                      ...AppLocalizations.supportedLocales,
-                      Locale('eo'), // Additional locale which is not officially supported: Esperanto
-                    ],
-                    themeMode: state.themeType == ThemeType.system ? ThemeMode.system : (state.themeType == ThemeType.light ? ThemeMode.light : ThemeMode.dark),
-                    theme: theme,
-                    darkTheme: darkTheme,
-                    debugShowCheckedModeBanner: false,
-                    scaffoldMessengerKey: GlobalContext.scaffoldMessengerKey,
-                    scrollBehavior: (state.reduceAnimations && Platform.isAndroid) ? const ScrollBehavior().copyWith(overscroll: false) : null,
-                    home: Thunder(pageController: thunderPageController),
+                return OverlaySupport.global(
+                  child: AnnotatedRegion<SystemUiOverlayStyle>(
+                    // Set navigation bar color on Android to be transparent
+                    value: FlexColorScheme.themedSystemNavigationBar(context, systemNavBarStyle: FlexSystemNavBarStyle.transparent),
+                    child: MaterialApp(
+                      title: 'Thunder',
+                      locale: locale,
+                      localizationsDelegates: const [
+                        ...AppLocalizations.localizationsDelegates,
+                        MaterialLocalizationsEo.delegate,
+                        CupertinoLocalizationsEo.delegate,
+                      ],
+                      supportedLocales: const [
+                        ...AppLocalizations.supportedLocales,
+                        Locale('eo'), // Additional locale which is not officially supported: Esperanto
+                      ],
+                      themeMode: state.themeType == ThemeType.system ? ThemeMode.system : (state.themeType == ThemeType.light ? ThemeMode.light : ThemeMode.dark),
+                      theme: theme,
+                      darkTheme: darkTheme,
+                      debugShowCheckedModeBanner: false,
+                      scaffoldMessengerKey: GlobalContext.scaffoldMessengerKey,
+                      scrollBehavior: (state.reduceAnimations && Platform.isAndroid) ? const ScrollBehavior().copyWith(overscroll: false) : null,
+                      home: Thunder(pageController: thunderPageController),
+                    ),
                   ),
-                ),
-              );
-            },
-          );
-        },
+                );
+              },
+            );
+          },
+        ),
       ),
     );
   }

--- a/lib/post/bloc/post_bloc.dart
+++ b/lib/post/bloc/post_bloc.dart
@@ -11,6 +11,7 @@ import 'package:thunder/core/enums/local_settings.dart';
 import 'package:thunder/core/models/models.dart';
 import 'package:thunder/core/singletons/lemmy_client.dart';
 import 'package:thunder/core/singletons/preferences.dart';
+import 'package:thunder/post/repository/post_repository.dart';
 import 'package:thunder/post/utils/post.dart';
 import 'package:thunder/utils/constants.dart';
 import 'package:thunder/utils/error_messages.dart';
@@ -20,7 +21,11 @@ part 'post_event.dart';
 part 'post_state.dart';
 
 class PostBloc extends Bloc<PostEvent, PostState> {
-  PostBloc() : super(PostState()) {
+  late PostRepository repository;
+
+  PostBloc({PostRepository? repository}) : super(PostState()) {
+    this.repository = repository ?? LemmyPostRepository(client: LemmyClient.instance.lemmyApiV3);
+
     on<GetPostEvent>(_getPostEvent);
     on<GetPostCommentsEvent>(_getPostCommentsEvent);
     on<ReportCommentEvent>(_reportCommentEvent);
@@ -155,7 +160,7 @@ class PostBloc extends Bloc<PostEvent, PostState> {
       emit(state.copyWith(status: PostStatus.success, post: updatedPost));
       emit(state.copyWith(status: PostStatus.refreshing));
 
-      updatedPost = await votePost(originalPost, event.score);
+      updatedPost = await repository.vote(originalPost, event.score);
 
       return emit(state.copyWith(status: PostStatus.success, post: updatedPost));
     } catch (e) {
@@ -180,7 +185,7 @@ class PostBloc extends Bloc<PostEvent, PostState> {
       emit(state.copyWith(status: PostStatus.success, post: updatedPost));
       emit(state.copyWith(status: PostStatus.refreshing));
 
-      updatedPost = await savePost(originalPost, event.save);
+      updatedPost = await repository.save(originalPost, event.save);
 
       return emit(state.copyWith(status: PostStatus.success, post: updatedPost));
     } catch (e) {

--- a/lib/post/cubit/create_post_cubit.dart
+++ b/lib/post/cubit/create_post_cubit.dart
@@ -1,20 +1,23 @@
 import 'package:bloc/bloc.dart';
 import 'package:equatable/equatable.dart';
 import 'package:lemmy_api_client/pictrs.dart';
-import 'package:lemmy_api_client/v3.dart';
-import 'package:thunder/localizations/app_localizations.dart';
 
+import 'package:thunder/core/singletons/lemmy_client.dart';
+import 'package:thunder/localizations/app_localizations.dart';
 import 'package:thunder/account/account.dart';
 import 'package:thunder/core/models/models.dart';
-import 'package:thunder/feed/utils/post.dart';
-import 'package:thunder/post/utils/post.dart';
+import 'package:thunder/post/repository/post_repository.dart';
 import 'package:thunder/utils/error_messages.dart';
 import 'package:thunder/utils/global_context.dart';
 
 part 'create_post_state.dart';
 
 class CreatePostCubit extends Cubit<CreatePostState> {
-  CreatePostCubit() : super(const CreatePostState(status: CreatePostStatus.initial));
+  late PostRepository repository;
+
+  CreatePostCubit({PostRepository? repository}) : super(const CreatePostState(status: CreatePostStatus.initial)) {
+    this.repository = repository ?? LemmyPostRepository(client: LemmyClient.instance.lemmyApiV3);
+  }
 
   Future<void> clearMessage() async {
     emit(state.copyWith(status: CreatePostStatus.initial, message: null));
@@ -65,7 +68,7 @@ class CreatePostCubit extends Cubit<CreatePostState> {
     emit(state.copyWith(status: CreatePostStatus.submitting));
 
     try {
-      PostView postView = await createPost(
+      final post = await repository.create(
         communityId: communityId,
         name: name,
         body: body,
@@ -77,11 +80,8 @@ class CreatePostCubit extends Cubit<CreatePostState> {
         languageId: languageId,
       );
 
-      // Parse the newly created post
-      List<ThunderPost> posts = await parsePosts([postView]);
-
-      emit(state.copyWith(status: CreatePostStatus.success, post: posts.firstOrNull));
-      return posts.firstOrNull?.id;
+      emit(state.copyWith(status: CreatePostStatus.success, post: post));
+      return post.id;
     } catch (e) {
       emit(state.copyWith(status: CreatePostStatus.error, message: getExceptionErrorMessage(e)));
     }

--- a/lib/post/repository/post_repository.dart
+++ b/lib/post/repository/post_repository.dart
@@ -1,8 +1,11 @@
+import 'dart:async';
+
 import 'package:lemmy_api_client/v3.dart';
 
 import 'package:thunder/account/account.dart';
 import 'package:thunder/core/enums/subscription_status.dart';
 import 'package:thunder/core/models/models.dart';
+import 'package:thunder/core/singletons/lemmy_client.dart';
 import 'package:thunder/post/utils/post.dart';
 import 'package:thunder/utils/global_context.dart';
 
@@ -82,14 +85,28 @@ abstract class PostRepository {
   /// Reports a post
   /// @TODO: Change the return type to an internal model
   Future<PostReportResponse> report(int postId, String reason);
+
+  /// Dispose method to clean up resources
+  void dispose();
 }
 
 /// Implementation of [PostRepository] using Lemmy API
 class LemmyPostRepository implements PostRepository {
   /// The Lemmy client to use for the repository
-  final LemmyApiV3 client;
+  LemmyApiV3 client;
 
-  LemmyPostRepository({required this.client});
+  /// Stream subscription for client changes
+  StreamSubscription<LemmyApiV3>? _subscription;
+
+  LemmyPostRepository({required this.client}) {
+    _subscription = LemmyClient.onClientChanged.listen((newClient) => client = newClient);
+  }
+
+  @override
+  void dispose() {
+    _subscription?.cancel();
+    _subscription = null;
+  }
 
   @override
   Future<ThunderPost?> getPost(int postId, {int? commentId}) async {

--- a/lib/post/repository/post_repository.dart
+++ b/lib/post/repository/post_repository.dart
@@ -1,0 +1,342 @@
+import 'package:lemmy_api_client/v3.dart';
+
+import 'package:thunder/account/account.dart';
+import 'package:thunder/core/enums/subscription_status.dart';
+import 'package:thunder/core/models/models.dart';
+import 'package:thunder/post/utils/post.dart';
+import 'package:thunder/utils/global_context.dart';
+
+extension on MarkPostAsReadResponse {
+  bool isSuccess() {
+    return postView != null || success == true;
+  }
+}
+
+/// Interface for a post repository
+abstract class PostRepository {
+  /// Fetches a post by its ID
+  Future<ThunderPost?> getPost(int postId, {int? commentId});
+
+  /// Creates a new post
+  Future<ThunderPost> create({
+    required int communityId,
+    required String name,
+    String? body,
+    String? url,
+    String? customThumbnail,
+    String? altText,
+    bool? nsfw,
+    int? postIdBeingEdited,
+    int? languageId,
+  });
+
+  /// Creates a placeholder post from the given parameters. This is mainly used to display a preview of the post
+  /// with the applied settings on Settings -> Appearance -> Posts page.
+  Future<ThunderPost?> createExample({
+    String? postTitle,
+    String? postUrl,
+    String? postBody,
+    String? postThumbnailUrl,
+    String? postAltText,
+    bool? locked,
+    bool? nsfw,
+    bool? pinned,
+    String? personName,
+    String? personDisplayName,
+    String? personInstance,
+    String? communityName,
+    String? instanceUrl,
+    int? commentCount,
+    int? scoreCount,
+    bool? saved,
+    bool? read,
+  });
+
+  /// Votes on a post
+  Future<ThunderPost> vote(ThunderPost post, int score);
+
+  /// Saves or unsaves a post
+  Future<ThunderPost> save(ThunderPost post, bool save);
+
+  /// Marks a post as read/unread
+  Future<bool> read(int postId, bool read);
+
+  /// Marks multiple posts as read/unread
+  Future<List<int>> readMultiple(List<int> postIds, bool read);
+
+  /// Marks a post as hidden/unhidden
+  Future<bool> hide(int postId, bool hide);
+
+  /// Deletes a post
+  Future<bool> delete(int postId, bool delete);
+
+  /// Locks/unlocks a post
+  Future<bool> lock(int postId, bool lock);
+
+  /// Pins/unpins a post to a community
+  Future<bool> pinCommunity(int postId, bool pin);
+
+  /// Removes/restores a post (moderator action)
+  Future<bool> remove(int postId, bool remove, String reason);
+
+  /// Reports a post
+  /// @TODO: Change the return type to an internal model
+  Future<PostReportResponse> report(int postId, String reason);
+}
+
+/// Implementation of [PostRepository] using Lemmy API
+class LemmyPostRepository implements PostRepository {
+  /// The Lemmy client to use for the repository
+  final LemmyApiV3 client;
+
+  LemmyPostRepository({required this.client});
+
+  @override
+  Future<ThunderPost?> getPost(int postId, {int? commentId}) async {
+    final account = await fetchActiveProfile();
+
+    final response = await client.run(GetPost(id: postId, auth: account.jwt, commentId: commentId));
+    final posts = await parsePosts([response.postView]);
+    return posts.firstOrNull;
+  }
+
+  @override
+  Future<ThunderPost> create({
+    required int communityId,
+    required String name,
+    String? body,
+    String? url,
+    String? customThumbnail,
+    String? altText,
+    bool? nsfw,
+    int? postIdBeingEdited,
+    int? languageId,
+  }) async {
+    final l10n = GlobalContext.l10n;
+    final account = await fetchActiveProfile();
+    if (account.anonymous) throw Exception(l10n.userNotLoggedIn);
+
+    PostResponse postResponse;
+    if (postIdBeingEdited != null) {
+      postResponse = await client.run(EditPost(
+        auth: account.jwt!,
+        name: name,
+        body: body,
+        url: url?.isEmpty == true ? null : url,
+        customThumbnail: customThumbnail?.isEmpty == true ? null : customThumbnail,
+        altText: altText?.isEmpty == true ? null : altText,
+        nsfw: nsfw,
+        postId: postIdBeingEdited,
+        languageId: languageId,
+      ));
+    } else {
+      postResponse = await client.run(CreatePost(
+        auth: account.jwt!,
+        communityId: communityId,
+        name: name,
+        body: body,
+        url: url?.isEmpty == true ? null : url,
+        customThumbnail: customThumbnail?.isEmpty == true ? null : customThumbnail,
+        altText: altText?.isEmpty == true ? null : altText,
+        nsfw: nsfw,
+        languageId: languageId,
+      ));
+    }
+
+    final posts = await parsePosts([postResponse.postView]);
+    return posts.firstOrNull!;
+  }
+
+  @override
+  Future<ThunderPost> vote(ThunderPost post, int score) async {
+    final l10n = GlobalContext.l10n;
+    final account = await fetchActiveProfile();
+    if (account.anonymous) throw Exception(l10n.userNotLoggedIn);
+
+    final response = await client.run(CreatePostLike(auth: account.jwt!, postId: post.id, score: score));
+    return post.copyWith(postView: response.postView, post: response.postView.post);
+  }
+
+  @override
+  Future<ThunderPost> save(ThunderPost post, bool save) async {
+    final l10n = GlobalContext.l10n;
+    final account = await fetchActiveProfile();
+    if (account.anonymous) throw Exception(l10n.userNotLoggedIn);
+
+    final response = await client.run(SavePost(auth: account.jwt!, postId: post.id, save: save));
+    return post.copyWith(postView: response.postView, post: response.postView.post);
+  }
+
+  @override
+  Future<bool> read(int postId, bool read) async {
+    final l10n = GlobalContext.l10n;
+    final account = await fetchActiveProfile();
+    if (account.anonymous) throw Exception(l10n.userNotLoggedIn);
+
+    final response = await client.run(MarkPostAsRead(auth: account.jwt!, postIds: [postId], read: read));
+    return response.isSuccess();
+  }
+
+  @override
+  Future<List<int>> readMultiple(List<int> postIds, bool read) async {
+    final l10n = GlobalContext.l10n;
+    final account = await fetchActiveProfile();
+    if (account.anonymous) throw Exception(l10n.userNotLoggedIn);
+
+    List<int> failed = [];
+
+    final response = await client.run(MarkPostAsRead(auth: account.jwt!, postIds: postIds, read: read));
+    if (!response.isSuccess()) failed = List<int>.generate(postIds.length, (index) => index);
+
+    return failed;
+  }
+
+  @override
+  Future<bool> hide(int postId, bool hide) async {
+    final l10n = GlobalContext.l10n;
+    final account = await fetchActiveProfile();
+    if (account.anonymous) throw Exception(l10n.userNotLoggedIn);
+
+    final response = await client.run(HidePost(auth: account.jwt!, postIds: [postId], hide: hide));
+    return response.success;
+  }
+
+  @override
+  Future<bool> delete(int postId, bool delete) async {
+    final l10n = GlobalContext.l10n;
+    final account = await fetchActiveProfile();
+    if (account.anonymous) throw Exception(l10n.userNotLoggedIn);
+
+    final response = await client.run(DeletePost(auth: account.jwt!, postId: postId, deleted: delete));
+    return response.postView.post.deleted == delete;
+  }
+
+  @override
+  Future<bool> lock(int postId, bool lock) async {
+    final l10n = GlobalContext.l10n;
+    final account = await fetchActiveProfile();
+    if (account.anonymous) throw Exception(l10n.userNotLoggedIn);
+
+    final response = await client.run(LockPost(auth: account.jwt!, postId: postId, locked: lock));
+    return response.postView.post.locked == lock;
+  }
+
+  @override
+  Future<bool> pinCommunity(int postId, bool pin) async {
+    final l10n = GlobalContext.l10n;
+    final account = await fetchActiveProfile();
+    if (account.anonymous) throw Exception(l10n.userNotLoggedIn);
+
+    final response = await client.run(FeaturePost(auth: account.jwt!, postId: postId, featured: pin, featureType: PostFeatureType.community));
+    return response.postView.post.featuredCommunity == pin;
+  }
+
+  @override
+  Future<bool> remove(int postId, bool remove, String reason) async {
+    final l10n = GlobalContext.l10n;
+    final account = await fetchActiveProfile();
+    if (account.anonymous) throw Exception(l10n.userNotLoggedIn);
+
+    final response = await client.run(RemovePost(auth: account.jwt!, postId: postId, removed: remove, reason: reason));
+    return response.postView.post.removed == remove;
+  }
+
+  @override
+  Future<PostReportResponse> report(int postId, String reason) async {
+    final l10n = GlobalContext.l10n;
+    final account = await fetchActiveProfile();
+    if (account.anonymous) throw Exception(l10n.userNotLoggedIn);
+
+    final response = await client.run(CreatePostReport(auth: account.jwt!, postId: postId, reason: reason));
+    return response;
+  }
+
+  @override
+  Future<ThunderPost?> createExample({
+    String? postTitle,
+    String? postUrl,
+    String? postBody,
+    String? postThumbnailUrl,
+    String? postAltText,
+    bool? locked,
+    bool? nsfw,
+    bool? pinned,
+    String? personName,
+    String? personDisplayName,
+    String? personInstance,
+    String? communityName,
+    String? instanceUrl,
+    int? commentCount,
+    int? scoreCount,
+    bool? saved,
+    bool? read,
+  }) async {
+    PostView postView = PostView(
+      post: Post(
+        id: 1,
+        name: postTitle ?? 'Example Title',
+        url: postUrl,
+        body: postBody,
+        thumbnailUrl: postThumbnailUrl,
+        altText: postAltText,
+        creatorId: 1,
+        communityId: 1,
+        removed: false,
+        locked: locked ?? false,
+        published: DateTime.now(),
+        deleted: false,
+        nsfw: nsfw ?? false,
+        apId: '',
+        local: false,
+        languageId: 0,
+        featuredCommunity: pinned ?? false,
+        featuredLocal: false,
+      ),
+      creator: Person(
+        id: 1,
+        name: personName ?? 'Example Username',
+        displayName: personDisplayName ?? 'Example Name',
+        banned: false,
+        published: DateTime.now(),
+        actorId: 'https://$personInstance/u/$personName',
+        local: false,
+        deleted: false,
+        botAccount: false,
+        instanceId: 1,
+      ),
+      community: Community(
+        id: 1,
+        name: communityName ?? 'Example Community',
+        title: '',
+        removed: false,
+        published: DateTime.now(),
+        deleted: false,
+        nsfw: false,
+        actorId: instanceUrl ?? 'https://thunder.lemmy',
+        local: false,
+        hidden: false,
+        postingRestrictedToMods: false,
+        instanceId: 1,
+      ),
+      creatorBannedFromCommunity: false,
+      counts: PostAggregates(
+        id: 1,
+        postId: 1,
+        comments: commentCount ?? 0,
+        score: scoreCount ?? 0,
+        upvotes: 0,
+        downvotes: 0,
+        published: DateTime.now(),
+      ),
+      subscribed: SubscriptionStatus.notSubscribed.toLemmyType(),
+      saved: saved ?? false,
+      read: read ?? false,
+      creatorBlocked: false,
+      unreadComments: 0,
+    );
+
+    List<ThunderPost> posts = await parsePosts([postView]);
+
+    return Future.value(posts.firstOrNull);
+  }
+}

--- a/lib/post/utils/post.dart
+++ b/lib/post/utils/post.dart
@@ -2,22 +2,14 @@ import 'package:flutter/material.dart';
 
 import 'package:lemmy_api_client/v3.dart';
 
-import 'package:thunder/account/account.dart';
 import 'package:thunder/core/enums/local_settings.dart';
 import 'package:thunder/core/enums/media_type.dart';
 import 'package:thunder/core/models/media.dart';
 import 'package:thunder/core/models/models.dart';
 import 'package:thunder/core/singletons/lemmy_client.dart';
 import 'package:thunder/core/singletons/preferences.dart';
-import 'package:thunder/utils/global_context.dart';
 import 'package:thunder/utils/media/image.dart';
 import 'package:thunder/utils/media/video.dart';
-
-extension on MarkPostAsReadResponse {
-  bool isSuccess() {
-    return postView != null || success == true;
-  }
-}
 
 // Optimistically updates a post. This changes the value of the post locally, without sending the network request
 ThunderPost optimisticallyVotePost(ThunderPost post, int voteType) {
@@ -93,142 +85,6 @@ ThunderPost optimisticallyPinPostToCommunity(ThunderPost post, bool pin) {
 // Optimistically removes a post. This changes the value of the post locally, without sending the network request
 ThunderPost optimisticallyRemovePost(ThunderPost post, bool remove) {
   return post.copyWith(post: post.internalPost.copyWith(removed: remove));
-}
-
-/// Logic to mark post as read
-Future<bool> markPostAsRead(int postId, bool read) async {
-  final l10n = GlobalContext.l10n;
-  final account = await fetchActiveProfile();
-  if (account.anonymous) throw Exception(l10n.userNotLoggedIn);
-
-  final lemmy = LemmyClient.instance.lemmyApiV3;
-
-  if (LemmyClient.instance.supportsFeature(LemmyFeature.multiRead)) {
-    final response = await lemmy.run(MarkPostAsRead(auth: account.jwt!, postIds: [postId], read: read));
-    return response.isSuccess();
-  } else {
-    final response = await lemmy.run(MarkPostAsRead(auth: account.jwt!, postId: postId, read: read));
-    return response.isSuccess();
-  }
-}
-
-/// Logic to mark multiple posts as read
-Future<List<int>> markPostsAsRead(List<int> postIds, bool read) async {
-  final l10n = GlobalContext.l10n;
-  final account = await fetchActiveProfile();
-  if (account.anonymous) throw Exception(l10n.userNotLoggedIn);
-
-  final lemmy = LemmyClient.instance.lemmyApiV3;
-
-  List<int> failed = [];
-
-  if (LemmyClient.instance.supportsFeature(LemmyFeature.multiRead)) {
-    final response = await lemmy.run(MarkPostAsRead(auth: account.jwt!, postIds: postIds, read: read));
-    if (!response.isSuccess()) failed = List<int>.generate(postIds.length, (index) => index);
-  } else {
-    for (int i = 0; i < postIds.length; i++) {
-      final response = await lemmy.run(MarkPostAsRead(auth: account.jwt!, postId: postIds[i], read: read));
-      if (!response.isSuccess()) failed.add(i);
-    }
-  }
-
-  return failed;
-}
-
-/// Logic to mark post as hidden
-Future<bool> markPostAsHidden(int postId, bool hide) async {
-  final l10n = GlobalContext.l10n;
-  final account = await fetchActiveProfile();
-  if (account.anonymous) throw Exception(l10n.userNotLoggedIn);
-
-  final lemmy = LemmyClient.instance.lemmyApiV3;
-
-  final response = await lemmy.run(HidePost(auth: account.jwt!, postIds: [postId], hide: hide));
-  return response.success;
-}
-
-/// Logic to delete post
-Future<bool> deletePost(int postId, bool delete) async {
-  final l10n = GlobalContext.l10n;
-  final account = await fetchActiveProfile();
-  if (account.anonymous) throw Exception(l10n.userNotLoggedIn);
-
-  final lemmy = LemmyClient.instance.lemmyApiV3;
-
-  final response = await lemmy.run(DeletePost(auth: account.jwt!, postId: postId, deleted: delete));
-  return response.postView.post.deleted == delete;
-}
-
-/// Logic to lock a post
-Future<bool> lockPost(int postId, bool lock) async {
-  final l10n = GlobalContext.l10n;
-  final account = await fetchActiveProfile();
-  if (account.anonymous) throw Exception(l10n.userNotLoggedIn);
-
-  final lemmy = LemmyClient.instance.lemmyApiV3;
-
-  final response = await lemmy.run(LockPost(auth: account.jwt!, postId: postId, locked: lock));
-  return response.postView.post.locked == lock;
-}
-
-/// Logic to pin a post to a community
-Future<bool> pinPostToCommunity(int postId, bool pin) async {
-  final l10n = GlobalContext.l10n;
-  final account = await fetchActiveProfile();
-  if (account.anonymous) throw Exception(l10n.userNotLoggedIn);
-
-  final lemmy = LemmyClient.instance.lemmyApiV3;
-
-  final response = await lemmy.run(FeaturePost(auth: account.jwt!, postId: postId, featured: pin, featureType: PostFeatureType.community));
-  return response.postView.post.featuredCommunity == pin;
-}
-
-/// Logic to remove a post to a community (moderator action)
-Future<bool> removePost(int postId, bool remove, String reason) async {
-  final l10n = GlobalContext.l10n;
-  final account = await fetchActiveProfile();
-  if (account.anonymous) throw Exception(l10n.userNotLoggedIn);
-
-  final lemmy = LemmyClient.instance.lemmyApiV3;
-
-  final response = await lemmy.run(RemovePost(auth: account.jwt!, postId: postId, removed: remove, reason: reason));
-  return response.postView.post.removed == remove;
-}
-
-/// Logic to report a given post
-Future<PostReportResponse> reportPost(int postId, String reason) async {
-  final l10n = GlobalContext.l10n;
-  final account = await fetchActiveProfile();
-  if (account.anonymous) throw Exception(l10n.userNotLoggedIn);
-
-  final lemmy = LemmyClient.instance.lemmyApiV3;
-
-  final response = await lemmy.run(CreatePostReport(auth: account.jwt!, postId: postId, reason: reason));
-  return response;
-}
-
-/// Logic to vote on a post
-Future<ThunderPost> votePost(ThunderPost post, int score) async {
-  final l10n = GlobalContext.l10n;
-  final account = await fetchActiveProfile();
-  if (account.anonymous) throw Exception(l10n.userNotLoggedIn);
-
-  final lemmy = LemmyClient.instance.lemmyApiV3;
-
-  final response = await lemmy.run(CreatePostLike(auth: account.jwt!, postId: post.id, score: score));
-  return post.copyWith(postView: response.postView, post: response.postView.post);
-}
-
-/// Logic to save a post
-Future<ThunderPost> savePost(ThunderPost post, bool save) async {
-  final l10n = GlobalContext.l10n;
-  final account = await fetchActiveProfile();
-  if (account.anonymous) throw Exception(l10n.userNotLoggedIn);
-
-  final lemmy = LemmyClient.instance.lemmyApiV3;
-
-  final response = await lemmy.run(SavePost(auth: account.jwt!, postId: post.id, save: save));
-  return post.copyWith(postView: response.postView, post: response.postView.post);
 }
 
 /// Parse a post with media

--- a/lib/search/pages/search_page.dart
+++ b/lib/search/pages/search_page.dart
@@ -1,11 +1,11 @@
 import 'dart:async';
 import 'dart:io';
 
-import 'package:back_button_interceptor/back_button_interceptor.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 
+import 'package:back_button_interceptor/back_button_interceptor.dart';
 import 'package:fading_edge_scrollview/fading_edge_scrollview.dart';
 import 'package:flex_color_scheme/flex_color_scheme.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
@@ -164,7 +164,7 @@ class _SearchPageState extends State<SearchPage> with AutomaticKeepAliveClientMi
     final String? currentAnonymousInstance = context.read<ThunderBloc>().state.currentAnonymousInstance;
 
     return BlocProvider(
-      create: (context) => FeedBloc(lemmyClient: LemmyClient.instance),
+      create: (context) => FeedBloc(),
       child: MultiBlocListener(
         listeners: [
           BlocListener<FeedBloc, FeedState>(listener: (context, state) => setState(() {})),

--- a/lib/settings/pages/post_appearance_settings_page.dart
+++ b/lib/settings/pages/post_appearance_settings_page.dart
@@ -5,11 +5,10 @@ import 'package:flutter/services.dart';
 
 import 'package:intl/intl.dart';
 import 'package:expandable/expandable.dart';
-import 'package:collection/collection.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
-import 'package:thunder/localizations/app_localizations.dart';
 import 'package:smooth_highlight/smooth_highlight.dart';
 
+import 'package:thunder/localizations/app_localizations.dart';
 import 'package:thunder/community/widgets/post_card_view_comfortable.dart';
 import 'package:thunder/community/widgets/post_card_view_compact.dart';
 import 'package:thunder/core/enums/custom_theme_type.dart';
@@ -18,11 +17,10 @@ import 'package:thunder/core/enums/local_settings.dart';
 import 'package:thunder/core/enums/post_body_view_type.dart';
 import 'package:thunder/core/enums/view_mode.dart';
 import 'package:thunder/core/models/models.dart';
-import 'package:thunder/core/singletons/lemmy_client.dart';
 import 'package:thunder/core/singletons/preferences.dart';
 import 'package:thunder/feed/feed.dart';
-import 'package:thunder/feed/utils/post.dart';
 import 'package:thunder/post/enums/post_card_metadata_item.dart';
+import 'package:thunder/post/repository/post_repository.dart';
 import 'package:thunder/settings/widgets/list_option.dart';
 import 'package:thunder/settings/widgets/toggle_option.dart';
 import 'package:thunder/shared/dialogs.dart';
@@ -331,7 +329,9 @@ class _PostAppearanceSettingsPageState extends State<PostAppearanceSettingsPage>
 
   /// Generates an example post to show in the post preview
   Future<List<ThunderPost?>> getExamplePosts() async {
-    ThunderPost? postText = await createExamplePost(
+    final repository = context.read<PostRepository>();
+
+    ThunderPost? postText = await repository.createExample(
       postTitle: 'Example Text Post',
       personName: 'Lightning',
       personInstance: 'lemmy.world',
@@ -342,7 +342,7 @@ class _PostAppearanceSettingsPageState extends State<PostAppearanceSettingsPage>
       commentCount: 4,
     );
 
-    ThunderPost? postImage = await createExamplePost(
+    ThunderPost? postImage = await repository.createExample(
       postTitle: 'Example Image Post',
       personName: 'Lightning',
       personDisplayName: 'User',
@@ -355,7 +355,7 @@ class _PostAppearanceSettingsPageState extends State<PostAppearanceSettingsPage>
       commentCount: 4230,
     );
 
-    ThunderPost? postLink = await createExamplePost(
+    ThunderPost? postLink = await repository.createExample(
       postTitle: 'Example Link Post',
       personName: 'Lightning',
       personDisplayName: 'User',
@@ -501,7 +501,7 @@ class _PostAppearanceSettingsPageState extends State<PostAppearanceSettingsPage>
                         if (snapshot.data == null) return Container();
 
                         return BlocProvider(
-                          create: (context) => FeedBloc(lemmyClient: LemmyClient()),
+                          create: (context) => FeedBloc(),
                           child: ListView.builder(
                             padding: EdgeInsets.zero,
                             shrinkWrap: true,

--- a/lib/thunder/pages/thunder_page.dart
+++ b/lib/thunder/pages/thunder_page.dart
@@ -7,7 +7,6 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 
 // Packages
-import 'package:thunder/localizations/app_localizations.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_native_splash/flutter_native_splash.dart';
 import 'package:overlay_support/overlay_support.dart';
@@ -15,6 +14,7 @@ import 'package:back_button_interceptor/back_button_interceptor.dart';
 import 'package:fading_edge_scrollview/fading_edge_scrollview.dart';
 
 // Internal
+import 'package:thunder/localizations/app_localizations.dart';
 import 'package:thunder/account/account.dart';
 import 'package:thunder/community/widgets/community_drawer.dart';
 import 'package:thunder/core/enums/enums.dart';
@@ -165,7 +165,7 @@ class _ThunderState extends State<Thunder> {
       providers: [
         BlocProvider(create: (context) => InboxBloc()),
         BlocProvider(create: (context) => SearchBloc()),
-        BlocProvider(create: (context) => FeedBloc(lemmyClient: LemmyClient.instance)),
+        BlocProvider(create: (context) => FeedBloc()),
       ],
       child: MultiBlocListener(
         listeners: [

--- a/lib/thunder/utils/deep_link.dart
+++ b/lib/thunder/utils/deep_link.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 
+import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:lemmy_api_client/v3.dart' hide ModlogActionType;
 
 import 'package:thunder/account/utils/profiles.dart';
@@ -8,7 +9,7 @@ import 'package:thunder/core/models/models.dart';
 import 'package:thunder/core/singletons/lemmy_client.dart';
 import 'package:thunder/feed/view/feed_page.dart';
 import 'package:thunder/modlog/modlog.dart';
-import 'package:thunder/post/utils/post.dart';
+import 'package:thunder/post/repository/post_repository.dart';
 import 'package:thunder/shared/snackbar.dart';
 import 'package:thunder/thunder/enums/deep_link_enums.dart';
 import 'package:thunder/utils/global_context.dart';
@@ -233,13 +234,12 @@ Future<DeepLinkResult> _navigateToPost(BuildContext context, String link) async 
   }
 
   try {
-    final lemmy = LemmyClient.instance.lemmyApiV3;
-    final account = await fetchActiveProfile();
-    final response = await lemmy.run(GetPost(id: postId, auth: account.jwt));
+    final repository = context.read<PostRepository>();
+    final post = await repository.getPost(postId);
 
     if (!context.mounted) return DeepLinkResult.failure(GlobalContext.l10n.unexpectedError);
 
-    navigateToPost(context, post: (await parsePosts([response.postView])).first);
+    navigateToPost(context, post: post);
     return DeepLinkResult.successful();
   } catch (e) {
     throw DeepLinkException(GlobalContext.l10n.exceptionProcessingUri, url: link, type: DeepLinkErrorType.entityResolution);

--- a/lib/user/pages/media_management_page.dart
+++ b/lib/user/pages/media_management_page.dart
@@ -2,8 +2,8 @@ import 'package:flutter/material.dart';
 
 import 'package:extended_image/extended_image.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
-import 'package:thunder/localizations/app_localizations.dart';
 
+import 'package:thunder/localizations/app_localizations.dart';
 import 'package:thunder/account/account.dart';
 import 'package:thunder/comment/comment.dart';
 import 'package:thunder/core/enums/image_caching_mode.dart';
@@ -179,7 +179,7 @@ class MediaManagementPage extends StatelessWidget {
                                                             else if (state.status == UserSettingsStatus.succeededSearchingMedia) ...[
                                                               if (state.imageSearchPosts?.isNotEmpty == true)
                                                                 BlocProvider.value(
-                                                                  value: FeedBloc(lemmyClient: LemmyClient.instance),
+                                                                  value: FeedBloc(),
                                                                   child: CustomScrollView(
                                                                     physics: const NeverScrollableScrollPhysics(),
                                                                     shrinkWrap: true,

--- a/lib/utils/links.dart
+++ b/lib/utils/links.dart
@@ -12,6 +12,7 @@ import 'package:lemmy_api_client/v3.dart' hide ModlogActionType;
 import 'package:link_preview_generator/link_preview_generator.dart';
 import 'package:share_plus/share_plus.dart';
 import 'package:thunder/core/models/models.dart';
+import 'package:thunder/post/repository/post_repository.dart';
 import 'package:url_launcher/url_launcher.dart' as url_launcher;
 import 'package:flutter_custom_tabs/flutter_custom_tabs.dart';
 import 'package:thunder/localizations/app_localizations.dart';
@@ -30,7 +31,6 @@ import 'package:thunder/thunder/bloc/thunder_bloc.dart';
 import 'package:thunder/account/account.dart';
 import 'package:thunder/core/singletons/lemmy_client.dart';
 import 'package:thunder/feed/view/feed_page.dart';
-import 'package:thunder/post/utils/post.dart';
 import 'package:thunder/utils/instance.dart';
 
 class LinkInfo {
@@ -175,13 +175,11 @@ void handleLink(BuildContext context, {required String url, bool forceOpenInBrow
       // Show the loading page while we fetch the post
       if (context.mounted) showLoadingPage(context);
 
-      GetPostResponse post = await lemmy.run(GetPost(
-        id: postId,
-        auth: account.jwt,
-      ));
+      final repository = context.read<PostRepository>();
+      final post = await repository.getPost(postId);
 
       if (context.mounted) {
-        navigateToPost(context, post: (await parsePosts([post.postView])).first);
+        navigateToPost(context, post: post);
         return;
       }
     } catch (e) {

--- a/lib/utils/navigation.dart
+++ b/lib/utils/navigation.dart
@@ -33,7 +33,7 @@ import 'package:thunder/post/bloc/post_bloc.dart';
 import 'package:thunder/post/cubit/create_post_cubit.dart';
 import 'package:thunder/post/enums/post_action.dart';
 import 'package:thunder/post/pages/post_page.dart';
-import 'package:thunder/post/utils/post.dart';
+import 'package:thunder/post/repository/post_repository.dart';
 import 'package:thunder/search/bloc/search_bloc.dart';
 import 'package:thunder/search/pages/search_page.dart';
 import 'package:thunder/settings/pages/about_settings_page.dart';
@@ -155,32 +155,19 @@ Future<void> navigateToPost(
 
   ThunderPost? pvm = post;
 
-  if (pvm == null) {
-    final client = LemmyClient.instance.lemmyApiV3;
-    final account = await fetchActiveProfile();
-
-    GetPostResponse getPostResponse = await client.run(
-      GetPost(
-        auth: account.jwt,
-        id: postId,
-      ),
-    );
-
-    List<ThunderPost> posts = await parsePosts([getPostResponse.postView]);
-
-    pvm = posts.first;
-  }
+  final repository = context.read<PostRepository>();
+  pvm ??= await repository.getPost(postId!);
 
   // Mark post as read when tapped
   if (profileBloc.state.isLoggedIn) {
-    feedBloc?.add(FeedItemActionedEvent(postId: pvm.id, postAction: PostAction.read, value: true));
+    feedBloc?.add(FeedItemActionedEvent(postId: pvm!.id, postAction: PostAction.read, value: true));
   }
 
   final state = thunderBloc.state;
   final reduceAnimations = state.reduceAnimations;
   final enableFullScreenSwipeNavigationGesture = state.enableFullScreenSwipeNavigationGesture;
 
-  final post_bloc.PostBloc postBloc = _cachedPostBloc?.postApId == pvm.url
+  final post_bloc.PostBloc postBloc = _cachedPostBloc?.postApId == pvm!.url
       ? _cachedPostBloc!.postBloc
       : (_cachedPostBloc = (
           postApId: pvm.url,
@@ -238,7 +225,7 @@ Future<void> navigateToModlogPage(
 
   // Optional blocs
   final hasFeedBloc = context.findAncestorWidgetOfExactType<BlocProvider<FeedBloc>>();
-  final feedBloc = hasFeedBloc != null ? context.read<FeedBloc>() : FeedBloc(lemmyClient: lemmyClient ?? LemmyClient.instance);
+  final feedBloc = hasFeedBloc != null ? context.read<FeedBloc>() : FeedBloc(repository: LemmyPostRepository(client: lemmyClient?.lemmyApiV3 ?? LemmyClient.instance.lemmyApiV3));
 
   final state = thunderBloc.state;
   final reduceAnimations = state.reduceAnimations;
@@ -280,18 +267,8 @@ Future<void> navigateToComment(BuildContext context, ThunderComment comment) asy
   final ThunderState state = context.read<ThunderBloc>().state;
   final bool reduceAnimations = state.reduceAnimations;
 
-  final client = LemmyClient.instance.lemmyApiV3;
-  final account = await fetchActiveProfile();
-
-  GetPostResponse getPostResponse = await client.run(
-    GetPost(
-      auth: account.jwt,
-      id: comment.post?.id,
-      commentId: comment.id,
-    ),
-  );
-
-  List<ThunderPost> posts = await parsePosts([getPostResponse.postView]);
+  final repository = context.read<PostRepository>();
+  final post = await repository.getPost(comment.post!.id, commentId: comment.id);
 
   final SwipeablePageRoute route = SwipeablePageRoute(
     transitionDuration: isLoadingPageShown
@@ -310,7 +287,7 @@ Future<void> navigateToComment(BuildContext context, ThunderComment comment) asy
         BlocProvider(create: (context) => PostBloc()),
       ],
       child: PostPage(
-        initialPost: posts.first,
+        initialPost: post!,
         highlightedCommentId: comment.id,
         commentPath: comment.path,
         onPostUpdated: (ThunderPost post) {},
@@ -416,7 +393,7 @@ Future<void> navigateToCreatePostPage(
       builder: (navigatorContext) {
         return MultiBlocProvider(
           providers: [
-            feedBloc != null ? BlocProvider<FeedBloc>.value(value: feedBloc) : BlocProvider(create: (context) => FeedBloc(lemmyClient: LemmyClient.instance)),
+            feedBloc != null ? BlocProvider<FeedBloc>.value(value: feedBloc) : BlocProvider(create: (context) => FeedBloc()),
             if (postBloc != null) BlocProvider<PostBloc>.value(value: postBloc),
             BlocProvider<ThunderBloc>.value(value: thunderBloc),
             BlocProvider<ProfileBloc>.value(value: profileBloc),


### PR DESCRIPTION
## Pull Request Description

> Review with whitespace off

This PR introduces a base `PostRepository` abstract class, along with a Lemmy-specific implementation that handles all post-related interactions with the Lemmy API. I've integrated this new logic into the feed page, post page, and other areas that rely on post-related logic.

Additionally, with the abstract `PostRepository` class, we’ll be able to support other API implementations in the future (e.g., PieFed) and eventually allow Thunder to dynamically switch between repositories based on the connected instance.

Note: I've only done some basic tests here so I do expect there to be some bugs that come up!

<!--- Please describe what was changed -->

## Issue Being Fixed

<!-- Please describe the problem that is being fixed and, if applicable, reference a GitHub issue -->

Issue Number: N/A

## Screenshots / Recordings

<!-- This section is optional but highly recommended to show off your changes! -->

## Checklist

- [ ] If a new package was added, did you ensure it uses an appropriate license and is actively maintained?
- [ ] Did you use localized strings (and added appropriate descriptions) where applicable?
- [ ] Did you add `semanticLabel`s where applicable for accessibility?
