### PR TITLE
Hide incompatible sort types for PieFed instances

### DIFF
--- a/lib/community/widgets/community_header/community_header_actions.dart
+++ b/lib/community/widgets/community_header/community_header_actions.dart
@@ -165,7 +165,8 @@ class _SortActionChip extends StatelessWidget {
       return const SizedBox.shrink();
     }
 
-    final state = context.read<FeedBloc>().state;
+    final feedBloc = context.read<FeedBloc>();
+    final state = feedBloc.state;
 
     return ThunderActionChip(
       icon: getSortIcon(state) ?? Icons.sort_rounded,
@@ -179,6 +180,7 @@ class _SortActionChip extends StatelessWidget {
           context: context,
           isScrollControlled: true,
           builder: (builderContext) => SortPicker(
+            account: feedBloc.account,
             title: l10n.sortOptions,
             onSelect: (selected) async {
               try {

--- a/lib/core/enums/comment_sort_type.dart
+++ b/lib/core/enums/comment_sort_type.dart
@@ -1,15 +1,21 @@
 import 'package:lemmy_api_client/v3.dart' as lemmy;
 
+import 'package:thunder/core/enums/threadiverse_platform.dart';
+
 enum CommentSortType {
   hot('Hot'),
   top('Top'),
   new_('New'),
   old('Old'),
-  controversial('Controversial');
+  controversial('Controversial', platform: ThreadiversePlatform.lemmy);
 
+  /// The value of the sort type for the API.
   final String value;
 
-  const CommentSortType(this.value);
+  /// The platform this sort type is used on. If null, it is used on all platforms.
+  final ThreadiversePlatform? platform;
+
+  const CommentSortType(this.value, {this.platform});
 }
 
 extension CommentSortTypeMapping on CommentSortType {

--- a/lib/core/enums/post_sort_type.dart
+++ b/lib/core/enums/post_sort_type.dart
@@ -1,29 +1,35 @@
 import 'package:lemmy_api_client/v3.dart' as lemmy;
 
+import 'package:thunder/core/enums/threadiverse_platform.dart';
+
 enum PostSortType {
   active('Active'),
   hot('Hot'),
   new_('New'),
-  old('Old'),
-  topDay('TopDay'),
-  topWeek('TopWeek'),
-  topMonth('TopMonth'),
-  topYear('TopYear'),
-  topAll('TopAll'),
-  mostComments('MostComments'),
-  newComments('NewComments'),
   topHour('TopHour'),
   topSixHour('TopSixHour'),
   topTwelveHour('TopTwelveHour'),
+  topDay('TopDay'),
+  topWeek('TopWeek'),
+  topMonth('TopMonth'),
   topThreeMonths('TopThreeMonths'),
   topSixMonths('TopSixMonths'),
   topNineMonths('TopNineMonths'),
-  controversial('Controversial'),
-  scaled('Scaled');
+  topYear('TopYear'),
+  topAll('TopAll'),
+  scaled('Scaled'),
+  old('Old', platform: ThreadiversePlatform.lemmy),
+  mostComments('MostComments', platform: ThreadiversePlatform.lemmy),
+  newComments('NewComments', platform: ThreadiversePlatform.lemmy),
+  controversial('Controversial', platform: ThreadiversePlatform.lemmy);
 
+  /// The value of the sort type for the API.
   final String value;
 
-  const PostSortType(this.value);
+  /// The platform this sort type is used on. If null, it is used on all platforms.
+  final ThreadiversePlatform? platform;
+
+  const PostSortType(this.value, {this.platform});
 }
 
 extension PostSortTypeMapping on PostSortType {

--- a/lib/feed/widgets/feed_fab.dart
+++ b/lib/feed/widgets/feed_fab.dart
@@ -11,6 +11,7 @@ import 'package:thunder/core/enums/fab_action.dart';
 import 'package:thunder/feed/bloc/feed_bloc.dart';
 import 'package:thunder/feed/utils/utils.dart';
 import 'package:thunder/feed/view/feed_page.dart';
+import 'package:thunder/utils/global_context.dart';
 import 'package:thunder/utils/navigation.dart';
 import 'package:thunder/shared/gesture_fab.dart';
 import 'package:thunder/shared/snackbar.dart';
@@ -268,13 +269,15 @@ class FeedFAB extends StatelessWidget {
   }
 
   Future<void> triggerChangeSort(BuildContext context) async {
-    final l10n = AppLocalizations.of(context)!;
+    final l10n = GlobalContext.l10n;
+    final feedBloc = context.read<FeedBloc>();
 
     showModalBottomSheet<void>(
       showDragHandle: true,
       context: context,
       isScrollControlled: true,
       builder: (builderContext) => SortPicker(
+        account: feedBloc.account,
         title: l10n.sortOptions,
         onSelect: (selected) async => context.read<FeedBloc>().add(FeedChangePostSortTypeEvent(selected.payload)),
         previouslySelected: context.read<FeedBloc>().state.postSortType,

--- a/lib/feed/widgets/feed_page_app_bar.dart
+++ b/lib/feed/widgets/feed_page_app_bar.dart
@@ -181,7 +181,8 @@ class FeedAppBarCommunityActions extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final l10n = GlobalContext.l10n;
-    final postSortType = context.read<FeedBloc>().state.postSortType;
+    final feedBloc = context.read<FeedBloc>();
+    final postSortType = feedBloc.state.postSortType;
 
     return Padding(
       padding: const EdgeInsets.only(right: 8.0),
@@ -203,6 +204,7 @@ class FeedAppBarCommunityActions extends StatelessWidget {
                 context: context,
                 isScrollControlled: true,
                 builder: (builderContext) => SortPicker(
+                  account: feedBloc.account,
                   title: l10n.sortOptions,
                   onSelect: (selected) async => context.read<FeedBloc>().add(FeedChangePostSortTypeEvent(selected.payload)),
                   previouslySelected: postSortType,
@@ -246,6 +248,7 @@ class FeedAppBarUserActions extends StatelessWidget {
                 context: context,
                 isScrollControlled: true,
                 builder: (builderContext) => SortPicker(
+                  account: feedBloc.account,
                   title: l10n.sortOptions,
                   onSelect: (selected) async => feedBloc.add(FeedChangePostSortTypeEvent(selected.payload)),
                   previouslySelected: feedBloc.state.postSortType,
@@ -287,6 +290,7 @@ class FeedAppBarGeneralActions extends StatelessWidget {
               context: context,
               isScrollControlled: true,
               builder: (builderContext) => SortPicker(
+                account: feedBloc.account,
                 title: l10n.sortOptions,
                 onSelect: (selected) async => feedBloc.add(FeedChangePostSortTypeEvent(selected.payload)),
                 previouslySelected: feedBloc.state.postSortType,

--- a/lib/inbox/pages/inbox_page.dart
+++ b/lib/inbox/pages/inbox_page.dart
@@ -3,7 +3,6 @@ import 'package:flutter/services.dart';
 
 import 'package:flutter_bloc/flutter_bloc.dart';
 
-import 'package:thunder/localizations/app_localizations.dart';
 import 'package:thunder/account/account.dart';
 import 'package:thunder/core/enums/comment_sort_type.dart';
 import 'package:thunder/inbox/bloc/inbox_bloc.dart';
@@ -16,6 +15,7 @@ import 'package:thunder/shared/dialogs.dart';
 import 'package:thunder/shared/snackbar.dart';
 import 'package:thunder/shared/thunder_popup_menu_item.dart';
 import 'package:thunder/utils/constants.dart';
+import 'package:thunder/utils/global_context.dart';
 
 /// A widget that displays the user's inbox replies, mentions, and private messages.
 class InboxPage extends StatefulWidget {
@@ -74,12 +74,14 @@ class _InboxPageState extends State<InboxPage> with SingleTickerProviderStateMix
 
   /// Displays the sort options bottom sheet for comments, since replies and mentions are technically comments
   void showSortBottomSheet() {
-    final AppLocalizations l10n = AppLocalizations.of(context)!;
+    final l10n = GlobalContext.l10n;
+    final inboxBloc = context.read<InboxBloc>();
 
     showModalBottomSheet<void>(
       showDragHandle: true,
       context: context,
       builder: (builderContext) => CommentSortPicker(
+        account: inboxBloc.account,
         title: l10n.sortOptions,
         onSelect: (selected) async {
           setState(() => commentSortType = selected.payload);
@@ -92,7 +94,7 @@ class _InboxPageState extends State<InboxPage> with SingleTickerProviderStateMix
 
   @override
   Widget build(BuildContext context) {
-    final l10n = AppLocalizations.of(context)!;
+    final l10n = GlobalContext.l10n;
 
     return Scaffold(
       body: BlocConsumer<InboxBloc, InboxState>(

--- a/lib/instance/pages/instance_page.dart
+++ b/lib/instance/pages/instance_page.dart
@@ -187,6 +187,7 @@ class _InstancePageState extends State<InstancePage> {
                             IconButton(
                               icon: Icon(Icons.sort, semanticLabel: l10n.sortBy),
                               onPressed: () {
+                                final feedBloc = context.read<FeedBloc>();
                                 HapticFeedback.mediumImpact();
 
                                 showModalBottomSheet<void>(
@@ -194,6 +195,7 @@ class _InstancePageState extends State<InstancePage> {
                                   context: context,
                                   isScrollControlled: true,
                                   builder: (builderContext) => SortPicker(
+                                    account: feedBloc.account,
                                     title: l10n.sortOptions,
                                     onSelect: (selected) async {
                                       postSortType = selected.payload;

--- a/lib/post/pages/post_page.dart
+++ b/lib/post/pages/post_page.dart
@@ -127,7 +127,8 @@ class _PostPageState extends State<PostPage> {
   }
 
   void showSortBottomSheet(BuildContext context, PostState state) {
-    final l10n = AppLocalizations.of(context)!;
+    final l10n = GlobalContext.l10n;
+    final postBloc = context.read<PostBloc>();
 
     HapticFeedback.mediumImpact();
 
@@ -135,6 +136,7 @@ class _PostPageState extends State<PostPage> {
       showDragHandle: true,
       context: context,
       builder: (builderContext) => CommentSortPicker(
+        account: postBloc.account,
         title: l10n.sortOptions,
         onSelect: (selected) async {
           await scrollController.animateTo(0, duration: const Duration(milliseconds: 250), curve: Curves.easeInOutCubicEmphasized);
@@ -146,7 +148,7 @@ class _PostPageState extends State<PostPage> {
   }
 
   void replyToPost(BuildContext context, ThunderPost? post, {bool postLocked = false}) async {
-    final l10n = AppLocalizations.of(context)!;
+    final l10n = GlobalContext.l10n;
     final state = context.read<ProfileBloc>().state;
 
     if (postLocked) return showSnackbar(l10n.postLocked);

--- a/lib/post/widgets/post_page_app_bar.dart
+++ b/lib/post/widgets/post_page_app_bar.dart
@@ -205,12 +205,15 @@ class PostAppBarActions extends StatelessWidget {
         IconButton(
           icon: Icon(Icons.sort, semanticLabel: l10n.sortBy),
           onPressed: () {
+            final postBloc = context.read<PostBloc>();
+
             HapticFeedback.mediumImpact();
 
             showModalBottomSheet<void>(
               showDragHandle: true,
               context: context,
               builder: (builderContext) => CommentSortPicker(
+                account: postBloc.account,
                 title: l10n.sortOptions,
                 onSelect: (selected) async {
                   await onReset?.call();
@@ -282,7 +285,7 @@ class PostAppBarActions extends StatelessWidget {
     return ('', null);
   }
 
-  ListPickerItem<CommentSortType>? commentSortTypeItem = CommentSortPicker.getCommentSortTypeItems().firstWhereOrNull((item) => item.payload == state.commentSortType);
+  ListPickerItem<CommentSortType>? commentSortTypeItem = getCommentSortTypeItems().firstWhereOrNull((item) => item.payload == state.commentSortType);
 
   return (commentSortTypeItem?.label ?? '', commentSortTypeItem?.icon);
 }

--- a/lib/search/pages/search_page.dart
+++ b/lib/search/pages/search_page.dart
@@ -789,13 +789,15 @@ class _SearchPageState extends State<SearchPage> with AutomaticKeepAliveClientMi
   }
 
   void showSortBottomSheet(BuildContext context) {
-    final AppLocalizations l10n = AppLocalizations.of(context)!;
+    final l10n = GlobalContext.l10n;
+    final feedBloc = context.read<FeedBloc>();
 
     showModalBottomSheet(
       context: context,
       showDragHandle: true,
       isScrollControlled: true,
       builder: (builderContext) => SortPicker(
+        account: feedBloc.account,
         title: l10n.sortOptions,
         onSelect: (selected) async {
           setState(() {

--- a/lib/settings/pages/general_settings_page.dart
+++ b/lib/settings/pages/general_settings_page.dart
@@ -403,7 +403,7 @@ class _GeneralSettingsPageState extends State<GeneralSettingsPage> with SingleTi
                     icon: Icons.local_fire_department_rounded,
                     payload: defaultPostSortType,
                   ),
-                  options: [...SortPicker.getDefaultPostSortTypeItems(), ...topPostSortTypeItems],
+                  options: [...getDefaultPostSortTypeItems(), ...getTopPostSortTypeItems()],
                   icon: Icons.sort_rounded,
                   onChanged: (_) async {},
                   isBottomModalScrollControlled: true,
@@ -591,7 +591,7 @@ class _GeneralSettingsPageState extends State<GeneralSettingsPage> with SingleTi
             child: ListOption(
               description: l10n.defaultCommentSortType,
               value: ListPickerItem(label: defaultCommentSortType.name, icon: Icons.local_fire_department_rounded, payload: defaultCommentSortType),
-              options: CommentSortPicker.getCommentSortTypeItems(),
+              options: getCommentSortTypeItems(),
               icon: Icons.comment_bank_rounded,
               onChanged: (_) async {},
               customListPicker: CommentSortPicker(
@@ -603,10 +603,10 @@ class _GeneralSettingsPageState extends State<GeneralSettingsPage> with SingleTi
               ),
               valueDisplay: Row(
                 children: [
-                  Icon(CommentSortPicker.getCommentSortTypeItems().firstWhere((item) => item.payload == defaultCommentSortType).icon, size: 13),
+                  Icon(getCommentSortTypeItems().firstWhere((item) => item.payload == defaultCommentSortType).icon, size: 13),
                   const SizedBox(width: 4),
                   Text(
-                    CommentSortPicker.getCommentSortTypeItems().firstWhere((item) => item.payload == defaultCommentSortType).label,
+                    getCommentSortTypeItems().firstWhere((item) => item.payload == defaultCommentSortType).label,
                     style: theme.textTheme.titleSmall,
                   ),
                 ],

--- a/lib/shared/comment_sort_picker.dart
+++ b/lib/shared/comment_sort_picker.dart
@@ -1,67 +1,72 @@
 import 'package:flutter/material.dart';
 
+import 'package:thunder/account/account.dart';
 import 'package:thunder/core/enums/comment_sort_type.dart';
 import 'package:thunder/shared/picker_item.dart';
 import 'package:thunder/utils/bottom_sheet_list_picker.dart';
-import 'package:thunder/localizations/app_localizations.dart';
 import 'package:thunder/utils/global_context.dart';
 
+List<ListPickerItem<CommentSortType>> getCommentSortTypeItems({Account? account}) {
+  final l10n = GlobalContext.l10n;
+  final platform = account?.platform;
+
+  List<ListPickerItem<CommentSortType>> commentSortTypeItems = [
+    ListPickerItem(
+      payload: CommentSortType.hot,
+      icon: Icons.local_fire_department,
+      label: l10n.hot,
+    ),
+    ListPickerItem(
+      payload: CommentSortType.top,
+      icon: Icons.military_tech,
+      label: l10n.top,
+    ),
+    ListPickerItem(
+      payload: CommentSortType.controversial,
+      icon: Icons.warning_rounded,
+      label: l10n.controversial,
+    ),
+    ListPickerItem(
+      payload: CommentSortType.new_,
+      icon: Icons.auto_awesome_rounded,
+      label: l10n.new_,
+    ),
+    ListPickerItem(
+      payload: CommentSortType.old,
+      icon: Icons.access_time_outlined,
+      label: l10n.old,
+    ),
+  ];
+
+  if (platform == null) return commentSortTypeItems;
+
+  // Only return the sort types that are available for the platform (or all platforms).
+  return commentSortTypeItems.where((item) => item.payload.platform == platform || item.payload.platform == null).toList();
+}
+
 /// Create a picker which allows selecting a valid comment sort type.
-/// Specify a [minimumVersion] to determine which sort types will be displayed.
-/// Pass `null` to NOT show any version-specific types (e.g., Scaled).
-/// Pass [LemmyClient.maxVersion] to show ALL types.
 class CommentSortPicker extends BottomSheetListPicker<CommentSortType> {
-  static List<ListPickerItem<CommentSortType>> getCommentSortTypeItems() => [
-        ListPickerItem(
-          payload: CommentSortType.hot,
-          icon: Icons.local_fire_department,
-          label: AppLocalizations.of(GlobalContext.context)!.hot,
-        ),
-        ListPickerItem(
-          payload: CommentSortType.top,
-          icon: Icons.military_tech,
-          label: AppLocalizations.of(GlobalContext.context)!.top,
-        ),
-        ListPickerItem(
-          payload: CommentSortType.controversial,
-          icon: Icons.warning_rounded,
-          label: AppLocalizations.of(GlobalContext.context)!.controversial,
-        ),
-        ListPickerItem(
-          payload: CommentSortType.new_,
-          icon: Icons.auto_awesome_rounded,
-          label: AppLocalizations.of(GlobalContext.context)!.new_,
-        ),
-        ListPickerItem(
-          payload: CommentSortType.old,
-          icon: Icons.access_time_outlined,
-          label: AppLocalizations.of(GlobalContext.context)!.old,
-        ),
-      ];
+  final Account? account;
 
   CommentSortPicker({
     super.key,
+    this.account,
     required super.onSelect,
     required super.title,
-    List<ListPickerItem<CommentSortType>>? items,
     super.previouslySelected,
-  }) : super(items: items ?? CommentSortPicker.getCommentSortTypeItems());
+  }) : super(items: getCommentSortTypeItems(account: account));
 
   @override
   State<StatefulWidget> createState() => _SortPickerState();
 }
 
 class _SortPickerState extends State<CommentSortPicker> {
-  bool topSelected = false;
-
   @override
   Widget build(BuildContext context) {
     return SingleChildScrollView(
-      child: AnimatedSwitcher(
-        duration: const Duration(milliseconds: 100),
-        transitionBuilder: (Widget child, Animation<double> animation) {
-          return FadeTransition(opacity: animation, child: child);
-        },
+      child: AnimatedSize(
+        duration: const Duration(milliseconds: 400),
+        curve: Curves.easeInOutCubicEmphasized,
         child: defaultSortPicker(),
       ),
     );
@@ -71,7 +76,6 @@ class _SortPickerState extends State<CommentSortPicker> {
     final theme = Theme.of(context);
 
     return Column(
-      key: ValueKey<bool>(topSelected),
       mainAxisAlignment: MainAxisAlignment.start,
       mainAxisSize: MainAxisSize.max,
       children: [
@@ -79,18 +83,13 @@ class _SortPickerState extends State<CommentSortPicker> {
           padding: const EdgeInsets.only(bottom: 16.0, left: 26.0, right: 16.0),
           child: Align(
             alignment: Alignment.centerLeft,
-            child: Text(
-              widget.title,
-              style: theme.textTheme.titleLarge!.copyWith(),
-            ),
+            child: Text(widget.title, style: theme.textTheme.titleLarge),
           ),
         ),
         ListView(
           shrinkWrap: true,
           physics: const NeverScrollableScrollPhysics(),
-          children: [
-            ..._generateList(CommentSortPicker.getCommentSortTypeItems(), theme),
-          ],
+          children: [..._generateList(getCommentSortTypeItems(account: widget.account), theme)],
         ),
         const SizedBox(height: 16.0),
       ],
@@ -99,17 +98,15 @@ class _SortPickerState extends State<CommentSortPicker> {
 
   List<Widget> _generateList(List<ListPickerItem<CommentSortType>> items, ThemeData theme) {
     return items
-        .map(
-          (item) => PickerItem(
-            label: item.label,
-            icon: item.icon,
-            onSelected: () {
-              Navigator.of(context).pop();
-              widget.onSelect?.call(item);
-            },
-            isSelected: widget.previouslySelected == item.payload,
-          ),
-        )
+        .map((item) => PickerItem(
+              label: item.label,
+              icon: item.icon,
+              onSelected: () {
+                Navigator.of(context).pop();
+                widget.onSelect?.call(item);
+              },
+              isSelected: widget.previouslySelected == item.payload,
+            ))
         .toList();
   }
 }

--- a/lib/shared/sort_picker.dart
+++ b/lib/shared/sort_picker.dart
@@ -1,126 +1,146 @@
 import 'package:flutter/material.dart';
 
+import 'package:thunder/account/account.dart';
 import 'package:thunder/core/enums/post_sort_type.dart';
 import 'package:thunder/shared/picker_item.dart';
 import 'package:thunder/utils/bottom_sheet_list_picker.dart';
-import 'package:thunder/localizations/app_localizations.dart';
 import 'package:thunder/utils/global_context.dart';
 
-List<ListPickerItem<PostSortType>> topPostSortTypeItems = [
-  ListPickerItem(
-    payload: PostSortType.topHour,
-    icon: Icons.check_box_outline_blank,
-    label: AppLocalizations.of(GlobalContext.context)!.topHour,
-  ),
-  ListPickerItem(
-    payload: PostSortType.topSixHour,
-    icon: Icons.calendar_view_month,
-    label: AppLocalizations.of(GlobalContext.context)!.topSixHour,
-  ),
-  ListPickerItem(
-    payload: PostSortType.topTwelveHour,
-    icon: Icons.calendar_view_week,
-    label: AppLocalizations.of(GlobalContext.context)!.topTwelveHour,
-  ),
-  ListPickerItem(
-    payload: PostSortType.topDay,
-    icon: Icons.today,
-    label: AppLocalizations.of(GlobalContext.context)!.topDay,
-  ),
-  ListPickerItem(
-    payload: PostSortType.topWeek,
-    icon: Icons.view_week_sharp,
-    label: AppLocalizations.of(GlobalContext.context)!.topWeek,
-  ),
-  ListPickerItem(
-    payload: PostSortType.topMonth,
-    icon: Icons.calendar_month,
-    label: AppLocalizations.of(GlobalContext.context)!.topMonth,
-  ),
-  ListPickerItem(
-    payload: PostSortType.topThreeMonths,
-    icon: Icons.calendar_month_outlined,
-    label: AppLocalizations.of(GlobalContext.context)!.topThreeMonths,
-  ),
-  ListPickerItem(
-    payload: PostSortType.topSixMonths,
-    icon: Icons.calendar_today_outlined,
-    label: AppLocalizations.of(GlobalContext.context)!.topSixMonths,
-  ),
-  ListPickerItem(
-    payload: PostSortType.topNineMonths,
-    icon: Icons.calendar_view_day_outlined,
-    label: AppLocalizations.of(GlobalContext.context)!.topNineMonths,
-  ),
-  ListPickerItem(
-    payload: PostSortType.topYear,
-    icon: Icons.calendar_today,
-    label: AppLocalizations.of(GlobalContext.context)!.topYear,
-  ),
-  ListPickerItem(
-    payload: PostSortType.topAll,
-    icon: Icons.military_tech,
-    label: AppLocalizations.of(GlobalContext.context)!.topAll,
-  ),
-];
+List<ListPickerItem<PostSortType>> getTopPostSortTypeItems({Account? account}) {
+  final l10n = GlobalContext.l10n;
+  final platform = account?.platform;
 
-List<ListPickerItem<PostSortType>> allPostSortTypeItems = [...SortPicker.getDefaultPostSortTypeItems(), ...topPostSortTypeItems];
+  List<ListPickerItem<PostSortType>> topPostSortTypeItems = [
+    ListPickerItem(
+      payload: PostSortType.topHour,
+      icon: Icons.check_box_outline_blank,
+      label: l10n.topHour,
+    ),
+    ListPickerItem(
+      payload: PostSortType.topSixHour,
+      icon: Icons.calendar_view_month,
+      label: l10n.topSixHour,
+    ),
+    ListPickerItem(
+      payload: PostSortType.topTwelveHour,
+      icon: Icons.calendar_view_week,
+      label: l10n.topTwelveHour,
+    ),
+    ListPickerItem(
+      payload: PostSortType.topDay,
+      icon: Icons.today,
+      label: l10n.topDay,
+    ),
+    ListPickerItem(
+      payload: PostSortType.topWeek,
+      icon: Icons.view_week_sharp,
+      label: l10n.topWeek,
+    ),
+    ListPickerItem(
+      payload: PostSortType.topMonth,
+      icon: Icons.calendar_month,
+      label: l10n.topMonth,
+    ),
+    ListPickerItem(
+      payload: PostSortType.topThreeMonths,
+      icon: Icons.calendar_month_outlined,
+      label: l10n.topThreeMonths,
+    ),
+    ListPickerItem(
+      payload: PostSortType.topSixMonths,
+      icon: Icons.calendar_today_outlined,
+      label: l10n.topSixMonths,
+    ),
+    ListPickerItem(
+      payload: PostSortType.topNineMonths,
+      icon: Icons.calendar_view_day_outlined,
+      label: l10n.topNineMonths,
+    ),
+    ListPickerItem(
+      payload: PostSortType.topYear,
+      icon: Icons.calendar_today,
+      label: l10n.topYear,
+    ),
+    ListPickerItem(
+      payload: PostSortType.topAll,
+      icon: Icons.military_tech,
+      label: l10n.topAll,
+    ),
+  ];
+
+  if (platform == null) return topPostSortTypeItems;
+
+  // Only return the sort types that are available for the platform (or all platforms).
+  return topPostSortTypeItems.where((item) => item.payload.platform == platform || item.payload.platform == null).toList();
+}
+
+List<ListPickerItem<PostSortType>> getDefaultPostSortTypeItems({Account? account}) {
+  final l10n = GlobalContext.l10n;
+  final platform = account?.platform;
+
+  List<ListPickerItem<PostSortType>> defaultPostSortTypeItems = [
+    ListPickerItem(
+      payload: PostSortType.hot,
+      icon: Icons.local_fire_department_rounded,
+      label: l10n.hot,
+    ),
+    ListPickerItem(
+      payload: PostSortType.active,
+      icon: Icons.rocket_launch_rounded,
+      label: l10n.active,
+    ),
+    ListPickerItem(
+      payload: PostSortType.scaled,
+      icon: Icons.line_weight_rounded,
+      label: l10n.scaled,
+    ),
+    ListPickerItem(
+      payload: PostSortType.controversial,
+      icon: Icons.warning_rounded,
+      label: l10n.controversial,
+    ),
+    ListPickerItem(
+      payload: PostSortType.new_,
+      icon: Icons.auto_awesome_rounded,
+      label: l10n.new_,
+    ),
+    ListPickerItem(
+      payload: PostSortType.old,
+      icon: Icons.access_time_outlined,
+      label: l10n.old,
+    ),
+    ListPickerItem(
+      payload: PostSortType.mostComments,
+      icon: Icons.comment_bank_rounded,
+      label: l10n.mostComments,
+    ),
+    ListPickerItem(
+      payload: PostSortType.newComments,
+      icon: Icons.add_comment_rounded,
+      label: l10n.newComments,
+    ),
+  ];
+
+  if (platform == null) return defaultPostSortTypeItems;
+
+  // Only return the sort types that are available for the platform (or all platforms).
+  return defaultPostSortTypeItems.where((item) => item.payload.platform == platform || item.payload.platform == null).toList();
+}
+
+List<ListPickerItem<PostSortType>> allPostSortTypeItems = [...getDefaultPostSortTypeItems(), ...getTopPostSortTypeItems()];
 
 class SortPicker extends BottomSheetListPicker<PostSortType> {
-  static List<ListPickerItem<PostSortType>> getDefaultPostSortTypeItems() => [
-        ListPickerItem(
-          payload: PostSortType.hot,
-          icon: Icons.local_fire_department_rounded,
-          label: AppLocalizations.of(GlobalContext.context)!.hot,
-        ),
-        ListPickerItem(
-          payload: PostSortType.active,
-          icon: Icons.rocket_launch_rounded,
-          label: AppLocalizations.of(GlobalContext.context)!.active,
-        ),
-        ListPickerItem(
-          payload: PostSortType.scaled,
-          icon: Icons.line_weight_rounded,
-          label: AppLocalizations.of(GlobalContext.context)!.scaled,
-        ),
-        ListPickerItem(
-          payload: PostSortType.controversial,
-          icon: Icons.warning_rounded,
-          label: AppLocalizations.of(GlobalContext.context)!.controversial,
-        ),
-        ListPickerItem(
-          payload: PostSortType.new_,
-          icon: Icons.auto_awesome_rounded,
-          label: AppLocalizations.of(GlobalContext.context)!.new_,
-        ),
-        ListPickerItem(
-          payload: PostSortType.old,
-          icon: Icons.access_time_outlined,
-          label: AppLocalizations.of(GlobalContext.context)!.old,
-        ),
-        ListPickerItem(
-          payload: PostSortType.mostComments,
-          icon: Icons.comment_bank_rounded,
-          label: AppLocalizations.of(GlobalContext.context)!.mostComments,
-        ),
-        ListPickerItem(
-          payload: PostSortType.newComments,
-          icon: Icons.add_comment_rounded,
-          label: AppLocalizations.of(GlobalContext.context)!.newComments,
-        ),
-      ];
+  /// The account that triggered the sort picker.
+  final Account? account;
 
   /// Create a picker which allows selecting a valid sort type.
-  /// Specify a [minimumVersion] to determine which sort types will be displayed.
-  /// Pass `null` to NOT show any version-specific types (e.g., Scaled).
-  /// Pass [LemmyClient.maxVersion] to show ALL types.
   SortPicker({
     super.key,
+    this.account,
     required super.onSelect,
     required super.title,
-    List<ListPickerItem<PostSortType>>? items,
     super.previouslySelected,
-  }) : super(items: items ?? getDefaultPostSortTypeItems());
+  }) : super(items: getDefaultPostSortTypeItems(account: account));
 
   @override
   State<StatefulWidget> createState() => _SortPickerState();
@@ -133,8 +153,8 @@ class _SortPickerState extends State<SortPicker> {
   Widget build(BuildContext context) {
     return SingleChildScrollView(
       child: AnimatedSize(
-        duration: const Duration(milliseconds: 100),
-        curve: Curves.easeInOut,
+        duration: const Duration(milliseconds: 400),
+        curve: Curves.easeInOutCubicEmphasized,
         child: topSelected ? topSortPicker() : defaultSortPicker(),
       ),
     );
@@ -142,6 +162,7 @@ class _SortPickerState extends State<SortPicker> {
 
   Widget defaultSortPicker() {
     final theme = Theme.of(context);
+    final l10n = GlobalContext.l10n;
 
     return Column(
       key: ValueKey<bool>(topSelected),
@@ -152,26 +173,19 @@ class _SortPickerState extends State<SortPicker> {
           padding: const EdgeInsets.only(bottom: 16.0, left: 26.0, right: 16.0),
           child: Align(
             alignment: Alignment.centerLeft,
-            child: Text(
-              widget.title,
-              style: theme.textTheme.titleLarge!.copyWith(),
-            ),
+            child: Text(widget.title, style: theme.textTheme.titleLarge),
           ),
         ),
         ListView(
           shrinkWrap: true,
           physics: const NeverScrollableScrollPhysics(),
           children: [
-            ..._generateList(SortPicker.getDefaultPostSortTypeItems(), theme),
+            ..._generateList(getDefaultPostSortTypeItems(account: widget.account), theme),
             PickerItem(
-              label: AppLocalizations.of(GlobalContext.context)!.top,
+              label: l10n.top,
               icon: Icons.military_tech,
-              onSelected: () {
-                setState(() {
-                  topSelected = true;
-                });
-              },
-              isSelected: topPostSortTypeItems.map((item) => item.payload).contains(widget.previouslySelected),
+              onSelected: () => setState(() => topSelected = true),
+              isSelected: getTopPostSortTypeItems(account: widget.account).map((item) => item.payload).contains(widget.previouslySelected),
               trailingIcon: Icons.chevron_right,
             )
           ],
@@ -183,6 +197,7 @@ class _SortPickerState extends State<SortPicker> {
 
   Widget topSortPicker() {
     final theme = Theme.of(context);
+    final l10n = GlobalContext.l10n;
 
     return Column(
       key: ValueKey<bool>(topSelected),
@@ -190,7 +205,7 @@ class _SortPickerState extends State<SortPicker> {
       mainAxisSize: MainAxisSize.max,
       children: [
         Semantics(
-          label: '${AppLocalizations.of(context)!.sortByTop},${AppLocalizations.of(context)!.backButton}',
+          label: '${l10n.sortByTop},${l10n.backButton}',
           child: Padding(
             padding: const EdgeInsets.only(left: 10, right: 10),
             child: Material(
@@ -209,20 +224,9 @@ class _SortPickerState extends State<SortPicker> {
                     alignment: Alignment.centerLeft,
                     child: Row(
                       children: [
-                        const Icon(
-                          Icons.chevron_left,
-                          size: 30,
-                        ),
-                        const SizedBox(
-                          width: 12,
-                        ),
-                        Semantics(
-                          excludeSemantics: true,
-                          child: Text(
-                            AppLocalizations.of(context)!.sortByTop,
-                            style: theme.textTheme.titleLarge!.copyWith(),
-                          ),
-                        ),
+                        const Icon(Icons.chevron_left, size: 30),
+                        const SizedBox(width: 12),
+                        Semantics(excludeSemantics: true, child: Text(l10n.sortByTop, style: theme.textTheme.titleLarge)),
                       ],
                     ),
                   ),
@@ -234,9 +238,7 @@ class _SortPickerState extends State<SortPicker> {
         ListView(
           shrinkWrap: true,
           physics: const NeverScrollableScrollPhysics(),
-          children: [
-            ..._generateList(topPostSortTypeItems, theme),
-          ],
+          children: [..._generateList(getTopPostSortTypeItems(account: widget.account), theme)],
         ),
         const SizedBox(height: 16.0),
       ],

--- a/lib/user/pages/user_settings_page.dart
+++ b/lib/user/pages/user_settings_page.dart
@@ -338,11 +338,12 @@ class _UserSettingsPageState extends State<UserSettingsPage> {
                                   icon: Icons.local_fire_department_rounded,
                                   payload: localUser?.defaultSortType,
                                 ),
-                                options: [...SortPicker.getDefaultPostSortTypeItems(), ...topPostSortTypeItems],
+                                options: [...getDefaultPostSortTypeItems(account: account), ...getTopPostSortTypeItems(account: account)],
                                 icon: Icons.sort_rounded,
                                 onChanged: (_) async {},
                                 isBottomModalScrollControlled: true,
                                 customListPicker: SortPicker(
+                                  account: account,
                                   title: l10n.defaultFeedSortType,
                                   onSelect: (value) async {
                                     context.read<UserSettingsBloc>().add(UpdateUserSettingsEvent(defaultPostSortType: value.payload));

--- a/lib/user/widgets/user_header/user_header_actions.dart
+++ b/lib/user/widgets/user_header/user_header_actions.dart
@@ -281,7 +281,8 @@ class _SortActionChip extends StatelessWidget {
       return const SizedBox.shrink();
     }
 
-    final state = context.read<FeedBloc>().state;
+    final feedBloc = context.read<FeedBloc>();
+    final state = feedBloc.state;
 
     return ThunderActionChip(
       icon: getSortIcon(state),
@@ -295,6 +296,7 @@ class _SortActionChip extends StatelessWidget {
           context: context,
           isScrollControlled: true,
           builder: (builderContext) => SortPicker(
+            account: feedBloc.account,
             title: l10n.sortOptions,
             onSelect: (selected) async {
               try {


### PR DESCRIPTION
## Pull Request Description

<!--- Please describe what was changed -->

This PR hides incompatible post and comment sort types for PieFed. The logic has been generalized to support other platforms in the future if needed! Each `CommentSortType` and `PostSortType` enum now accepts an optional `platform` field. When specified, the associated sort type will only appear for profiles using that platform.

The bottom sheet widgets for sorting have also been updated to accept an optional `account` parameter. If an account is provided, only sort types supported by that account's platform will be displayed. If no account is passed, all available sort types will be shown.

## Issue Being Fixed

<!-- Please describe the problem that is being fixed and, if applicable, reference a GitHub issue -->

Issue Number: N/A

## Screenshots / Recordings

<!-- This section is optional but highly recommended to show off your changes! -->

## Checklist

- [ ] If a new package was added, did you ensure it uses an appropriate license and is actively maintained?
- [ ] Did you use localized strings (and added appropriate descriptions) where applicable?
- [ ] Did you add `semanticLabel`s where applicable for accessibility?
