### PR TITLE
Fix unified push notification logic

### DIFF
--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -971,7 +971,7 @@
   },
   "failedToBlock": "Failed to block: {errorMessage}",
   "@failedToBlock": {},
-  "failedToCommunicateWithThunderNotificationServer": "Failed to communicate with Thunder notification server at '{serverAddress}'",
+  "failedToCommunicateWithThunderNotificationServer": "Failed to communicate with Thunder notification server at {serverAddress}.",
   "@failedToCommunicateWithThunderNotificationServer": {
     "description": "Error message for when we fail to communicate with Thunder notification server"
   },

--- a/lib/localizations/app_localizations.dart
+++ b/lib/localizations/app_localizations.dart
@@ -1841,7 +1841,7 @@ abstract class AppLocalizations {
   /// Error message for when we fail to communicate with Thunder notification server
   ///
   /// In en, this message translates to:
-  /// **'Failed to communicate with Thunder notification server at \'{serverAddress}\''**
+  /// **'Failed to communicate with Thunder notification server at {serverAddress}.'**
   String failedToCommunicateWithThunderNotificationServer(Object serverAddress);
 
   /// No description provided for @failedToLoadBlocks.

--- a/lib/localizations/app_localizations_ar.dart
+++ b/lib/localizations/app_localizations_ar.dart
@@ -968,7 +968,7 @@ class AppLocalizationsAr extends AppLocalizations {
   @override
   String failedToCommunicateWithThunderNotificationServer(
       Object serverAddress) {
-    return 'Failed to communicate with Thunder notification server at \'$serverAddress\'';
+    return 'Failed to communicate with Thunder notification server at $serverAddress.';
   }
 
   @override

--- a/lib/localizations/app_localizations_cs.dart
+++ b/lib/localizations/app_localizations_cs.dart
@@ -984,7 +984,7 @@ class AppLocalizationsCs extends AppLocalizations {
   @override
   String failedToCommunicateWithThunderNotificationServer(
       Object serverAddress) {
-    return 'Failed to communicate with Thunder notification server at \'$serverAddress\'';
+    return 'Failed to communicate with Thunder notification server at $serverAddress.';
   }
 
   @override

--- a/lib/localizations/app_localizations_en.dart
+++ b/lib/localizations/app_localizations_en.dart
@@ -976,7 +976,7 @@ class AppLocalizationsEn extends AppLocalizations {
   @override
   String failedToCommunicateWithThunderNotificationServer(
       Object serverAddress) {
-    return 'Failed to communicate with Thunder notification server at \'$serverAddress\'';
+    return 'Failed to communicate with Thunder notification server at $serverAddress.';
   }
 
   @override

--- a/lib/localizations/app_localizations_eo.dart
+++ b/lib/localizations/app_localizations_eo.dart
@@ -973,7 +973,7 @@ class AppLocalizationsEo extends AppLocalizations {
   @override
   String failedToCommunicateWithThunderNotificationServer(
       Object serverAddress) {
-    return 'Failed to communicate with Thunder notification server at \'$serverAddress\'';
+    return 'Failed to communicate with Thunder notification server at $serverAddress.';
   }
 
   @override

--- a/lib/localizations/app_localizations_fi.dart
+++ b/lib/localizations/app_localizations_fi.dart
@@ -973,7 +973,7 @@ class AppLocalizationsFi extends AppLocalizations {
   @override
   String failedToCommunicateWithThunderNotificationServer(
       Object serverAddress) {
-    return 'Failed to communicate with Thunder notification server at \'$serverAddress\'';
+    return 'Failed to communicate with Thunder notification server at $serverAddress.';
   }
 
   @override

--- a/lib/localizations/app_localizations_fr.dart
+++ b/lib/localizations/app_localizations_fr.dart
@@ -1002,7 +1002,7 @@ class AppLocalizationsFr extends AppLocalizations {
   @override
   String failedToCommunicateWithThunderNotificationServer(
       Object serverAddress) {
-    return 'Failed to communicate with Thunder notification server at \'$serverAddress\'';
+    return 'Failed to communicate with Thunder notification server at $serverAddress.';
   }
 
   @override

--- a/lib/localizations/app_localizations_hu.dart
+++ b/lib/localizations/app_localizations_hu.dart
@@ -976,7 +976,7 @@ class AppLocalizationsHu extends AppLocalizations {
   @override
   String failedToCommunicateWithThunderNotificationServer(
       Object serverAddress) {
-    return 'Failed to communicate with Thunder notification server at \'$serverAddress\'';
+    return 'Failed to communicate with Thunder notification server at $serverAddress.';
   }
 
   @override

--- a/lib/localizations/app_localizations_nb.dart
+++ b/lib/localizations/app_localizations_nb.dart
@@ -971,7 +971,7 @@ class AppLocalizationsNb extends AppLocalizations {
   @override
   String failedToCommunicateWithThunderNotificationServer(
       Object serverAddress) {
-    return 'Failed to communicate with Thunder notification server at \'$serverAddress\'';
+    return 'Failed to communicate with Thunder notification server at $serverAddress.';
   }
 
   @override

--- a/lib/localizations/app_localizations_nl.dart
+++ b/lib/localizations/app_localizations_nl.dart
@@ -977,7 +977,7 @@ class AppLocalizationsNl extends AppLocalizations {
   @override
   String failedToCommunicateWithThunderNotificationServer(
       Object serverAddress) {
-    return 'Failed to communicate with Thunder notification server at \'$serverAddress\'';
+    return 'Failed to communicate with Thunder notification server at $serverAddress.';
   }
 
   @override

--- a/lib/localizations/app_localizations_pl.dart
+++ b/lib/localizations/app_localizations_pl.dart
@@ -986,7 +986,7 @@ class AppLocalizationsPl extends AppLocalizations {
   @override
   String failedToCommunicateWithThunderNotificationServer(
       Object serverAddress) {
-    return 'Failed to communicate with Thunder notification server at \'$serverAddress\'';
+    return 'Failed to communicate with Thunder notification server at $serverAddress.';
   }
 
   @override

--- a/lib/localizations/app_localizations_pt.dart
+++ b/lib/localizations/app_localizations_pt.dart
@@ -985,7 +985,7 @@ class AppLocalizationsPt extends AppLocalizations {
   @override
   String failedToCommunicateWithThunderNotificationServer(
       Object serverAddress) {
-    return 'Failed to communicate with Thunder notification server at \'$serverAddress\'';
+    return 'Failed to communicate with Thunder notification server at $serverAddress.';
   }
 
   @override

--- a/lib/localizations/app_localizations_ru.dart
+++ b/lib/localizations/app_localizations_ru.dart
@@ -987,7 +987,7 @@ class AppLocalizationsRu extends AppLocalizations {
   @override
   String failedToCommunicateWithThunderNotificationServer(
       Object serverAddress) {
-    return 'Failed to communicate with Thunder notification server at \'$serverAddress\'';
+    return 'Failed to communicate with Thunder notification server at $serverAddress.';
   }
 
   @override

--- a/lib/localizations/app_localizations_sk.dart
+++ b/lib/localizations/app_localizations_sk.dart
@@ -984,7 +984,7 @@ class AppLocalizationsSk extends AppLocalizations {
   @override
   String failedToCommunicateWithThunderNotificationServer(
       Object serverAddress) {
-    return 'Failed to communicate with Thunder notification server at \'$serverAddress\'';
+    return 'Failed to communicate with Thunder notification server at $serverAddress.';
   }
 
   @override

--- a/lib/localizations/app_localizations_sv.dart
+++ b/lib/localizations/app_localizations_sv.dart
@@ -970,7 +970,7 @@ class AppLocalizationsSv extends AppLocalizations {
   @override
   String failedToCommunicateWithThunderNotificationServer(
       Object serverAddress) {
-    return 'Failed to communicate with Thunder notification server at \'$serverAddress\'';
+    return 'Failed to communicate with Thunder notification server at $serverAddress.';
   }
 
   @override

--- a/lib/localizations/app_localizations_uk.dart
+++ b/lib/localizations/app_localizations_uk.dart
@@ -978,7 +978,7 @@ class AppLocalizationsUk extends AppLocalizations {
   @override
   String failedToCommunicateWithThunderNotificationServer(
       Object serverAddress) {
-    return 'Failed to communicate with Thunder notification server at \'$serverAddress\'';
+    return 'Failed to communicate with Thunder notification server at $serverAddress.';
   }
 
   @override

--- a/lib/localizations/app_localizations_zh.dart
+++ b/lib/localizations/app_localizations_zh.dart
@@ -976,7 +976,7 @@ class AppLocalizationsZh extends AppLocalizations {
   @override
   String failedToCommunicateWithThunderNotificationServer(
       Object serverAddress) {
-    return 'Failed to communicate with Thunder notification server at \'$serverAddress\'';
+    return 'Failed to communicate with Thunder notification server at $serverAddress.';
   }
 
   @override

--- a/lib/notification/shared/notification_server.dart
+++ b/lib/notification/shared/notification_server.dart
@@ -77,7 +77,7 @@ Future<bool> deleteAccountFromNotificationServer() async {
   }
 }
 
-Future<bool> requestTestNotification() async {
+Future<String?> requestTestNotification() async {
   try {
     final prefs = UserPreferences.instance.preferences;
     String pushNotificationServer = prefs.getString(LocalSettings.pushNotificationServer.name) ?? THUNDER_SERVER_URL;
@@ -94,9 +94,9 @@ Future<bool> requestTestNotification() async {
     );
 
     // Check if the request was successful
-    if (response.statusCode == 201) return true;
-    return false;
+    if (response.statusCode == 201) return null;
+    return response.body;
   } catch (e) {
-    return false;
+    return e.toString();
   }
 }

--- a/lib/notification/utils/unified_push.dart
+++ b/lib/notification/utils/unified_push.dart
@@ -226,5 +226,6 @@ void initUnifiedPushNotifications({required StreamController<NotificationRespons
   );
 
   // Register Thunder with UnifiedPush
-  UnifiedPush.tryUseCurrentOrDefaultDistributor();
+  bool canRegister = await UnifiedPush.tryUseCurrentOrDefaultDistributor();
+  if (canRegister) await UnifiedPush.register(instance: "thunder");
 }

--- a/lib/settings/pages/debug_settings_page.dart
+++ b/lib/settings/pages/debug_settings_page.dart
@@ -472,10 +472,12 @@ class _DebugSettingsPageState extends State<DebugSettingsPage> {
                   ),
                   onTap: inboxNotificationType == NotificationType.unifiedPush
                       ? () async {
-                          if (await requestTestNotification()) {
+                          final error = await requestTestNotification();
+
+                          if (error == null) {
                             showSnackbar(l10n.sentRequestForTestNotification);
                           } else {
-                            showSnackbar(l10n.failedToCommunicateWithThunderNotificationServer(pushNotificationServer ?? ''));
+                            showSnackbar(l10n.failedToCommunicateWithThunderNotificationServer('$pushNotificationServer\n\n$error'));
                           }
                         }
                       : null,
@@ -512,10 +514,12 @@ class _DebugSettingsPageState extends State<DebugSettingsPage> {
                           );
 
                           if (result) {
-                            if (await requestTestNotification()) {
+                            final error = await requestTestNotification();
+
+                            if (error == null) {
                               showSnackbar(l10n.sentRequestForTestNotification);
                             } else {
-                              showSnackbar(l10n.failedToCommunicateWithThunderNotificationServer(pushNotificationServer ?? ''));
+                              showSnackbar(l10n.failedToCommunicateWithThunderNotificationServer('$pushNotificationServer\n\n$error'));
                             }
 
                             SystemNavigator.pop();


### PR DESCRIPTION
## Pull Request Description

This PR fixes a issue with unified push notifications not being registered properly. This was due to a regression when upgrading the UnifiedPush package. Additionally, error messages are now exposed via the snackbar when testing notifications.

<!--- Please describe what was changed -->

## Issue Being Fixed

<!-- Please describe the problem that is being fixed and, if applicable, reference a GitHub issue -->

Issue Number: N/A

## Screenshots / Recordings

<!-- This section is optional but highly recommended to show off your changes! -->

## Checklist

- [ ] If a new package was added, did you ensure it uses an appropriate license and is actively maintained?
- [ ] Did you use localized strings (and added appropriate descriptions) where applicable?
- [ ] Did you add `semanticLabel`s where applicable for accessibility?
