### PR TITLE
Fix mark reply/mention as read

### DIFF
--- a/lib/src/features/comment/data/models/thunder_comment.dart
+++ b/lib/src/features/comment/data/models/thunder_comment.dart
@@ -10,6 +10,9 @@ class ThunderComment {
   /// The comment's creator ID
   final int creatorId;
 
+  /// The comment reply/mention ID (for replies/mentions)
+  final int? replyMentionId;
+
   /// The comment's post ID
   final int postId;
 
@@ -97,6 +100,7 @@ class ThunderComment {
   ThunderComment({
     required this.id,
     required this.creatorId,
+    this.replyMentionId,
     required this.postId,
     required this.content,
     required this.removed,
@@ -130,6 +134,7 @@ class ThunderComment {
   ThunderComment copyWith({
     int? id,
     int? creatorId,
+    int? replyMentionId,
     int? postId,
     String? content,
     bool? removed,
@@ -162,6 +167,7 @@ class ThunderComment {
     return ThunderComment(
       id: id ?? this.id,
       creatorId: creatorId ?? this.creatorId,
+      replyMentionId: replyMentionId ?? this.replyMentionId,
       postId: postId ?? this.postId,
       content: content ?? this.content,
       removed: removed ?? this.removed,
@@ -211,7 +217,7 @@ class ThunderComment {
     );
   }
 
-  factory ThunderComment.fromLemmyCommentView(Map<String, dynamic> commentView) {
+  factory ThunderComment.fromLemmyCommentView(Map<String, dynamic> commentView, {int? replyMentionId}) {
     final comment = commentView['comment'];
     final creator = commentView['creator'];
     final post = commentView['post'];
@@ -221,6 +227,7 @@ class ThunderComment {
     return ThunderComment(
       id: comment['id'],
       creatorId: comment['creator_id'],
+      replyMentionId: replyMentionId,
       postId: comment['post_id'],
       content: comment['content'],
       removed: comment['removed'],

--- a/lib/src/features/inbox/presentation/bloc/inbox_bloc.dart
+++ b/lib/src/features/inbox/presentation/bloc/inbox_bloc.dart
@@ -233,10 +233,16 @@ class InboxBloc extends Bloc<InboxEvent, InboxState> {
     ThunderComment? existingPersonMentionView;
     PrivateMessageView? existingPrivateMessageView;
 
-    if (event.commentReplyId != null) {
+    if (event.commentReplyId != null && event.action == CommentAction.read) {
+      existingIndex = state.replies.indexWhere((element) => element.replyMentionId == event.commentReplyId);
+      existingCommentReplyView = state.replies[existingIndex];
+    } else if (event.commentReplyId != null && event.action != CommentAction.read) {
       existingIndex = state.replies.indexWhere((element) => element.id == event.commentReplyId);
       existingCommentReplyView = state.replies[existingIndex];
-    } else if (event.personMentionId != null) {
+    } else if (event.personMentionId != null && event.action == CommentAction.read) {
+      existingIndex = state.mentions.indexWhere((element) => element.replyMentionId == event.personMentionId);
+      existingPersonMentionView = state.mentions[existingIndex];
+    } else if (event.personMentionId != null && event.action != CommentAction.read) {
       existingIndex = state.mentions.indexWhere((element) => element.id == event.personMentionId);
       existingPersonMentionView = state.mentions[existingIndex];
     } else if (event.privateMessageId != null) {

--- a/lib/src/features/inbox/presentation/widgets/inbox_mentions_view.dart
+++ b/lib/src/features/inbox/presentation/widgets/inbox_mentions_view.dart
@@ -5,6 +5,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 
 import 'package:thunder/l10n/generated/app_localizations.dart';
+import 'package:thunder/src/app/utils/navigation.dart';
 import 'package:thunder/src/features/account/account.dart';
 import 'package:thunder/src/features/comment/comment.dart';
 import 'package:thunder/src/features/feed/feed.dart';
@@ -53,8 +54,28 @@ class _InboxMentionsViewState extends State<InboxMentionsView> {
                   CommentReference(
                     comment: comment,
                     isOwnComment: comment.creatorId == context.read<ProfileBloc>().state.account.userId,
+                    onVoteAction: (int commentId, int voteType) => context.read<InboxBloc>().add(
+                          InboxItemActionEvent(
+                            action: CommentAction.vote,
+                            personMentionId: comment.id,
+                            value: switch (voteType) {
+                              1 => comment.myVote == 1 ? 0 : 1,
+                              -1 => comment.myVote == -1 ? 0 : -1,
+                              _ => 0,
+                            },
+                          ),
+                        ),
+                    onSaveAction: (int commentId, bool save) => context.read<InboxBloc>().add(InboxItemActionEvent(action: CommentAction.save, personMentionId: comment.id, value: save)),
+                    onDeleteAction: (int commentId, bool deleted) => context.read<InboxBloc>().add(InboxItemActionEvent(action: CommentAction.delete, personMentionId: comment.id, value: deleted)),
+                    onReplyEditAction: (ThunderComment comment, bool isEdit) {
+                      return navigateToCreateCommentPage(
+                        context,
+                        comment: isEdit ? comment : null,
+                        parentComment: isEdit ? null : comment,
+                      );
+                    },
                     child: IconButton(
-                      onPressed: () => context.read<InboxBloc>().add(InboxItemActionEvent(action: CommentAction.read, personMentionId: comment.id, value: !comment.read!)),
+                      onPressed: () => context.read<InboxBloc>().add(InboxItemActionEvent(action: CommentAction.read, personMentionId: comment.replyMentionId!, value: !comment.read!)),
                       icon: Icon(
                         Icons.check,
                         semanticLabel: l10n.markAsRead,

--- a/lib/src/features/inbox/presentation/widgets/inbox_replies_view.dart
+++ b/lib/src/features/inbox/presentation/widgets/inbox_replies_view.dart
@@ -76,7 +76,7 @@ class _InboxRepliesViewState extends State<InboxRepliesView> {
                       );
                     },
                     child: IconButton(
-                      onPressed: () => context.read<InboxBloc>().add(InboxItemActionEvent(action: CommentAction.read, commentReplyId: reply.id, value: !reply.read!)),
+                      onPressed: () => context.read<InboxBloc>().add(InboxItemActionEvent(action: CommentAction.read, commentReplyId: reply.replyMentionId!, value: !reply.read!)),
                       icon: Icon(
                         Icons.check,
                         semanticLabel: l10n.markAsRead,

--- a/lib/src/features/notification/data/repositories/notification_repository.dart
+++ b/lib/src/features/notification/data/repositories/notification_repository.dart
@@ -111,6 +111,7 @@ class NotificationRepositoryImpl implements NotificationRepository {
 
           return comment.copyWith(
             recipient: ThunderUser.fromLemmyUser(crv.recipient.toJson()),
+            replyMentionId: crv.commentReply.id,
             read: crv.commentReply.read,
           );
         }).toList();
@@ -122,6 +123,7 @@ class NotificationRepositoryImpl implements NotificationRepository {
 
           return comment.copyWith(
             recipient: ThunderUser.fromPiefedUser(crv['recipient']),
+            replyMentionId: crv['comment_reply']['id'],
             read: crv['comment_reply']['read'],
           );
         }).toList();
@@ -169,6 +171,7 @@ class NotificationRepositoryImpl implements NotificationRepository {
 
           return comment.copyWith(
             recipient: ThunderUser.fromLemmyUser(mention.recipient.toJson()),
+            replyMentionId: mention.personMention.id,
             read: mention.personMention.read,
           );
         }).toList();
@@ -179,6 +182,7 @@ class NotificationRepositoryImpl implements NotificationRepository {
 
           return comment.copyWith(
             recipient: ThunderUser.fromPiefedUser(mention['recipient']),
+            replyMentionId: mention['comment_reply']['id'],
             read: mention['comment_reply']['read'],
           );
         }).toList();


### PR DESCRIPTION
## Pull Request Description

This PR fixes an issue where marking a reply/mention was not working as expected, likely due to recent changes with PieFed integration. Additionally, this also adds support for vote/save/delete/reply actions for mentions (was missing the appropriate callbacks)

<!--- Please describe what was changed -->

## Issue Being Fixed

<!-- Please describe the problem that is being fixed and, if applicable, reference a GitHub issue -->

Issue Number: N/A

## Screenshots / Recordings

<!-- This section is optional but highly recommended to show off your changes! -->

## Checklist

- [ ] If a new package was added, did you ensure it uses an appropriate license and is actively maintained?
- [ ] Did you use localized strings (and added appropriate descriptions) where applicable?
- [ ] Did you add `semanticLabel`s where applicable for accessibility?
