### PR TITLE
Fix user labels not appearing for some users

### DIFF
--- a/lib/src/features/comment/presentation/widgets/comment_card/comment_card_header.dart
+++ b/lib/src/features/comment/presentation/widgets/comment_card/comment_card_header.dart
@@ -100,7 +100,7 @@ class CommentCardHeader extends StatelessWidget {
                 )
               ],
             ),
-            UserLabelChip(username: UserLabel.usernameFromParts(comment.creator!.name, comment.creator!.actorId))
+            UserLabelChip(username: UserLabel.usernameFromParts(comment.creator!.displayNameOrName, comment.creator!.actorId))
           ],
         ),
       ),


### PR DESCRIPTION
## Pull Request Description

This PR fixes an issue where user labels would not appear for certain users with display names.

<!--- Please describe what was changed -->

## Issue Being Fixed

<!-- Please describe the problem that is being fixed and, if applicable, reference a GitHub issue -->

Issue Number: https://lemmy.world/post/34802224

## Screenshots / Recordings

<!-- This section is optional but highly recommended to show off your changes! -->

## Checklist

- [ ] If a new package was added, did you ensure it uses an appropriate license and is actively maintained?
- [ ] Did you use localized strings (and added appropriate descriptions) where applicable?
- [ ] Did you add `semanticLabel`s where applicable for accessibility?
