### PR TITLE
Disable Android auto backup/restore

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -15,6 +15,7 @@
         android:networkSecurityConfig="@xml/network_security_config"
         android:requestLegacyExternalStorage="true"
         android:enableOnBackInvokedCallback="false"
+        android:allowBackup="false"
         >
       
         <activity

--- a/lib/src/app/bloc/thunder_bloc.dart
+++ b/lib/src/app/bloc/thunder_bloc.dart
@@ -264,7 +264,7 @@ class ThunderBloc extends Bloc<ThunderEvent, ThunderState> {
       VideoPlayBackSpeed videoDefaultPlaybackSpeed = VideoPlayBackSpeed.values.byName(UserPreferences.getLocalSetting(LocalSettings.videoDefaultPlaybackSpeed) ?? VideoPlayBackSpeed.normal.name);
       VideoPlayerMode videoPlayerMode = VideoPlayerMode.values.byName(UserPreferences.getLocalSetting(LocalSettings.videoPlayerMode) ?? VideoPlayerMode.inApp.name);
 
-      String currentAnonymousInstance = UserPreferences.getLocalSetting(LocalSettings.currentAnonymousInstance) ?? 'lemmy.ml';
+      String currentAnonymousInstance = UserPreferences.getLocalSetting(LocalSettings.currentAnonymousInstance) ?? DEFAULT_INSTANCE;
 
       return emit(state.copyWith(
         status: ThunderStatus.success,

--- a/lib/src/app/bloc/thunder_state.dart
+++ b/lib/src/app/bloc/thunder_state.dart
@@ -168,7 +168,7 @@ class ThunderState extends Equatable {
 
     /// -------------------------- Accessibility Related Settings --------------------------
     this.reduceAnimations = false,
-    this.currentAnonymousInstance = 'lemmy.ml',
+    this.currentAnonymousInstance = DEFAULT_INSTANCE,
 
     /// --------------------------------- UI Events ---------------------------------
     // Expand/Close FAB event

--- a/lib/src/features/account/presentation/utils/profiles.dart
+++ b/lib/src/features/account/presentation/utils/profiles.dart
@@ -1,14 +1,14 @@
-import 'package:collection/collection.dart';
 import 'package:flutter/material.dart';
 
+import 'package:collection/collection.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
+
 import 'package:thunder/src/core/enums/local_settings.dart';
 import 'package:thunder/src/core/enums/threadiverse_platform.dart';
-
 import 'package:thunder/src/core/singletons/preferences.dart';
 import 'package:thunder/src/app/bloc/thunder_bloc.dart';
 import 'package:thunder/src/features/account/account.dart';
-import 'package:thunder/src/shared/utils/instance.dart';
+import 'package:thunder/src/shared/utils/constants.dart';
 
 /// Fetches the currently active profile. This includes logged in and anonymous accounts.
 ///
@@ -36,13 +36,10 @@ Future<Account> fetchActiveProfile() async {
     return account;
   }
 
-  // No anonymous account found. Let's create a new default one.TODO: Allow changing of default instance.
-  final defaultInstance = 'lemmy.ml';
+  // No anonymous account found. Let's create a new default one. TODO: Allow changing of default instance.
+  final defaultInstance = DEFAULT_INSTANCE;
 
-  // Detect the platform for the default instance
-  final ThreadiversePlatform? platform = await detectPlatformFromNodeInfo(defaultInstance);
-
-  account = await Account.insertAnonymousInstance(Account(id: '', instance: defaultInstance, index: -1, anonymous: true, platform: platform));
+  account = await Account.insertAnonymousInstance(Account(id: '', instance: defaultInstance, index: -1, anonymous: true, platform: ThreadiversePlatform.lemmy));
   if (account == null) throw Exception("Failed to create default profile");
 
   // Set this instance as the default anonymous instance.

--- a/lib/src/features/account/presentation/widgets/profile_modal_body.dart
+++ b/lib/src/features/account/presentation/widgets/profile_modal_body.dart
@@ -1,8 +1,8 @@
 import 'dart:io';
 
-import 'package:dart_ping/dart_ping.dart';
 import 'package:flutter/material.dart';
 
+import 'package:dart_ping/dart_ping.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:cached_network_image/cached_network_image.dart';
 import 'package:swipeable_page_route/swipeable_page_route.dart';
@@ -14,6 +14,7 @@ import 'package:thunder/src/app/theme/bloc/theme_bloc.dart';
 import 'package:thunder/src/features/notification/notification.dart';
 import 'package:thunder/src/app/bloc/thunder_bloc.dart';
 import 'package:thunder/src/features/user/user.dart';
+import 'package:thunder/src/shared/utils/constants.dart';
 import 'package:thunder/src/shared/utils/instance.dart';
 import 'package:thunder/l10n/generated/app_localizations.dart';
 
@@ -707,19 +708,17 @@ class _ProfileSelectState extends State<ProfileSelect> {
           profileBloc.add(SwitchProfile(accountId: accountsNotCurrent.last.id));
         } else {
           // No accounts and no anonymous instances left. Create a new one.
-          // Detect the platform for the default instance
-          final ThreadiversePlatform? platform = await detectPlatformFromNodeInfo('lemmy.ml');
-
           await Account.insertAnonymousInstance(Account(
             id: '',
-            instance: 'lemmy.ml',
+            instance: DEFAULT_INSTANCE,
             index: -1,
             anonymous: true,
-            platform: platform,
+            platform: ThreadiversePlatform.lemmy,
           ));
+
           thunderBloc.add(const OnSetCurrentAnonymousInstance(null));
-          thunderBloc.add(const OnSetCurrentAnonymousInstance('lemmy.ml'));
-          profileBloc.add(SwitchProfile(accountId: 'lemmy.ml'));
+          thunderBloc.add(const OnSetCurrentAnonymousInstance(DEFAULT_INSTANCE));
+          profileBloc.add(SwitchProfile(accountId: DEFAULT_INSTANCE));
         }
 
         setState(() {

--- a/lib/src/shared/utils/constants.dart
+++ b/lib/src/shared/utils/constants.dart
@@ -70,3 +70,5 @@ const Color DARK_THEME_BACKGROUND_COLOR = Color.fromARGB(255, 50, 50, 50);
 const Color LIGHT_THEME_BACKGROUND_COLOR = Color.fromARGB(255, 242, 242, 242);
 
 const double APP_BAR_HEIGHT = 70.0;
+
+const DEFAULT_INSTANCE = 'lemmy.world';

--- a/lib/src/shared/utils/preferences.dart
+++ b/lib/src/shared/utils/preferences.dart
@@ -12,7 +12,6 @@ import 'package:thunder/src/core/enums/theme_type.dart';
 import 'package:thunder/src/features/notification/notification.dart';
 import 'package:thunder/src/core/singletons/preferences.dart';
 import 'package:thunder/src/shared/utils/constants.dart';
-import 'package:thunder/src/shared/utils/instance.dart';
 
 @Deprecated('Use Draft model through database instead')
 class DraftComment {
@@ -149,15 +148,12 @@ Future<void> performSharedPreferencesMigration() async {
   final List<String>? anonymousInstances = prefs.getStringList('setting_anonymous_instances');
   try {
     for (String instance in anonymousInstances ?? []) {
-      // Detect the platform for the migrated instance
-      final ThreadiversePlatform? platform = await detectPlatformFromNodeInfo(instance);
-
       Account anonymousInstance = Account(
         id: '',
         instance: instance,
         index: -1,
         anonymous: true,
-        platform: platform,
+        platform: ThreadiversePlatform.lemmy,
       );
       Account.insertAnonymousInstance(anonymousInstance);
     }


### PR DESCRIPTION
## Pull Request Description

This PR disables Android's auto backup/restore feature. See https://developer.android.com/identity/data/autobackup for more details. There are a couple of reasons for disabling this:
- We already have existing methods of backing up and restoring data within Thunder. Ideally, users should rely on these methods to handle backups/restore as we have more control over the process (e.g., determining what to backup and how they should be restored)
- Re-installing Thunder should reset Thunder back to a clean state without any previous user data/settings. This makes it easier to debug issues that result from the auto restore

Additionally, I've cleaned up some logic surrounding Lemmy/PieFed detection (and also switched the default instance back to lemmy.world)

<!--- Please describe what was changed -->

## Issue Being Fixed

<!-- Please describe the problem that is being fixed and, if applicable, reference a GitHub issue -->

Issue Number: N/A

## Screenshots / Recordings

<!-- This section is optional but highly recommended to show off your changes! -->

## Checklist

- [ ] If a new package was added, did you ensure it uses an appropriate license and is actively maintained?
- [ ] Did you use localized strings (and added appropriate descriptions) where applicable?
- [ ] Did you add `semanticLabel`s where applicable for accessibility?
