### PR TITLE
Re-introduce user selection when creating posts/comments

### DIFF
--- a/lib/comment/cubit/create_comment_cubit.dart
+++ b/lib/comment/cubit/create_comment_cubit.dart
@@ -1,6 +1,7 @@
+import 'package:flutter/foundation.dart';
+
 import 'package:bloc/bloc.dart';
 import 'package:equatable/equatable.dart';
-import 'package:flutter/foundation.dart';
 import 'package:lemmy_api_client/pictrs.dart';
 
 import 'package:thunder/account/account.dart';
@@ -26,6 +27,14 @@ class CreateCommentCubit extends Cubit<CreateCommentState> {
 
   Future<void> clearMessage() async {
     emit(state.copyWith(status: CreateCommentStatus.initial, message: null));
+  }
+
+  Future<void> switchAccount(Account newAccount) async {
+    account = newAccount;
+    repository = CommentRepositoryImpl(account: account);
+
+    debugPrint('Account switched to ${account.username}@${account.instance}');
+    emit(state.copyWith(status: CreateCommentStatus.success));
   }
 
   Future<void> uploadImages(List<String> imageFiles) async {

--- a/lib/comment/cubit/create_comment_cubit.dart
+++ b/lib/comment/cubit/create_comment_cubit.dart
@@ -8,7 +8,6 @@ import 'package:thunder/comment/models/thunder_comment.dart';
 import 'package:thunder/comment/repository/comment_repository.dart';
 import 'package:thunder/core/data_providers/piefed_api.dart';
 import 'package:thunder/core/enums/threadiverse_platform.dart';
-import 'package:thunder/localizations/app_localizations.dart';
 import 'package:thunder/utils/error_messages.dart';
 import 'package:thunder/utils/global_context.dart';
 

--- a/lib/comment/view/create_comment_page.dart
+++ b/lib/comment/view/create_comment_page.dart
@@ -444,13 +444,18 @@ class _CreateCommentPageState extends State<CreateCommentPage> {
                                       });
                                     },
                                     MarkdownType.community: () {
-                                      showCommunityInputDialog(context, title: l10n.community, onCommunitySelected: (ThunderCommunity community) {
-                                        _bodyTextController.text = _bodyTextController.text.replaceRange(
-                                          _bodyTextController.selection.end,
-                                          _bodyTextController.selection.end,
-                                          '!${community.name}@${fetchInstanceNameFromUrl(community.actorId)}',
-                                        );
-                                      });
+                                      showCommunityInputDialog(
+                                        context,
+                                        title: l10n.community,
+                                        account: account,
+                                        onCommunitySelected: (ThunderCommunity community) {
+                                          _bodyTextController.text = _bodyTextController.text.replaceRange(
+                                            _bodyTextController.selection.end,
+                                            _bodyTextController.selection.end,
+                                            '!${community.name}@${fetchInstanceNameFromUrl(community.actorId)}',
+                                          );
+                                        },
+                                      );
                                     },
                                   },
                                   imageIsLoading: state.status == CreateCommentStatus.imageUploadInProgress,

--- a/lib/comment/view/create_comment_page.dart
+++ b/lib/comment/view/create_comment_page.dart
@@ -26,7 +26,6 @@ import 'package:thunder/shared/input_dialogs.dart';
 import 'package:thunder/shared/language_selector.dart';
 import 'package:thunder/shared/snackbar.dart';
 import 'package:thunder/user/models/thunder_user.dart';
-import 'package:thunder/user/utils/restore_user.dart';
 import 'package:thunder/user/widgets/user_selector.dart';
 import 'package:thunder/utils/colors.dart';
 import 'package:thunder/utils/constants.dart';
@@ -60,6 +59,12 @@ class CreateCommentPage extends StatefulWidget {
 }
 
 class _CreateCommentPageState extends State<CreateCommentPage> {
+  /// The current account
+  Account? account;
+
+  /// The account's user information
+  ThunderUser? user;
+
   /// Holds the draft type associated with the comment. This type is determined by the input parameters passed in.
   /// If [comment], it will be [DraftType.commentEdit].
   /// If [post] or [parentComment] is passed in, it will be [DraftType.commentCreate].
@@ -101,9 +106,6 @@ class _CreateCommentPageState extends State<CreateCommentPage> {
   /// Whether to view source for posts or comments
   bool viewSource = false;
 
-  /// The active user that was selected when the page was opened
-  Account? originalUser;
-
   /// Whether the user was temporarily changed to create the comment
   bool userChanged = false;
 
@@ -119,6 +121,8 @@ class _CreateCommentPageState extends State<CreateCommentPage> {
   @override
   void initState() {
     super.initState();
+
+    account = context.read<ProfileBloc>().state.account;
 
     postId = widget.post?.id ?? widget.parentComment?.postId;
     parentCommentId = widget.parentComment?.id;
@@ -237,18 +241,11 @@ class _CreateCommentPageState extends State<CreateCommentPage> {
   Widget build(BuildContext context) {
     final l10n = AppLocalizations.of(context)!;
     final theme = Theme.of(context);
-    originalUser ??= context.read<ProfileBloc>().state.account;
-
-    final account = context.select<ProfileBloc, Account>((bloc) => bloc.state.account);
 
     return PopScope(
-      onPopInvokedWithResult: (didPop, result) {
-        if (context.mounted) {
-          restoreUser(context, originalUser);
-        }
-      },
+      onPopInvokedWithResult: (didPop, result) {},
       child: BlocProvider(
-        create: (context) => CreateCommentCubit(account: account),
+        create: (context) => CreateCommentCubit(account: account!),
         child: BlocConsumer<CreateCommentCubit, CreateCommentState>(
           listener: (context, state) {
             if (state.status == CreateCommentStatus.success && state.comment != null) {
@@ -348,7 +345,7 @@ class _CreateCommentPageState extends State<CreateCommentPage> {
                                   Padding(
                                     padding: const EdgeInsets.only(left: 16.0),
                                     child: UserSelector(
-                                      profileModalHeading: l10n.selectAccountToCommentAs,
+                                      account: account!,
                                       postActorId: widget.post?.apId,
                                       onPostChanged: (ThunderPost post) => postId = post.id,
                                       parentCommentActorId: widget.parentComment?.apId,
@@ -356,7 +353,14 @@ class _CreateCommentPageState extends State<CreateCommentPage> {
                                         postId = parentComment.postId;
                                         parentCommentId = parentComment.id;
                                       },
-                                      onUserChanged: () => userChanged = true,
+                                      onUserChanged: (account) {
+                                        setState(() {
+                                          userChanged = this.account?.instance != account.instance;
+                                          this.account = account;
+                                        });
+
+                                        context.read<CreateCommentCubit>().switchAccount(account);
+                                      },
                                       enableAccountSwitching: widget.comment == null,
                                     ),
                                   ),
@@ -438,7 +442,7 @@ class _CreateCommentPageState extends State<CreateCommentPage> {
                                       showUserInputDialog(
                                         context,
                                         title: l10n.username,
-                                        account: account,
+                                        account: account!,
                                         onUserSelected: (ThunderUser user) {
                                           _bodyTextController.text = _bodyTextController.text.replaceRange(
                                             _bodyTextController.selection.end,
@@ -452,7 +456,7 @@ class _CreateCommentPageState extends State<CreateCommentPage> {
                                       showCommunityInputDialog(
                                         context,
                                         title: l10n.community,
-                                        account: account,
+                                        account: account!,
                                         onCommunitySelected: (ThunderCommunity community) {
                                           _bodyTextController.text = _bodyTextController.text.replaceRange(
                                             _bodyTextController.selection.end,
@@ -565,18 +569,4 @@ class _CreateCommentPageState extends State<CreateCommentPage> {
           languageId: languageId,
         );
   }
-}
-
-@Deprecated('Use Draft model through database instead')
-class DraftComment {
-  String? text;
-  bool saveAsDraft = true;
-
-  DraftComment({this.text});
-
-  Map<String, dynamic> toJson() => {'text': text};
-
-  static DraftComment fromJson(Map<String, dynamic> json) => DraftComment(text: json['text']);
-
-  bool get isNotEmpty => text?.isNotEmpty == true;
 }

--- a/lib/comment/view/create_comment_page.dart
+++ b/lib/comment/view/create_comment_page.dart
@@ -435,13 +435,18 @@ class _CreateCommentPageState extends State<CreateCommentPage> {
                                   ],
                                   customTapActions: {
                                     MarkdownType.username: () {
-                                      showUserInputDialog(context, title: l10n.username, onUserSelected: (ThunderUser user) {
-                                        _bodyTextController.text = _bodyTextController.text.replaceRange(
-                                          _bodyTextController.selection.end,
-                                          _bodyTextController.selection.end,
-                                          '[@${user.name}@${fetchInstanceNameFromUrl(user.actorId)}](${user.actorId})',
-                                        );
-                                      });
+                                      showUserInputDialog(
+                                        context,
+                                        title: l10n.username,
+                                        account: account,
+                                        onUserSelected: (ThunderUser user) {
+                                          _bodyTextController.text = _bodyTextController.text.replaceRange(
+                                            _bodyTextController.selection.end,
+                                            _bodyTextController.selection.end,
+                                            '[@${user.name}@${fetchInstanceNameFromUrl(user.actorId)}](${user.actorId})',
+                                          );
+                                        },
+                                      );
                                     },
                                     MarkdownType.community: () {
                                       showCommunityInputDialog(

--- a/lib/community/pages/create_post_page.dart
+++ b/lib/community/pages/create_post_page.dart
@@ -7,17 +7,17 @@ import 'package:flutter/material.dart';
 
 // Package imports
 import 'package:flutter_bloc/flutter_bloc.dart';
-import 'package:thunder/community/models/thunder_community.dart';
-import 'package:thunder/core/enums/meta_search_type.dart';
-import 'package:thunder/core/enums/post_sort_type.dart';
-import 'package:thunder/core/models/thunder_language.dart';
-import 'package:thunder/localizations/app_localizations.dart';
 import 'package:flutter_keyboard_visibility/flutter_keyboard_visibility.dart';
 import 'package:flutter_typeahead/flutter_typeahead.dart';
 import 'package:link_preview_generator/link_preview_generator.dart';
 import 'package:markdown_editor/markdown_editor.dart';
 
 // Project imports
+import 'package:thunder/community/models/thunder_community.dart';
+import 'package:thunder/core/enums/meta_search_type.dart';
+import 'package:thunder/core/enums/post_sort_type.dart';
+import 'package:thunder/core/models/thunder_language.dart';
+import 'package:thunder/localizations/app_localizations.dart';
 import 'package:thunder/account/account.dart';
 import 'package:thunder/core/enums/enums.dart';
 import 'package:thunder/drafts/models/draft.dart';
@@ -38,15 +38,18 @@ import 'package:thunder/shared/language_selector.dart';
 import 'package:thunder/shared/media/media_view.dart';
 import 'package:thunder/shared/snackbar.dart';
 import 'package:thunder/user/models/thunder_user.dart';
-import 'package:thunder/user/utils/restore_user.dart';
 import 'package:thunder/user/widgets/user_selector.dart';
 import 'package:thunder/utils/colors.dart';
 import 'package:thunder/utils/debounce.dart';
+import 'package:thunder/utils/global_context.dart';
 import 'package:thunder/utils/instance.dart';
 import 'package:thunder/utils/media/image.dart';
 
 class CreatePostPage extends StatefulWidget {
+  /// The community ID to create the post in
   final int? communityId;
+
+  /// The community to create the post in
   final ThunderCommunity? community;
 
   /// Whether or not to pre-populate the post with the [title], [text], [image], [url], [customThumbnail], and/or [altText]
@@ -100,6 +103,12 @@ class CreatePostPage extends StatefulWidget {
 }
 
 class _CreatePostPageState extends State<CreatePostPage> {
+  /// The account to use for the post
+  Account? account;
+
+  /// The account's user information
+  ThunderUser? user;
+
   /// Holds the draft type associated with the post. This type is determined by the input parameters passed in.
   /// If [post] is passed in, this will be a [DraftType.postEdit].
   /// If [communityId] or [communityView] is passed in, this will be a [DraftType.postCreate].
@@ -148,6 +157,7 @@ class _CreatePostPageState extends State<CreatePostPage> {
   /// The id of the community that the post will be created in
   int? communityId;
 
+  /// The language ID for the post
   int? languageId;
 
   /// The community associated with the post. This is used to display the community information
@@ -169,12 +179,13 @@ class _CreatePostPageState extends State<CreatePostPage> {
   /// The keyboard visibility controller used to determine if the keyboard is visible at a given time
   final keyboardVisibilityController = KeyboardVisibilityController();
 
-  Account? originalUser;
   bool userChanged = false;
 
   @override
   void initState() {
     super.initState();
+
+    account = context.read<ProfileBloc>().state.account;
 
     communityId = widget.communityId;
 
@@ -377,16 +388,11 @@ class _CreatePostPageState extends State<CreatePostPage> {
 
   @override
   Widget build(BuildContext context) {
-    final l10n = AppLocalizations.of(context)!;
+    final l10n = GlobalContext.l10n;
     final theme = Theme.of(context);
-    originalUser ??= context.read<ProfileBloc>().state.account;
 
     return PopScope(
-      onPopInvokedWithResult: (didPop, result) {
-        if (context.mounted) {
-          restoreUser(context, originalUser);
-        }
-      },
+      onPopInvokedWithResult: (didPop, result) {},
       child: BlocConsumer<CreatePostCubit, CreatePostState>(
         listener: (context, state) {
           if (state.status == CreatePostStatus.success && state.post != null) {
@@ -436,6 +442,7 @@ class _CreatePostPageState extends State<CreatePostPage> {
                           padding: const EdgeInsets.only(left: 16.0, right: 16.0, top: 8.0),
                           child: Column(crossAxisAlignment: CrossAxisAlignment.start, children: <Widget>[
                             CommunitySelector(
+                              account: account!,
                               community: community,
                               onCommunitySelected: (ThunderCommunity c) {
                                 setState(() {
@@ -447,11 +454,9 @@ class _CreatePostPageState extends State<CreatePostPage> {
                             ),
                             const SizedBox(height: 4.0),
                             UserSelector(
-                              profileModalHeading: l10n.selectAccountToPostAs,
+                              account: account!,
                               communityActorId: community?.actorId,
                               onCommunityChanged: (community) {
-                                if (community == null) showSnackbar(l10n.unableToFindCommunityOnInstance);
-
                                 setState(() {
                                   communityId = community?.id;
                                   community = community;
@@ -459,7 +464,14 @@ class _CreatePostPageState extends State<CreatePostPage> {
 
                                 _validateSubmission();
                               },
-                              onUserChanged: () => userChanged = true,
+                              onUserChanged: (account) {
+                                setState(() {
+                                  userChanged = this.account?.instance != account.instance;
+                                  this.account = account;
+                                });
+
+                                context.read<CreatePostCubit>().switchAccount(account);
+                              },
                               enableAccountSwitching: widget.post == null,
                             ),
                             const SizedBox(height: 12.0),
@@ -639,9 +651,7 @@ class _CreatePostPageState extends State<CreatePostPage> {
                         ),
                       ),
                     ),
-                    const Divider(
-                      height: 1,
-                    ),
+                    const Divider(height: 1),
                     Container(
                       color: theme.cardColor,
                       margin: EdgeInsets.only(bottom: MediaQuery.of(context).viewInsets.bottom),
@@ -671,7 +681,7 @@ class _CreatePostPageState extends State<CreatePostPage> {
                                   showUserInputDialog(
                                     context,
                                     title: l10n.username,
-                                    account: context.read<ProfileBloc>().state.account,
+                                    account: account!,
                                     onUserSelected: (ThunderUser user) {
                                       _bodyTextController.text = _bodyTextController.text.replaceRange(
                                         _bodyTextController.selection.end,
@@ -685,7 +695,7 @@ class _CreatePostPageState extends State<CreatePostPage> {
                                   showCommunityInputDialog(
                                     context,
                                     title: l10n.community,
-                                    account: context.read<ProfileBloc>().state.account,
+                                    account: account!,
                                     onCommunitySelected: (community) {
                                       _bodyTextController.text = _bodyTextController.text
                                           .replaceRange(_bodyTextController.selection.end, _bodyTextController.selection.end, '!${community.name}@${fetchInstanceNameFromUrl(community.actorId)}');
@@ -767,10 +777,8 @@ class _CreatePostPageState extends State<CreatePostPage> {
     if (url != text) return;
 
     try {
-      final account = context.read<ProfileBloc>().state.account;
-
       // Fetch cross-posts
-      final response = await SearchRepositoryImpl(account: account).search(
+      final response = await SearchRepositoryImpl(account: account!).search(
         query: url,
         type: MetaSearchType.url,
         sort: PostSortType.topAll,
@@ -833,9 +841,13 @@ class _CreatePostPageState extends State<CreatePostPage> {
 class CommunitySelector extends StatefulWidget {
   const CommunitySelector({
     super.key,
+    required this.account,
     this.community,
     required this.onCommunitySelected,
   });
+
+  /// The account to use for the post
+  final Account account;
 
   /// The initial community to be passed in
   final ThunderCommunity? community;
@@ -860,7 +872,7 @@ class _CommunitySelectorState extends State<CommunitySelector> {
           showCommunityInputDialog(
             context,
             title: l10n.community,
-            account: context.read<ProfileBloc>().state.account,
+            account: widget.account,
             onCommunitySelected: widget.onCommunitySelected,
           );
         },
@@ -911,20 +923,4 @@ class _CommunitySelectorState extends State<CommunitySelector> {
       ),
     );
   }
-}
-
-@Deprecated('Use Draft model through database instead')
-class DraftPost {
-  String? title;
-  String? url;
-  String? text;
-  bool saveAsDraft = true;
-
-  DraftPost({this.title, this.url, this.text});
-
-  Map<String, dynamic> toJson() => {'title': title, 'url': url, 'text': text};
-
-  static DraftPost fromJson(Map<String, dynamic> json) => DraftPost(title: json['title'], url: json['url'], text: json['text']);
-
-  bool get isNotEmpty => title?.isNotEmpty == true || url?.isNotEmpty == true || text?.isNotEmpty == true;
 }

--- a/lib/community/pages/create_post_page.dart
+++ b/lib/community/pages/create_post_page.dart
@@ -668,13 +668,18 @@ class _CreatePostPageState extends State<CreatePostPage> {
                               ],
                               customTapActions: {
                                 MarkdownType.username: () {
-                                  showUserInputDialog(context, title: l10n.username, onUserSelected: (ThunderUser user) {
-                                    _bodyTextController.text = _bodyTextController.text.replaceRange(
-                                      _bodyTextController.selection.end,
-                                      _bodyTextController.selection.end,
-                                      '[@${user.name}@${fetchInstanceNameFromUrl(user.actorId)}](${user.actorId})',
-                                    );
-                                  });
+                                  showUserInputDialog(
+                                    context,
+                                    title: l10n.username,
+                                    account: context.read<ProfileBloc>().state.account,
+                                    onUserSelected: (ThunderUser user) {
+                                      _bodyTextController.text = _bodyTextController.text.replaceRange(
+                                        _bodyTextController.selection.end,
+                                        _bodyTextController.selection.end,
+                                        '[@${user.name}@${fetchInstanceNameFromUrl(user.actorId)}](${user.actorId})',
+                                      );
+                                    },
+                                  );
                                 },
                                 MarkdownType.community: () {
                                   showCommunityInputDialog(

--- a/lib/community/pages/create_post_page.dart
+++ b/lib/community/pages/create_post_page.dart
@@ -677,10 +677,15 @@ class _CreatePostPageState extends State<CreatePostPage> {
                                   });
                                 },
                                 MarkdownType.community: () {
-                                  showCommunityInputDialog(context, title: l10n.community, onCommunitySelected: (community) {
-                                    _bodyTextController.text = _bodyTextController.text
-                                        .replaceRange(_bodyTextController.selection.end, _bodyTextController.selection.end, '!${community.name}@${fetchInstanceNameFromUrl(community.actorId)}');
-                                  });
+                                  showCommunityInputDialog(
+                                    context,
+                                    title: l10n.community,
+                                    account: context.read<ProfileBloc>().state.account,
+                                    onCommunitySelected: (community) {
+                                      _bodyTextController.text = _bodyTextController.text
+                                          .replaceRange(_bodyTextController.selection.end, _bodyTextController.selection.end, '!${community.name}@${fetchInstanceNameFromUrl(community.actorId)}');
+                                    },
+                                  );
                                 },
                               },
                               imageIsLoading: state.status == CreatePostStatus.imageUploadInProgress,
@@ -850,6 +855,7 @@ class _CommunitySelectorState extends State<CommunitySelector> {
           showCommunityInputDialog(
             context,
             title: l10n.community,
+            account: context.read<ProfileBloc>().state.account,
             onCommunitySelected: widget.onCommunitySelected,
           );
         },

--- a/lib/community/widgets/community_header/community_header_actions.dart
+++ b/lib/community/widgets/community_header/community_header_actions.dart
@@ -10,6 +10,7 @@ import 'package:thunder/community/enums/community_action.dart';
 import 'package:thunder/community/models/thunder_community.dart';
 import 'package:thunder/core/enums/full_name.dart';
 import 'package:thunder/core/enums/subscription_status.dart';
+import 'package:thunder/core/enums/threadiverse_platform.dart';
 import 'package:thunder/core/models/models.dart';
 import 'package:thunder/feed/feed.dart';
 import 'package:thunder/feed/utils/community.dart';
@@ -119,13 +120,15 @@ class _ActionChipsList extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final account = context.read<ProfileBloc>().state.account;
+
     return Row(
       spacing: 8.0,
       children: [
         _SortActionChip(),
         ..._getAuthenticatedActions(context),
         _SearchActionChip(),
-        _ModlogActionChip(community: community),
+        if (account.platform == ThreadiversePlatform.lemmy) _ModlogActionChip(community: community),
         _ShareActionChip(community: community),
       ],
     );

--- a/lib/feed/widgets/feed_page_app_bar.dart
+++ b/lib/feed/widgets/feed_page_app_bar.dart
@@ -302,7 +302,7 @@ class FeedAppBarGeneralActions extends StatelessWidget {
               ThunderPopupMenuItem(
                 onTap: () async {
                   HapticFeedback.mediumImpact();
-                  await navigateToModlogPage(context, subtitle: 'TODO: Implement modlog subtitle');
+                  await navigateToModlogPage(context, subtitle: context.read<ProfileBloc>().state.account.instance);
                 },
                 icon: Icons.shield_rounded,
                 title: l10n.modlog,

--- a/lib/feed/widgets/tagline.dart
+++ b/lib/feed/widgets/tagline.dart
@@ -5,6 +5,7 @@ import 'package:flutter/material.dart';
 import 'package:expandable/expandable.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 
+import 'package:thunder/account/bloc/profile_bloc.dart';
 import 'package:thunder/localizations/app_localizations.dart';
 import 'package:thunder/shared/common_markdown_body.dart';
 import 'package:thunder/thunder/bloc/thunder_bloc.dart';
@@ -31,8 +32,8 @@ class _TagLineState extends State<TagLine> {
   void initState() {
     super.initState();
 
-    // final site = LemmyClient.instance.site;
-    // tagline = site?.taglines.isNotEmpty == true ? site?.taglines[Random().nextInt(site.taglines.length)].content : null;
+    final taglines = context.read<ProfileBloc>().state.siteResponse?.taglines;
+    tagline = taglines?.isNotEmpty == true ? taglines![Random().nextInt(taglines.length - 1)].content : null;
 
     // Check if the tagline is long enough to be truncated after the first frame is rendered.
     // This is necessary because the size of the text is not available until after the first frame.

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -33,11 +33,11 @@
   "@accountSettingsImportedSuccessfully": {
     "description": "Message shown to user when account settings are imported successfully"
   },
-  "accountSwitchParentCommentNotFound": "The selected comment was not found on '{instance}'. Switching back to previous account.",
+  "accountSwitchParentCommentNotFound": "The selected comment was not found on '{instance}'",
   "@accountSwitchParentCommentNotFound": {
     "description": "Error message for when we couldn't resolve comment to reply to"
   },
-  "accountSwitchPostNotFound": "The selected post was not found on '{instance}'. Switching back to previous account.",
+  "accountSwitchPostNotFound": "The selected post was not found on '{instance}'",
   "@accountSwitchPostNotFound": {
     "description": "Error message for when we couldn't resolve post to reply to"
   },

--- a/lib/localizations/app_localizations.dart
+++ b/lib/localizations/app_localizations.dart
@@ -203,13 +203,13 @@ abstract class AppLocalizations {
   /// Error message for when we couldn't resolve comment to reply to
   ///
   /// In en, this message translates to:
-  /// **'The selected comment was not found on \'{instance}\'. Switching back to previous account.'**
+  /// **'The selected comment was not found on \'{instance}\''**
   String accountSwitchParentCommentNotFound(Object instance);
 
   /// Error message for when we couldn't resolve post to reply to
   ///
   /// In en, this message translates to:
-  /// **'The selected post was not found on \'{instance}\'. Switching back to previous account.'**
+  /// **'The selected post was not found on \'{instance}\''**
   String accountSwitchPostNotFound(Object instance);
 
   /// Setting heading for action colors

--- a/lib/localizations/app_localizations_cs.dart
+++ b/lib/localizations/app_localizations_cs.dart
@@ -56,12 +56,12 @@ class AppLocalizationsCs extends AppLocalizations {
 
   @override
   String accountSwitchParentCommentNotFound(Object instance) {
-    return 'The selected comment was not found on \'$instance\'. Switching back to previous account.';
+    return 'The selected comment was not found on \'$instance\'';
   }
 
   @override
   String accountSwitchPostNotFound(Object instance) {
-    return 'The selected post was not found on \'$instance\'. Switching back to previous account.';
+    return 'The selected post was not found on \'$instance\'';
   }
 
   @override

--- a/lib/localizations/app_localizations_en.dart
+++ b/lib/localizations/app_localizations_en.dart
@@ -56,12 +56,12 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String accountSwitchParentCommentNotFound(Object instance) {
-    return 'The selected comment was not found on \'$instance\'. Switching back to previous account.';
+    return 'The selected comment was not found on \'$instance\'';
   }
 
   @override
   String accountSwitchPostNotFound(Object instance) {
-    return 'The selected post was not found on \'$instance\'. Switching back to previous account.';
+    return 'The selected post was not found on \'$instance\'';
   }
 
   @override

--- a/lib/localizations/app_localizations_eo.dart
+++ b/lib/localizations/app_localizations_eo.dart
@@ -49,12 +49,12 @@ class AppLocalizationsEo extends AppLocalizations {
 
   @override
   String accountSwitchParentCommentNotFound(Object instance) {
-    return 'The selected comment was not found on \'$instance\'. Switching back to previous account.';
+    return 'The selected comment was not found on \'$instance\'';
   }
 
   @override
   String accountSwitchPostNotFound(Object instance) {
-    return 'The selected post was not found on \'$instance\'. Switching back to previous account.';
+    return 'The selected post was not found on \'$instance\'';
   }
 
   @override

--- a/lib/localizations/app_localizations_fi.dart
+++ b/lib/localizations/app_localizations_fi.dart
@@ -49,12 +49,12 @@ class AppLocalizationsFi extends AppLocalizations {
 
   @override
   String accountSwitchParentCommentNotFound(Object instance) {
-    return 'The selected comment was not found on \'$instance\'. Switching back to previous account.';
+    return 'The selected comment was not found on \'$instance\'';
   }
 
   @override
   String accountSwitchPostNotFound(Object instance) {
-    return 'The selected post was not found on \'$instance\'. Switching back to previous account.';
+    return 'The selected post was not found on \'$instance\'';
   }
 
   @override

--- a/lib/localizations/app_localizations_hu.dart
+++ b/lib/localizations/app_localizations_hu.dart
@@ -56,12 +56,12 @@ class AppLocalizationsHu extends AppLocalizations {
 
   @override
   String accountSwitchParentCommentNotFound(Object instance) {
-    return 'The selected comment was not found on \'$instance\'. Switching back to previous account.';
+    return 'The selected comment was not found on \'$instance\'';
   }
 
   @override
   String accountSwitchPostNotFound(Object instance) {
-    return 'The selected post was not found on \'$instance\'. Switching back to previous account.';
+    return 'The selected post was not found on \'$instance\'';
   }
 
   @override

--- a/lib/localizations/app_localizations_nb.dart
+++ b/lib/localizations/app_localizations_nb.dart
@@ -49,12 +49,12 @@ class AppLocalizationsNb extends AppLocalizations {
 
   @override
   String accountSwitchParentCommentNotFound(Object instance) {
-    return 'The selected comment was not found on \'$instance\'. Switching back to previous account.';
+    return 'The selected comment was not found on \'$instance\'';
   }
 
   @override
   String accountSwitchPostNotFound(Object instance) {
-    return 'The selected post was not found on \'$instance\'. Switching back to previous account.';
+    return 'The selected post was not found on \'$instance\'';
   }
 
   @override

--- a/lib/localizations/app_localizations_nl.dart
+++ b/lib/localizations/app_localizations_nl.dart
@@ -60,7 +60,7 @@ class AppLocalizationsNl extends AppLocalizations {
 
   @override
   String accountSwitchPostNotFound(Object instance) {
-    return 'The selected post was not found on \'$instance\'. Switching back to previous account.';
+    return 'The selected post was not found on \'$instance\'';
   }
 
   @override

--- a/lib/localizations/app_localizations_pl.dart
+++ b/lib/localizations/app_localizations_pl.dart
@@ -56,7 +56,7 @@ class AppLocalizationsPl extends AppLocalizations {
 
   @override
   String accountSwitchParentCommentNotFound(Object instance) {
-    return 'The selected comment was not found on \'$instance\'. Switching back to previous account.';
+    return 'The selected comment was not found on \'$instance\'';
   }
 
   @override

--- a/lib/localizations/app_localizations_ru.dart
+++ b/lib/localizations/app_localizations_ru.dart
@@ -56,12 +56,12 @@ class AppLocalizationsRu extends AppLocalizations {
 
   @override
   String accountSwitchParentCommentNotFound(Object instance) {
-    return 'The selected comment was not found on \'$instance\'. Switching back to previous account.';
+    return 'The selected comment was not found on \'$instance\'';
   }
 
   @override
   String accountSwitchPostNotFound(Object instance) {
-    return 'The selected post was not found on \'$instance\'. Switching back to previous account.';
+    return 'The selected post was not found on \'$instance\'';
   }
 
   @override

--- a/lib/localizations/app_localizations_sk.dart
+++ b/lib/localizations/app_localizations_sk.dart
@@ -56,12 +56,12 @@ class AppLocalizationsSk extends AppLocalizations {
 
   @override
   String accountSwitchParentCommentNotFound(Object instance) {
-    return 'The selected comment was not found on \'$instance\'. Switching back to previous account.';
+    return 'The selected comment was not found on \'$instance\'';
   }
 
   @override
   String accountSwitchPostNotFound(Object instance) {
-    return 'The selected post was not found on \'$instance\'. Switching back to previous account.';
+    return 'The selected post was not found on \'$instance\'';
   }
 
   @override

--- a/lib/localizations/app_localizations_sv.dart
+++ b/lib/localizations/app_localizations_sv.dart
@@ -49,12 +49,12 @@ class AppLocalizationsSv extends AppLocalizations {
 
   @override
   String accountSwitchParentCommentNotFound(Object instance) {
-    return 'The selected comment was not found on \'$instance\'. Switching back to previous account.';
+    return 'The selected comment was not found on \'$instance\'';
   }
 
   @override
   String accountSwitchPostNotFound(Object instance) {
-    return 'The selected post was not found on \'$instance\'. Switching back to previous account.';
+    return 'The selected post was not found on \'$instance\'';
   }
 
   @override

--- a/lib/localizations/app_localizations_uk.dart
+++ b/lib/localizations/app_localizations_uk.dart
@@ -56,12 +56,12 @@ class AppLocalizationsUk extends AppLocalizations {
 
   @override
   String accountSwitchParentCommentNotFound(Object instance) {
-    return 'The selected comment was not found on \'$instance\'. Switching back to previous account.';
+    return 'The selected comment was not found on \'$instance\'';
   }
 
   @override
   String accountSwitchPostNotFound(Object instance) {
-    return 'The selected post was not found on \'$instance\'. Switching back to previous account.';
+    return 'The selected post was not found on \'$instance\'';
   }
 
   @override

--- a/lib/localizations/app_localizations_zh.dart
+++ b/lib/localizations/app_localizations_zh.dart
@@ -56,12 +56,12 @@ class AppLocalizationsZh extends AppLocalizations {
 
   @override
   String accountSwitchParentCommentNotFound(Object instance) {
-    return 'The selected comment was not found on \'$instance\'. Switching back to previous account.';
+    return 'The selected comment was not found on \'$instance\'';
   }
 
   @override
   String accountSwitchPostNotFound(Object instance) {
-    return 'The selected post was not found on \'$instance\'. Switching back to previous account.';
+    return 'The selected post was not found on \'$instance\'';
   }
 
   @override

--- a/lib/moderator/widgets/report_page_filter_bottom_sheet.dart
+++ b/lib/moderator/widgets/report_page_filter_bottom_sheet.dart
@@ -1,7 +1,10 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
-import 'package:thunder/community/models/thunder_community.dart';
 
+import 'package:flutter_bloc/flutter_bloc.dart';
+
+import 'package:thunder/account/bloc/profile_bloc.dart';
+import 'package:thunder/community/models/thunder_community.dart';
 import 'package:thunder/localizations/app_localizations.dart';
 import 'package:thunder/community/pages/create_post_page.dart';
 
@@ -77,6 +80,7 @@ class _ReportFilterBottomSheetState extends State<ReportFilterBottomSheet> {
             Text(l10n.community, style: const TextStyle(fontWeight: FontWeight.bold)),
             const SizedBox(height: 8.0),
             CommunitySelector(
+              account: context.read<ProfileBloc>().state.account,
               community: community,
               onCommunitySelected: (ThunderCommunity c) {
                 setState(() => community = c);

--- a/lib/post/cubit/create_post_cubit.dart
+++ b/lib/post/cubit/create_post_cubit.dart
@@ -29,6 +29,15 @@ class CreatePostCubit extends Cubit<CreatePostState> {
     emit(state.copyWith(status: CreatePostStatus.initial, message: null));
   }
 
+  /// Switches the account for the post.
+  Future<void> switchAccount(Account newAccount) async {
+    account = newAccount;
+    repository = PostRepositoryImpl(account: account);
+
+    debugPrint('Account switched to ${account.username}@${account.instance}');
+    emit(state.copyWith(status: CreatePostStatus.success));
+  }
+
   Future<void> uploadImages(List<String> imageFiles, {bool isPostImage = false}) async {
     final l10n = GlobalContext.l10n;
     if (account.anonymous) throw Exception(l10n.userNotLoggedIn);

--- a/lib/post/widgets/post_page_app_bar.dart
+++ b/lib/post/widgets/post_page_app_bar.dart
@@ -240,19 +240,20 @@ class PostAppBarActions extends StatelessWidget {
                 icon: Icons.select_all_rounded,
                 title: l10n.selectText,
               ),
-              ThunderPopupMenuItem(
-                onTap: () async {
-                  await temporarilySwitchAccount(
-                    context,
-                    profileModalHeading: l10n.viewPostAsDifferentAccount,
-                    onUserChanged: onUserChanged,
-                    postActorId: context.read<PostBloc>().state.post?.apId,
-                    onPostChanged: onPostChanged,
-                  );
-                },
-                icon: Icons.people_alt_rounded,
-                title: l10n.viewPostAsDifferentAccount,
-              ),
+              // TODO: Add this back once switching accounts is fixed
+              // ThunderPopupMenuItem(
+              //   onTap: () async {
+              //     await temporarilySwitchAccount(
+              //       context,
+              //       profileModalHeading: l10n.viewPostAsDifferentAccount,
+              //       onUserChanged: onUserChanged,
+              //       postActorId: context.read<PostBloc>().state.post?.apId,
+              //       onPostChanged: onPostChanged,
+              //     );
+              //   },
+              //   icon: Icons.people_alt_rounded,
+              //   title: l10n.viewPostAsDifferentAccount,
+              // ),
               if (state.post?.media.first.mediaType == MediaType.link && state.post!.media.first.originalUrl?.isNotEmpty == true)
                 ThunderPopupMenuItem(
                   onTap: () {

--- a/lib/search/pages/search_page.dart
+++ b/lib/search/pages/search_page.dart
@@ -403,18 +403,23 @@ class _SearchPageState extends State<SearchPage> with AutomaticKeepAliveClientMi
                                       });
                                       _doSearch();
                                     } else {
-                                      showCommunityInputDialog(context, title: l10n.community, onCommunitySelected: (ThunderCommunity community) {
-                                        setState(() {
-                                          _currentCommunityFilter = community.id;
-                                          _currentCommunityFilterName = generateCommunityFullName(
-                                            context,
-                                            community.name,
-                                            community.title,
-                                            fetchInstanceNameFromUrl(community.actorId),
-                                          );
-                                        });
-                                        _doSearch();
-                                      });
+                                      showCommunityInputDialog(
+                                        context,
+                                        title: l10n.community,
+                                        account: account,
+                                        onCommunitySelected: (ThunderCommunity community) {
+                                          setState(() {
+                                            _currentCommunityFilter = community.id;
+                                            _currentCommunityFilterName = generateCommunityFullName(
+                                              context,
+                                              community.name,
+                                              community.title,
+                                              fetchInstanceNameFromUrl(community.actorId),
+                                            );
+                                          });
+                                          _doSearch();
+                                        },
+                                      );
                                     }
                                   },
                                 ),

--- a/lib/search/pages/search_page.dart
+++ b/lib/search/pages/search_page.dart
@@ -438,18 +438,23 @@ class _SearchPageState extends State<SearchPage> with AutomaticKeepAliveClientMi
                                     });
                                     _doSearch();
                                   } else {
-                                    showUserInputDialog(context, title: l10n.creator, onUserSelected: (user) {
-                                      setState(() {
-                                        _currentCreatorFilter = user.id;
-                                        _currentCreatorFilterName = generateUserFullName(
-                                          context,
-                                          user.name,
-                                          user.displayName,
-                                          fetchInstanceNameFromUrl(user.actorId),
-                                        );
-                                      });
-                                      _doSearch();
-                                    });
+                                    showUserInputDialog(
+                                      context,
+                                      title: l10n.creator,
+                                      account: account,
+                                      onUserSelected: (user) {
+                                        setState(() {
+                                          _currentCreatorFilter = user.id;
+                                          _currentCreatorFilterName = generateUserFullName(
+                                            context,
+                                            user.name,
+                                            user.displayName,
+                                            fetchInstanceNameFromUrl(user.actorId),
+                                          );
+                                        });
+                                        _doSearch();
+                                      },
+                                    );
                                   }
                                 },
                               ),

--- a/lib/settings/pages/user_labels_settings_page.dart
+++ b/lib/settings/pages/user_labels_settings_page.dart
@@ -1,11 +1,14 @@
 import 'dart:async';
 
-import 'package:collection/collection.dart';
 import 'package:flutter/material.dart';
-import 'package:thunder/localizations/app_localizations.dart';
-import 'package:smooth_highlight/smooth_highlight.dart';
-import 'package:thunder/user/models/user_label.dart';
 
+import 'package:collection/collection.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:smooth_highlight/smooth_highlight.dart';
+
+import 'package:thunder/account/bloc/profile_bloc.dart';
+import 'package:thunder/localizations/app_localizations.dart';
+import 'package:thunder/user/models/user_label.dart';
 import 'package:thunder/core/enums/local_settings.dart';
 import 'package:thunder/post/utils/user_label_utils.dart';
 import 'package:thunder/shared/dialogs.dart';
@@ -89,6 +92,7 @@ class _UserLabelSettingsPageState extends State<UserLabelSettingsPage> with Sing
           showUserInputDialog(
             context,
             title: l10n.username,
+            account: context.read<ProfileBloc>().state.account,
             onUserSelected: (user) async {
               // Then show the label editor
               ({UserLabel? userLabel, bool deleted}) result = await showUserLabelEditorDialog(context, UserLabel.usernameFromParts(user.name, user.actorId));

--- a/lib/shared/input_dialogs.dart
+++ b/lib/shared/input_dialogs.dart
@@ -34,33 +34,40 @@ import 'package:thunder/utils/instance.dart';
 import 'package:thunder/utils/numbers.dart';
 
 /// Shows a dialog which allows typing/search for a user
-void showUserInputDialog(BuildContext context, {required String title, required void Function(ThunderUser) onUserSelected}) async {
-  final l10n = AppLocalizations.of(context)!;
+void showUserInputDialog(
+  BuildContext context, {
+  required String title,
+  required Account account,
+  required void Function(ThunderUser) onUserSelected,
+}) async {
+  final l10n = GlobalContext.l10n;
 
   Future<String?> onSubmitted({ThunderUser? payload, String? value}) async {
+    if (payload == null && value == null) return null;
+
     if (payload != null) {
       onUserSelected(payload);
       Navigator.of(context).pop();
-    } else if (value != null) {
-      // Normalize the username
-      final normalizedUsername = await getLemmyUser(value);
+      return null;
+    }
 
-      if (normalizedUsername != null) {
-        try {
-          final account = context.read<ProfileBloc>().state.account;
-          final response = await UserRepositoryImpl(account: account).getUser(username: normalizedUsername);
-          final user = response!['user'];
+    // Normalize the username
+    final normalizedUsername = await getLemmyUser(value!);
 
-          onUserSelected(user);
-          Navigator.of(context).pop();
-        } catch (e) {
-          return l10n.unableToFindUser;
-        }
-      } else {
+    if (normalizedUsername != null) {
+      try {
+        final response = await UserRepositoryImpl(account: account).getUser(username: normalizedUsername);
+        final user = response!['user'];
+
+        onUserSelected(user);
+        Navigator.of(context).pop();
+        return null;
+      } catch (e) {
         return l10n.unableToFindUser;
       }
     }
-    return null;
+
+    return l10n.unableToFindUser;
   }
 
   showInputDialog<ThunderUser>(
@@ -68,15 +75,18 @@ void showUserInputDialog(BuildContext context, {required String title, required 
     title: title,
     inputLabel: l10n.username,
     onSubmitted: onSubmitted,
-    getSuggestions: (query) => getUserSuggestions(context, query),
+    getSuggestions: (query) => getUserSuggestions(context, query: query, account: account),
     suggestionBuilder: (payload) => buildUserSuggestionWidget(context, payload),
   );
 }
 
-Future<List<ThunderUser>> getUserSuggestions(BuildContext context, String query) async {
-  if (query.isNotEmpty != true) return [];
+Future<List<ThunderUser>> getUserSuggestions(
+  BuildContext context, {
+  required String query,
+  required Account account,
+}) async {
+  if (query.isEmpty) return [];
 
-  final account = context.read<ProfileBloc>().state.account;
   final response = await SearchRepositoryImpl(account: account).search(
     query: query,
     type: MetaSearchType.users,
@@ -121,7 +131,10 @@ Widget buildUserSuggestionWidget(BuildContext context, ThunderUser payload, {voi
   );
 }
 
-/// Shows a dialog which allows typing/search for a community
+/// Shows a dialog which allows typing/search for a community.
+/// Given an [account], the dialog will show subscriptions and favorites of that account.
+///
+/// When searching for communities, it will use the provided [account]'s instance.
 void showCommunityInputDialog(
   BuildContext context, {
   required String title,

--- a/lib/shared/input_dialogs.dart
+++ b/lib/shared/input_dialogs.dart
@@ -8,6 +8,8 @@ import 'package:flutter_typeahead/flutter_typeahead.dart';
 import 'package:lemmy_api_client/v3.dart';
 import 'package:collection/collection.dart';
 
+import 'package:thunder/account/repository/account_repository.dart';
+import 'package:thunder/community/models/favourite.dart';
 import 'package:thunder/community/models/thunder_community.dart';
 import 'package:thunder/community/repository/community_repository.dart';
 import 'package:thunder/core/enums/meta_search_type.dart';
@@ -27,6 +29,7 @@ import 'package:thunder/shared/full_name_widgets.dart';
 import 'package:thunder/shared/marquee_widget.dart';
 import 'package:thunder/user/models/thunder_user.dart';
 import 'package:thunder/user/repository/user_repository.dart';
+import 'package:thunder/utils/global_context.dart';
 import 'package:thunder/utils/instance.dart';
 import 'package:thunder/utils/numbers.dart';
 
@@ -119,41 +122,54 @@ Widget buildUserSuggestionWidget(BuildContext context, ThunderUser payload, {voi
 }
 
 /// Shows a dialog which allows typing/search for a community
-void showCommunityInputDialog(BuildContext context, {required String title, required void Function(ThunderCommunity) onCommunitySelected, List<ThunderCommunity>? emptySuggestions}) async {
-  final l10n = AppLocalizations.of(context)!;
+void showCommunityInputDialog(
+  BuildContext context, {
+  required String title,
+  required Account account,
+  required void Function(ThunderCommunity community) onCommunitySelected,
+  List<ThunderCommunity>? emptySuggestions,
+}) async {
+  final l10n = GlobalContext.l10n;
+
+  List<ThunderCommunity>? favoritedCommunities;
 
   try {
-    final state = context.read<ProfileBloc>().state;
-    emptySuggestions ??= state.subscriptions;
-    emptySuggestions = prioritizeFavorites(emptySuggestions.toList(), state.favorites);
+    // Fetch subscriptions from the given account
+    final favorites = await Favorite.favorites(account.id);
+    final subscriptions = await AccountRepositoryImpl(account: account).subscriptions();
+    favoritedCommunities = subscriptions.where((community) => favorites.any((favorite) => favorite.communityId == community.id)).toList();
+
+    emptySuggestions ??= prioritizeFavorites(subscriptions, favoritedCommunities);
   } catch (e) {
-    // If we can't read the AccountBloc here, for whatever reason, it's ok. No need for subscriptions.
+    // If this is unavailable, continue
   }
 
   Future<String?> onSubmitted({ThunderCommunity? payload, String? value}) async {
+    if (payload == null && value == null) return null;
+
     if (payload != null) {
       onCommunitySelected(payload);
       Navigator.of(context).pop();
-    } else if (value != null) {
-      // Normalize the community name
-      final normalizedCommunity = await getLemmyCommunity(value);
+      return null;
+    }
 
-      if (normalizedCommunity != null) {
-        try {
-          final account = context.read<ProfileBloc>().state.account;
-          final response = await CommunityRepositoryImpl(account: account).getCommunity(name: normalizedCommunity);
-          final community = response['community'];
+    // Normalize the community name
+    final normalizedCommunity = await getLemmyCommunity(value!);
 
-          onCommunitySelected(community);
-          Navigator.of(context).pop();
-        } catch (e) {
-          return l10n.unableToFindCommunity;
-        }
-      } else {
+    if (normalizedCommunity != null) {
+      try {
+        final response = await CommunityRepositoryImpl(account: account).getCommunity(name: normalizedCommunity);
+        final community = response['community'];
+
+        onCommunitySelected(community);
+        Navigator.of(context).pop();
+        return null;
+      } catch (e) {
         return l10n.unableToFindCommunity;
       }
     }
-    return null;
+
+    return l10n.unableToFindCommunity;
   }
 
   showInputDialog<ThunderCommunity>(
@@ -161,15 +177,20 @@ void showCommunityInputDialog(BuildContext context, {required String title, requ
     title: title,
     inputLabel: l10n.community,
     onSubmitted: onSubmitted,
-    getSuggestions: (query) => getCommunitySuggestions(context, query, emptySuggestions),
+    getSuggestions: (query) => getCommunitySuggestions(context, query: query, account: account, emptySuggestions: emptySuggestions, favoritedCommunities: favoritedCommunities),
     suggestionBuilder: (payload) => buildCommunitySuggestionWidget(context, payload),
   );
 }
 
-Future<List<ThunderCommunity>> getCommunitySuggestions(BuildContext context, String query, List<ThunderCommunity>? emptySuggestions) async {
-  if (query.isNotEmpty != true) return emptySuggestions ?? [];
+Future<List<ThunderCommunity>> getCommunitySuggestions(
+  BuildContext context, {
+  required String query,
+  required Account account,
+  List<ThunderCommunity>? favoritedCommunities,
+  List<ThunderCommunity>? emptySuggestions,
+}) async {
+  if (query.isEmpty) return emptySuggestions ?? [];
 
-  final account = context.read<ProfileBloc>().state.account;
   final response = await SearchRepositoryImpl(account: account).search(
     query: query,
     type: MetaSearchType.communities,
@@ -177,21 +198,11 @@ Future<List<ThunderCommunity>> getCommunitySuggestions(BuildContext context, Str
     sort: PostSortType.topAll,
   );
 
-  List<ThunderCommunity>? favorites;
-
-  if (context.mounted) {
-    try {
-      favorites = context.read<ProfileBloc>().state.favorites;
-    } catch (e) {
-      // Don't worry if we can't fetch favorites
-    }
-  }
-
-  return prioritizeFavorites(response['communities'], favorites) ?? [];
+  return prioritizeFavorites(response['communities'], favoritedCommunities) ?? [];
 }
 
 Widget buildCommunitySuggestionWidget(BuildContext context, ThunderCommunity payload, {void Function(ThunderCommunity)? onSelected}) {
-  final l10n = AppLocalizations.of(context)!;
+  final l10n = GlobalContext.l10n;
 
   return Tooltip(
     message: generateCommunityFullName(
@@ -224,27 +235,25 @@ Widget buildCommunitySuggestionWidget(BuildContext context, ThunderCommunity pay
                   useDisplayName: false,
                 ),
               ),
-              Row(
-                children: [
-                  if (payload.subscribers != null) ...[
-                    const Icon(Icons.people_rounded, size: 16),
-                    const SizedBox(width: 5),
+              if (payload.subscribed != null && payload.subscribers != null) ...[
+                Row(
+                  children: [
+                    Icon(Icons.people_rounded, size: 16.0),
+                    SizedBox(width: 5.0),
                     Text(formatNumberToK(payload.subscribers ?? -1)),
-                  ],
-                  if (payload.subscribed != null) ...[
                     Text(' · ${switch (payload.subscribed) {
                       SubscriptionStatus.pending => l10n.pending,
                       SubscriptionStatus.subscribed => l10n.subscribed,
                       SubscriptionStatus.notSubscribed => '',
                       _ => '',
                     }}'),
+                    if (_getFavoriteStatus(context, payload)) ...[
+                      Text(' · '),
+                      Icon(Icons.star_rounded, size: 15.0),
+                    ],
                   ],
-                  if (_getFavoriteStatus(context, payload)) ...const [
-                    Text(' · '),
-                    Icon(Icons.star_rounded, size: 15),
-                  ],
-                ],
-              )
+                )
+              ],
             ],
           ),
         ),

--- a/lib/user/pages/user_settings_block_page.dart
+++ b/lib/user/pages/user_settings_block_page.dart
@@ -1,8 +1,9 @@
 import 'package:flutter/material.dart';
 
 import 'package:flutter_bloc/flutter_bloc.dart';
-import 'package:thunder/localizations/app_localizations.dart';
 
+import 'package:thunder/account/bloc/profile_bloc.dart';
+import 'package:thunder/localizations/app_localizations.dart';
 import 'package:thunder/core/enums/full_name.dart';
 import 'package:thunder/community/models/thunder_community.dart';
 import 'package:thunder/feed/view/feed_page.dart';
@@ -198,6 +199,7 @@ class _UserSettingsBlockPageState extends State<UserSettingsBlockPage> with Sing
               showCommunityInputDialog(
                 context,
                 title: l10n.blockCommunity,
+                account: context.read<ProfileBloc>().state.account,
                 onCommunitySelected: (ThunderCommunity community) {
                   context.read<UserSettingsBloc>().add(UnblockCommunityEvent(communityId: community.id, unblock: false));
                 },

--- a/lib/user/pages/user_settings_block_page.dart
+++ b/lib/user/pages/user_settings_block_page.dart
@@ -190,6 +190,7 @@ class _UserSettingsBlockPageState extends State<UserSettingsBlockPage> with Sing
               showUserInputDialog(
                 context,
                 title: l10n.blockUser,
+                account: context.read<ProfileBloc>().state.account,
                 onUserSelected: (user) {
                   context.read<UserSettingsBloc>().add(UnblockPersonEvent(personId: user.id, unblock: false));
                 },

--- a/lib/user/widgets/user_indicator.dart
+++ b/lib/user/widgets/user_indicator.dart
@@ -1,8 +1,8 @@
 import 'package:flutter/material.dart';
 
 import 'package:flutter_bloc/flutter_bloc.dart';
-import 'package:thunder/localizations/app_localizations.dart';
 
+import 'package:thunder/localizations/app_localizations.dart';
 import 'package:thunder/account/account.dart';
 import 'package:thunder/shared/avatars/user_avatar.dart';
 import 'package:thunder/shared/full_name_widgets.dart';
@@ -10,7 +10,10 @@ import 'package:thunder/user/models/thunder_user.dart';
 import 'package:thunder/utils/instance.dart';
 
 class UserIndicator extends StatefulWidget {
-  const UserIndicator({super.key});
+  /// The user to display.
+  final ThunderUser? user;
+
+  const UserIndicator({super.key, this.user});
 
   @override
   State<StatefulWidget> createState() => _UserIndicatorState();
@@ -27,12 +30,22 @@ class _UserIndicatorState extends State<UserIndicator> {
   void initState() {
     super.initState();
 
+    if (widget.user != null) return setState(() => user = widget.user);
+
     final state = context.read<ProfileBloc>().state;
 
     if (state.user != null) {
       setState(() => user = state.user);
     } else {
       context.read<ProfileBloc>().add(const FetchProfileInformation());
+    }
+  }
+
+  @override
+  void didUpdateWidget(UserIndicator oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (oldWidget.user?.id != widget.user?.id) {
+      setState(() => user = widget.user);
     }
   }
 

--- a/lib/user/widgets/user_selector.dart
+++ b/lib/user/widgets/user_selector.dart
@@ -1,46 +1,131 @@
 import 'package:flutter/material.dart';
 
-import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:thunder/comment/models/thunder_comment.dart';
 import 'package:thunder/community/models/thunder_community.dart';
-
-import 'package:thunder/localizations/app_localizations.dart';
 import 'package:thunder/account/account.dart';
 import 'package:thunder/post/models/thunder_post.dart';
 import 'package:thunder/post/utils/post.dart';
 import 'package:thunder/search/repository/search_repository.dart';
 import 'package:thunder/shared/snackbar.dart';
+import 'package:thunder/user/models/thunder_user.dart';
+import 'package:thunder/user/repository/user_repository.dart';
 import 'package:thunder/user/widgets/user_indicator.dart';
+import 'package:thunder/utils/global_context.dart';
 
-/// Creates a widget which displays a preview of the currently selected account, with the ability to change accounts.
+/// A widget that displays the currently selected user account with the ability to switch between accounts.
 ///
-/// By passing in a [communityActorId], it will attempt to resolve the community to the new user's instance (if changed),
-/// and will invoke [onCommunityChanged]. If the community could not be resolved, the callback will pass [null].
+/// This widget provides a method for switching between different user accounts and ensures that the
+/// target community, post, or comment is federated to the new account's instance before allowing
+/// the switch. If the content cannot be resolved on the new instance, the switch is blocked.
+///
+/// **Usage Examples:**
+///
+/// For creating a post in a community:
+/// ```dart
+/// UserSelector(
+///   account: currentAccount,
+///   onUserChanged: (account) => handleAccountChange(account),
+///   communityActorId: community.actorId,
+///   onCommunityChanged: (community) => handleCommunityChange(community),
+/// )
+/// ```
+///
+/// For creating a comment on a post:
+/// ```dart
+/// UserSelector(
+///   account: currentAccount,
+///   onUserChanged: (account) => handleAccountChange(account),
+///   postActorId: post.actorId,
+///   onPostChanged: (post) => handlePostChange(post),
+/// )
+/// ```
 class UserSelector extends StatefulWidget {
-  final void Function()? onUserChanged;
-  final String? profileModalHeading;
+  /// The currently selected account.
+  /// This is the account that will be displayed in the selector.
+  final Account account;
 
-  // Pass these when dealing with a community (i.e., creating a post)
+  /// Callback invoked when the user successfully switches to a different account.
+  ///
+  /// This callback is triggered after all federation checks have passed and the
+  /// new account has been confirmed to have access to the community, post, or comment.
+  ///
+  /// The [account] parameter contains the newly selected account.
+  final void Function(Account account)? onUserChanged;
+
+  // ========== Community-related parameters ==========
+  // Used when the selector is being used in the context of a community (e.g., creating a post)
+
+  /// The ActivityPub ID (actor ID) of the community to resolve when switching accounts.
+  ///
+  /// When provided, the widget will attempt to resolve this community on the new
+  /// account's instance before allowing the account switch. If the community cannot
+  /// be found on the new instance, the switch will be blocked.
   final String? communityActorId;
+
+  /// Callback invoked when the community is successfully resolved on the new account's instance.
+  ///
+  /// This callback receives the resolved [ThunderCommunity] that corresponds to
+  /// the [communityActorId] on the new instance. If the community cannot be resolved,
+  /// this callback will receive `null` and the account switch will be blocked.
+  ///
+  /// Required when [communityActorId] is provided.
   final void Function(ThunderCommunity? community)? onCommunityChanged;
 
-  // Pass these when dealing with a post (i.e., creating a comment)
-  // Unlike posts, where it's valid to have a null community (i.e., you're forced to pick a different one)
-  // It's not valid to have a null parent post/comment. Therefore if we can't resolve the objects,
-  // we will block the account switch, and the onChanged methods will never pass a null value.
+  // ========== Post-related parameters ==========
+  // Used when the selector is being used in the context of a post (e.g., creating a comment to a post)
+
+  /// The ActivityPub ID (actor ID) of the post to resolve when switching accounts.
+  ///
+  /// When provided, the widget will attempt to resolve this post on the new
+  /// account's instance before allowing the account switch. Unlike communities,
+  /// posts must be successfully resolved or the switch will be blocked.
+  ///
+  /// Used in conjunction with [onPostChanged].
   final String? postActorId;
+
+  /// Callback invoked when the post is successfully resolved on the new account's instance.
+  ///
+  /// This callback receives the resolved [ThunderPost] that corresponds to
+  /// the [postActorId] on the new instance. This callback will only be invoked
+  /// if the post is successfully resolved - failed resolution blocks the account switch.
+  ///
+  /// Required when [postActorId] is provided.
   final void Function(ThunderPost post)? onPostChanged;
+
+  // ========== Parent comment-related parameters ==========
+  // Used when replying to a specific comment
+
+  /// The ActivityPub ID (actor ID) of the parent comment to resolve when switching accounts.
+  ///
+  /// When provided, the widget will attempt to resolve this comment on the new
+  /// account's instance before allowing the account switch. The comment must be
+  /// successfully resolved or the switch will be blocked.
+  ///
+  /// Used in conjunction with [onParentCommentChanged].
   final String? parentCommentActorId;
+
+  /// Callback invoked when the parent comment is successfully resolved on the new account's instance.
+  ///
+  /// This callback receives the resolved [ThunderComment] that corresponds to
+  /// the [parentCommentActorId] on the new instance. This callback will only be invoked
+  /// if the comment is successfully resolved - failed resolution blocks the account switch.
+  ///
+  /// Required when [parentCommentActorId] is provided.
   final void Function(ThunderComment parentComment)? onParentCommentChanged;
 
-  /// Whether the user is allowed to change the active account
-  /// (e.g., it should not be allowed during edit)
+  /// Whether account switching is enabled.
+  ///
+  /// When `false`, the selector displays the current account but disables the ability
+  /// to switch to a different account. This is useful during operations like editing
+  /// where changing accounts would be inappropriate.
+  ///
+  /// Defaults to `true`.
   final bool enableAccountSwitching;
 
   const UserSelector({
     super.key,
+    required this.account,
     this.onUserChanged,
-    this.profileModalHeading,
     this.communityActorId,
     this.onCommunityChanged,
     this.postActorId,
@@ -55,32 +140,193 @@ class UserSelector extends StatefulWidget {
 }
 
 class _UserSelectorState extends State<UserSelector> {
+  /// The current user details for the selected account
+  ThunderUser? _user;
+
+  /// Whether the widget is currently loading user data
+  bool _isLoading = false;
+
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addPostFrameCallback((_) => _loadUserData(widget.account));
+  }
+
+  @override
+  void didUpdateWidget(UserSelector oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (oldWidget.account.id != widget.account.id) _loadUserData(widget.account);
+  }
+
+  /// Loads user data for the specified account
+  Future<void> _loadUserData(Account? account) async {
+    if (_isLoading) return;
+    setState(() => _isLoading = true);
+
+    try {
+      final targetAccount = account ?? widget.account;
+      final username = targetAccount.username;
+
+      if (username == null) {
+        setState(() {
+          _user = null;
+          _isLoading = false;
+        });
+        return;
+      }
+
+      final response = await UserRepositoryImpl(account: targetAccount).getUser(username: username);
+      final user = response?['user'] as ThunderUser?;
+
+      if (!mounted) return;
+
+      setState(() {
+        _user = user;
+        _isLoading = false;
+      });
+    } catch (e) {
+      if (!mounted) return;
+
+      setState(() {
+        _user = null;
+        _isLoading = false;
+      });
+
+      debugPrint('Failed to load user data: $e');
+    }
+  }
+
+  /// Initiates the account switching process
+  Future<void> _switchProfile() async {
+    if (!widget.enableAccountSwitching) return;
+
+    final newAccount = await showModalBottomSheet<Account>(
+      context: context,
+      showDragHandle: true,
+      builder: (context) => _UserProfileSelector(widget.account),
+    );
+
+    if (newAccount == null || !mounted || widget.account.id == newAccount.id) return;
+
+    final resolvedItems = await _performAccountSwitch(newAccount);
+    if (resolvedItems != null) {
+      await _loadUserData(newAccount);
+      _invokeCallbacks(newAccount, resolvedItems);
+    }
+  }
+
+  /// Performs federation checks and resolves content on the new account's instance
+  Future<Map<String, dynamic>?> _performAccountSwitch(Account newAccount) async {
+    final l10n = GlobalContext.l10n;
+
+    try {
+      ThunderCommunity? community;
+      ThunderPost? post;
+      ThunderComment? parentComment;
+
+      // Resolve community if needed
+      if (widget.communityActorId?.isNotEmpty == true) {
+        community = await _resolveCommunity(newAccount, widget.communityActorId!);
+        if (community == null) {
+          showSnackbar(l10n.unableToFindCommunityOnInstance);
+          return null;
+        }
+      }
+
+      // Resolve post if needed
+      if (widget.postActorId?.isNotEmpty == true) {
+        post = await _resolvePost(newAccount, widget.postActorId!);
+        if (post == null) {
+          showSnackbar(l10n.accountSwitchPostNotFound(newAccount.instance));
+          return null;
+        }
+      }
+
+      // Resolve parent comment if needed
+      if (widget.parentCommentActorId?.isNotEmpty == true) {
+        parentComment = await _resolveParentComment(newAccount, widget.parentCommentActorId!);
+        if (parentComment == null) {
+          showSnackbar(l10n.accountSwitchParentCommentNotFound(newAccount.instance));
+          return null;
+        }
+      }
+
+      return {
+        'community': community,
+        'post': post,
+        'parentComment': parentComment,
+      };
+    } catch (e) {
+      showSnackbar(e.toString());
+      return null;
+    }
+  }
+
+  /// Resolves a community on the new account's instance
+  Future<ThunderCommunity?> _resolveCommunity(Account account, String actorId) async {
+    try {
+      final response = await SearchRepositoryImpl(account: account).resolve(query: actorId);
+      return response.community != null ? ThunderCommunity.fromLemmyCommunityView(response.community!.toJson()) : null;
+    } catch (e) {
+      debugPrint('Failed to resolve community: $e');
+      return null;
+    }
+  }
+
+  /// Resolves a post on the new account's instance
+  Future<ThunderPost?> _resolvePost(Account account, String actorId) async {
+    try {
+      final response = await SearchRepositoryImpl(account: account).resolve(query: actorId);
+      if (response.post == null) return null;
+
+      final thunderPost = ThunderPost.fromLemmyPostView(response.post!.toJson());
+      final parsedPosts = await parsePosts([thunderPost]);
+      return parsedPosts.isNotEmpty ? parsedPosts.first : null;
+    } catch (e) {
+      debugPrint('Failed to resolve post: $e');
+      return null;
+    }
+  }
+
+  /// Resolves a parent comment on the new account's instance
+  Future<ThunderComment?> _resolveParentComment(Account account, String actorId) async {
+    try {
+      final response = await SearchRepositoryImpl(account: account).resolve(query: actorId);
+      return response.comment != null ? ThunderComment.fromLemmyCommentView(response.comment!.toJson()) : null;
+    } catch (e) {
+      debugPrint('Failed to resolve parent comment: $e');
+      return null;
+    }
+  }
+
+  /// Invokes the appropriate callbacks after a successful account switch
+  void _invokeCallbacks(Account newAccount, Map<String, dynamic> resolvedItems) {
+    widget.onUserChanged?.call(newAccount);
+
+    if (widget.communityActorId != null) {
+      widget.onCommunityChanged?.call(resolvedItems['community']);
+    }
+    if (widget.postActorId != null && resolvedItems['post'] != null) {
+      widget.onPostChanged?.call(resolvedItems['post'] as ThunderPost);
+    }
+    if (widget.parentCommentActorId != null && resolvedItems['parentComment'] != null) {
+      widget.onParentCommentChanged?.call(resolvedItems['parentComment'] as ThunderComment);
+    }
+  }
+
   @override
   Widget build(BuildContext context) {
     return Transform.translate(
-      offset: const Offset(-8, 0),
+      offset: const Offset(-8.0, 0),
       child: InkWell(
-        borderRadius: const BorderRadius.all(Radius.circular(50)),
-        onTap: !widget.enableAccountSwitching
-            ? null
-            : () async => await temporarilySwitchAccount(
-                  context,
-                  setState: setState,
-                  profileModalHeading: widget.profileModalHeading,
-                  onUserChanged: widget.onUserChanged,
-                  communityActorId: widget.communityActorId,
-                  onCommunityChanged: widget.onCommunityChanged,
-                  postActorId: widget.postActorId,
-                  onPostChanged: widget.onPostChanged,
-                  parentCommentActorId: widget.parentCommentActorId,
-                  onParentCommentChanged: widget.onParentCommentChanged,
-                ),
+        borderRadius: const BorderRadius.all(Radius.circular(50.0)),
+        onTap: widget.enableAccountSwitching ? _switchProfile : null,
         child: Padding(
-          padding: const EdgeInsets.only(left: 8, top: 4, bottom: 4),
+          padding: const EdgeInsets.only(left: 8.0, top: 4.0, bottom: 4.0),
           child: Row(
             mainAxisAlignment: MainAxisAlignment.spaceBetween,
             children: [
-              const UserIndicator(),
+              UserIndicator(user: _user),
               if (widget.enableAccountSwitching) const Icon(Icons.chevron_right_rounded),
             ],
           ),
@@ -90,86 +336,69 @@ class _UserSelectorState extends State<UserSelector> {
   }
 }
 
-Future<void> temporarilySwitchAccount(
-  BuildContext context, {
-  void Function(VoidCallback fn)? setState,
-  String? profileModalHeading,
-  void Function()? onUserChanged,
-  String? communityActorId,
-  void Function(ThunderCommunity? community)? onCommunityChanged,
-  String? postActorId,
-  void Function(ThunderPost post)? onPostChanged,
-  String? parentCommentActorId,
-  void Function(ThunderComment parentComment)? onParentCommentChanged,
-}) async {
-  final AppLocalizations l10n = AppLocalizations.of(context)!;
+/// Modal bottom sheet widget for selecting user accounts
+class _UserProfileSelector extends StatefulWidget {
+  /// The current account
+  final Account account;
 
-  final Account originalUser = context.read<ProfileBloc>().state.account;
+  const _UserProfileSelector(this.account);
 
-  await showProfileModalSheet(
-    context,
-    quickSelectMode: true,
-    customHeading: profileModalHeading,
-    reloadOnSwitch: false,
-  );
+  @override
+  State<_UserProfileSelector> createState() => _UserProfileSelectorState();
+}
 
-  // Wait slightly longer than the duration that is waited in the account switcher logic.
-  await Future.delayed(const Duration(milliseconds: 1500));
+class _UserProfileSelectorState extends State<_UserProfileSelector> {
+  /// The list of available user accounts
+  List<Account> _accounts = [];
 
-  if (context.mounted) {
-    Account? newUser = context.read<ProfileBloc>().state.account;
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addPostFrameCallback((_) => _loadAccounts());
+  }
 
-    if (originalUser.id != newUser.id) {
-      // The user changed. Reload the widget.
-      setState?.call(() {});
-      onUserChanged?.call();
+  /// Loads all available user accounts
+  Future<void> _loadAccounts() async {
+    try {
+      final accounts = await Account.accounts().then((accounts) => accounts.where((account) => account.id != widget.account.id).toList());
 
-      // If there is a selected community, see if we can resolve it to the new user's instance.
-      if (communityActorId?.isNotEmpty == true && onCommunityChanged != null) {
-        try {
-          final response = await SearchRepositoryImpl(account: newUser).resolve(query: communityActorId!);
-
-          if (response.community != null) {
-            final community = ThunderCommunity.fromLemmyCommunityView(response.community!.toJson());
-            onCommunityChanged(community);
-          }
-        } catch (e) {
-          // We'll just return null if we can't find it.
-        }
-      }
-
-      // If there is a selected post, see if we can resolve it to the new user's instance.
-      if (postActorId?.isNotEmpty == true && onPostChanged != null) {
-        try {
-          final response = await SearchRepositoryImpl(account: newUser).resolve(query: postActorId!);
-
-          if (response.post != null) {
-            onPostChanged((await parsePosts([ThunderPost.fromLemmyPostView(response.post!.toJson())])).first);
-          }
-
-          showSnackbar(l10n.accountSwitchPostNotFound(newUser.instance));
-          if (context.mounted) context.read<ProfileBloc>().add(SwitchProfile(accountId: originalUser.id, reload: false));
-        } catch (e) {
-          // We will handle this below.
-        }
-      }
-
-      // If there is a selected parent comment, see if we can resolve it to the new user's instance.
-      if (parentCommentActorId?.isNotEmpty == true && onParentCommentChanged != null) {
-        try {
-          final response = await SearchRepositoryImpl(account: newUser).resolve(query: parentCommentActorId!);
-
-          if (response.comment != null) {
-            final comment = ThunderComment.fromLemmyCommentView(response.comment!.toJson());
-            onParentCommentChanged(comment);
-          }
-
-          showSnackbar(l10n.accountSwitchParentCommentNotFound(newUser.instance));
-          if (context.mounted) context.read<ProfileBloc>().add(SwitchProfile(accountId: originalUser.id, reload: false));
-        } catch (e) {
-          // We will handle this below.
-        }
-      }
+      if (!mounted) return;
+      setState(() => _accounts = accounts);
+    } catch (e) {
+      if (!mounted) return;
+      setState(() => _accounts = []);
+      debugPrint('Failed to load accounts: $e');
     }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final l10n = GlobalContext.l10n;
+    final theme = Theme.of(context);
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 16.0, vertical: 8.0),
+          child: Text(l10n.account(2), style: theme.textTheme.titleLarge),
+        ),
+        _accounts.isEmpty
+            ? Center(child: Text(l10n.noAccountsAdded))
+            : ListView.builder(
+                shrinkWrap: true,
+                itemCount: _accounts.length,
+                itemBuilder: (context, index) {
+                  final account = _accounts[index];
+                  return ListTile(
+                    title: Text(account.username ?? '-', style: theme.textTheme.titleMedium),
+                    subtitle: Text(account.instance),
+                    onTap: () => Navigator.of(context).pop(account),
+                  );
+                },
+              ),
+      ],
+    );
   }
 }

--- a/lib/utils/preferences.dart
+++ b/lib/utils/preferences.dart
@@ -5,8 +5,6 @@ import 'package:thunder/account/account.dart';
 import 'package:thunder/core/enums/enums.dart';
 import 'package:thunder/core/enums/threadiverse_platform.dart';
 import 'package:thunder/drafts/models/draft.dart';
-import 'package:thunder/comment/comment.dart';
-import 'package:thunder/community/pages/create_post_page.dart';
 import 'package:thunder/core/enums/browser_mode.dart';
 import 'package:thunder/core/enums/full_name.dart';
 import 'package:thunder/core/enums/local_settings.dart';
@@ -16,6 +14,36 @@ import 'package:thunder/notification/enums/notification_type.dart';
 import 'package:thunder/core/singletons/preferences.dart';
 import 'package:thunder/utils/constants.dart';
 import 'package:thunder/utils/instance.dart';
+
+@Deprecated('Use Draft model through database instead')
+class DraftComment {
+  String? text;
+  bool saveAsDraft = true;
+
+  DraftComment({this.text});
+
+  Map<String, dynamic> toJson() => {'text': text};
+
+  static DraftComment fromJson(Map<String, dynamic> json) => DraftComment(text: json['text']);
+
+  bool get isNotEmpty => text?.isNotEmpty == true;
+}
+
+@Deprecated('Use Draft model through database instead')
+class DraftPost {
+  String? title;
+  String? url;
+  String? text;
+  bool saveAsDraft = true;
+
+  DraftPost({this.title, this.url, this.text});
+
+  Map<String, dynamic> toJson() => {'title': title, 'url': url, 'text': text};
+
+  static DraftPost fromJson(Map<String, dynamic> json) => DraftPost(title: json['title'], url: json['url'], text: json['text']);
+
+  bool get isNotEmpty => title?.isNotEmpty == true || url?.isNotEmpty == true || text?.isNotEmpty == true;
+}
 
 Future<void> performSharedPreferencesMigration() async {
   final prefs = UserPreferences.instance.preferences;


### PR DESCRIPTION
## Pull Request Description

This PR re-introduces the ability to switch between different profiles when creating new posts or comments. At the moment, this is only supported on Lemmy instances, as the `/resolve_object` endpoint hasn’t yet been implemented for PieFed.

Previously, Thunder handled temporary profile switching at the bloc level (e.g., `AuthBloc`), which meant the active profile changed across the entire app. With this re-implementation, the switching logic has been moved into the `CreatePostPage` and `CreateCommentPage` widgets. As a result, the selected account now only changes within the context of creating posts and comments.

This makes profile switching more predictable by isolating it to post/comment creation and helps prevent side effects in other parts of the app.

This PR also includes a few small, unrelated changes:
- Taglines now display correctly on Lemmy instances
- The modlog action has been removed from the community header on PieFed instances

**Note**: Viewing a post as a different user has been temporarily disabled while I work on re-implementing that feature!

<!--- Please describe what was changed -->

## Issue Being Fixed

<!-- Please describe the problem that is being fixed and, if applicable, reference a GitHub issue -->

Issue Number: N/A

## Screenshots / Recordings

<!-- This section is optional but highly recommended to show off your changes! -->

## Checklist

- [ ] If a new package was added, did you ensure it uses an appropriate license and is actively maintained?
- [ ] Did you use localized strings (and added appropriate descriptions) where applicable?
- [ ] Did you add `semanticLabel`s where applicable for accessibility?
