### PR TITLE
Hide URL metadata for image posts within post cards

### DIFF
--- a/lib/src/features/community/presentation/widgets/post_card_view_comfortable.dart
+++ b/lib/src/features/community/presentation/widgets/post_card_view_comfortable.dart
@@ -237,7 +237,7 @@ class PostCardViewComfortable extends StatelessWidget {
                         unreadCommentCount: post.unreadComments,
                         dateTime: dateTime,
                         edited: edited,
-                        url: media?.originalUrl,
+                        url: media?.mediaType == MediaType.image ? null : media?.originalUrl,
                         languageId: post.languageId,
                         dim: dim,
                       ),

--- a/lib/src/features/community/presentation/widgets/post_card_view_compact.dart
+++ b/lib/src/features/community/presentation/widgets/post_card_view_compact.dart
@@ -118,7 +118,7 @@ class PostCardViewCompact extends StatelessWidget {
                   unreadCommentCount: post.unreadComments,
                   dateTime: dateTime,
                   edited: edited,
-                  url: mediaUrl,
+                  url: post.media.firstOrNull?.mediaType == MediaType.image ? null : mediaUrl,
                   languageId: post.languageId,
                   dim: dim,
                 ),

--- a/lib/src/features/post/presentation/utils/post.dart
+++ b/lib/src/features/post/presentation/utils/post.dart
@@ -1,5 +1,7 @@
 import 'package:flutter/material.dart';
 
+import 'package:html_unescape/html_unescape_small.dart';
+
 import 'package:thunder/src/features/account/account.dart';
 import 'package:thunder/src/core/enums/local_settings.dart';
 import 'package:thunder/src/core/enums/media_type.dart';
@@ -108,7 +110,13 @@ Future<List<ThunderPost>> parsePosts(List<ThunderPost> posts, {String? resolutio
   return parsedPosts;
 }
 
+/// Perform some pre-processing on the post before displaying it.
+///
+/// This includes unescaping the title and parsing any associated media.
 Future<ThunderPost> parsePost(ThunderPost post, bool fetchImageDimensions, bool edgeToEdgeImages, bool tabletMode) async {
+  final html = HtmlUnescape();
+  final title = html.convert(post.name);
+
   List<Media> mediaList = [];
 
   // There are three sources of URLs: the main url attached to the post, the thumbnail url attached to the post, and the video url attached to the post
@@ -184,5 +192,5 @@ Future<ThunderPost> parsePost(ThunderPost post, bool fetchImageDimensions, bool 
   media.height = scaledSize?.height;
   mediaList.add(media);
 
-  return post.copyWith(media: mediaList);
+  return post.copyWith(media: mediaList, name: title);
 }

--- a/lib/src/features/post/presentation/widgets/post_body/post_body_title.dart
+++ b/lib/src/features/post/presentation/widgets/post_body/post_body_title.dart
@@ -1,7 +1,6 @@
 import 'package:flutter/material.dart';
 
 import 'package:flutter_bloc/flutter_bloc.dart';
-import 'package:html_unescape/html_unescape_small.dart';
 
 import 'package:thunder/src/features/account/account.dart';
 import 'package:thunder/src/core/enums/font_scale.dart';
@@ -114,7 +113,7 @@ class PostBodyTitle extends StatelessWidget {
     final titleFontSizeScale = context.select<ThunderBloc, FontScale>((bloc) => bloc.state.titleFontSizeScale);
 
     return ScalableText(
-      HtmlUnescape().convert(post.name),
+      post.name,
       fontScale: titleFontSizeScale,
       style: theme.textTheme.titleMedium,
     );

--- a/lib/src/features/post/presentation/widgets/post_card_title.dart
+++ b/lib/src/features/post/presentation/widgets/post_card_title.dart
@@ -1,7 +1,6 @@
 import 'package:flutter/material.dart';
 
 import 'package:flutter_bloc/flutter_bloc.dart';
-import 'package:html_unescape/html_unescape_small.dart';
 
 import 'package:thunder/src/core/enums/font_scale.dart';
 import 'package:thunder/src/features/post/post.dart';
@@ -45,8 +44,6 @@ class PostCardTitle extends StatelessWidget {
     this.dim = false,
   });
 
-  static final _html = HtmlUnescape();
-
   Color? _getDimmedColor(Color? color) => color?.withValues(alpha: 0.55);
 
   /// Returns the color of the title.
@@ -78,7 +75,7 @@ class PostCardTitle extends StatelessWidget {
         children: [
           WidgetSpan(child: statuses),
           TextSpan(
-            text: _html.convert(title),
+            text: title,
             style: textStyle?.copyWith(
               fontWeight: FontWeight.w600,
               fontSize: fontSize,

--- a/lib/src/shared/widgets/text/selectable_text_modal.dart
+++ b/lib/src/shared/widgets/text/selectable_text_modal.dart
@@ -5,7 +5,6 @@ import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 
 import 'package:flutter_bloc/flutter_bloc.dart';
-import 'package:html_unescape/html_unescape_small.dart';
 import 'package:thunder/src/core/enums/font_scale.dart';
 import 'package:thunder/src/shared/widgets/chips/thunder_action_chip.dart';
 import 'package:thunder/src/shared/markdown/common_markdown_body.dart';
@@ -115,7 +114,7 @@ void showSelectableTextModal(BuildContext context, {String? title, required Stri
                                     Align(
                                       alignment: Alignment.centerLeft,
                                       child: Text(
-                                        HtmlUnescape().convert(title!),
+                                        title!,
                                         style: theme.textTheme.bodyMedium?.copyWith(
                                           fontWeight: FontWeight.w600,
                                           fontSize: MediaQuery.textScalerOf(context).scale(theme.textTheme.bodyMedium!.fontSize! * thunderState.titleFontSizeScale.textScaleFactor),


### PR DESCRIPTION
## Pull Request Description

This PR hides the URL metadata for image posts within the related post cards (compact/card). URL metadata for other types of posts are still shown by default (e.g., links, videos, etc.).

Additionally, I've moved the HTML unescaping for post titles into the `parsePost` function to centralize that logic!

<!--- Please describe what was changed -->

## Issue Being Fixed

<!-- Please describe the problem that is being fixed and, if applicable, reference a GitHub issue -->

Issue Number: N/A

## Screenshots / Recordings

<!-- This section is optional but highly recommended to show off your changes! -->

## Checklist

- [ ] If a new package was added, did you ensure it uses an appropriate license and is actively maintained?
- [ ] Did you use localized strings (and added appropriate descriptions) where applicable?
- [ ] Did you add `semanticLabel`s where applicable for accessibility?
