### PR TITLE
Improvements to image loading and handling

### DIFF
--- a/lib/src/core/cache/image_dimension_cache.dart
+++ b/lib/src/core/cache/image_dimension_cache.dart
@@ -14,7 +14,7 @@ class ImageDimensionCache {
   final _cache = HashMap<String, Size>();
 
   /// Fetches the image dimensions using cache if valid
-  Future<Size?> get(String url) async {
+  Size? get(String url) {
     final entry = _cache[url];
 
     if (entry != null) {

--- a/lib/src/core/cache/image_dimension_cache.dart
+++ b/lib/src/core/cache/image_dimension_cache.dart
@@ -1,0 +1,33 @@
+import 'dart:collection';
+
+import 'package:flutter/material.dart';
+
+/// A simple cache that holds a given image's dimensions
+class ImageDimensionCache {
+  static final ImageDimensionCache _instance = ImageDimensionCache._internal();
+
+  factory ImageDimensionCache() => _instance;
+
+  ImageDimensionCache._internal();
+
+  /// Cache entry per image key
+  final _cache = HashMap<String, Size>();
+
+  /// Fetches the image dimensions using cache if valid
+  Future<Size?> get(String url) async {
+    final entry = _cache[url];
+
+    if (entry != null) {
+      debugPrint('ImageDimensionCache: Returning cached image dimensions for $url');
+      return entry;
+    }
+
+    return null;
+  }
+
+  /// Sets the image dimensions for the given [url].
+  void set(String url, Size size) {
+    _cache[url] = size;
+    debugPrint('ImageDimensionCache: Cached image dimensions for $url');
+  }
+}

--- a/lib/src/core/network/lemmy_api.dart
+++ b/lib/src/core/network/lemmy_api.dart
@@ -57,13 +57,13 @@ class LemmyApi {
   }
 
   /// Handle response from the request. Throws an exception if the request fails.
-  Map<String, dynamic> _handleResponse(Uri uri, Response response) {
+  Future _handleResponse(Uri uri, Response response) {
     if (response.statusCode != 200) {
       debugPrint('Lemmy API: Failed to make request to $uri: ${response.statusCode} ${response.body}');
       throw LemmyApiException(response.body, response.statusCode.toString());
     }
 
-    return jsonDecode(response.body);
+    return compute(jsonDecode, response.body);
   }
 
   /// Makes an HTTP request with the specified method
@@ -101,7 +101,7 @@ class LemmyApi {
         }
       }
 
-      return _handleResponse(uri, response);
+      return await _handleResponse(uri, response);
     } catch (e) {
       if (debug) debugPrint('Lemmy API: Error: $e');
       rethrow;
@@ -725,7 +725,7 @@ class LemmyApi {
       final response = await request.send();
       if (response.statusCode != 201) throw Exception('Failed to upload image: ${response.statusCode} ${response.reasonPhrase}');
 
-      final json = await jsonDecode(await response.stream.bytesToString());
+      final json = await compute(jsonDecode, await response.stream.bytesToString());
       return json;
     } catch (e) {
       throw Exception('Failed to upload image: $e');

--- a/lib/src/core/network/piefed_api.dart
+++ b/lib/src/core/network/piefed_api.dart
@@ -43,13 +43,13 @@ class PiefedApi {
   }
 
   /// Handle response from the request. Throws an exception if the request fails.
-  Map<String, dynamic> _handleResponse(Uri uri, Response response) {
+  Future _handleResponse(Uri uri, Response response) {
     if (response.statusCode != 200) {
       debugPrint('PieFed API: Failed to make request to $uri: ${response.statusCode} ${response.body}');
       throw Exception(response.body);
     }
 
-    return jsonDecode(response.body);
+    return compute(jsonDecode, response.body);
   }
 
   /// Makes an HTTP request with the specified method
@@ -87,7 +87,7 @@ class PiefedApi {
         }
       }
 
-      return _handleResponse(uri, response);
+      return await _handleResponse(uri, response);
     } catch (e) {
       if (debug) debugPrint('PieFed API: Error: $e');
       rethrow;
@@ -592,7 +592,7 @@ class PiefedApi {
       final response = await request.send();
       if (response.statusCode != 200) throw Exception('Failed to upload image: ${response.statusCode} ${response.reasonPhrase}');
 
-      final json = await jsonDecode(await response.stream.bytesToString());
+      final json = await compute(jsonDecode, await response.stream.bytesToString());
       return json['url'];
     } catch (e) {
       throw Exception('Failed to upload image: $e');

--- a/lib/src/features/instance/presentation/pages/instance_page.dart
+++ b/lib/src/features/instance/presentation/pages/instance_page.dart
@@ -83,9 +83,7 @@ class _InstancePageState extends State<InstancePage> {
     isBlocked ??= widget.isBlocked ?? false;
     final bool tabletMode = context.read<ThunderBloc>().state.tabletMode;
 
-    final bool isUserLoggedIn = context.read<ProfileBloc>().state.isLoggedIn;
     final String accountInstance = context.read<ProfileBloc>().state.account.instance;
-    final String? currentAnonymousInstance = context.read<ThunderBloc>().state.currentAnonymousInstance;
 
     final chipColor = theme.colorScheme.primaryContainer.withValues(alpha: 0.25);
 
@@ -96,7 +94,7 @@ class _InstancePageState extends State<InstancePage> {
         BlocProvider.value(
           value: InstancePageCubit(
             instance: fetchInstanceNameFromUrl(widget.site.site.actorId)!,
-            resolutionInstance: (isUserLoggedIn ? accountInstance : currentAnonymousInstance)!,
+            resolutionInstance: accountInstance,
             account: account,
           ),
         ),

--- a/lib/src/features/post/presentation/bloc/post_bloc.dart
+++ b/lib/src/features/post/presentation/bloc/post_bloc.dart
@@ -367,7 +367,7 @@ class PostBloc extends Bloc<PostEvent, PostState> {
 
     return emit(state.copyWith(
       status: PostStatus.success,
-      highlightedCommentId: event.comment.id,
+      highlightedCommentId: null,
       comments: state.commentNodes!.flatten(),
       moddingCommentId: -1,
     ));

--- a/lib/src/features/post/presentation/pages/post_page.dart
+++ b/lib/src/features/post/presentation/pages/post_page.dart
@@ -63,12 +63,6 @@ class _PostPageState extends State<PostPage> {
   /// Whether the post source should be displayed.
   bool viewSource = false;
 
-  /// The active account that was selected when the page was opened
-  Account? originalUser;
-
-  /// Whether the user changed during the course of viewing the post
-  bool userChanged = false;
-
   /// Whether we have set the initial scroll offset.
   /// This needs to be done after building so the controller is attached
   bool hasSetInitialScroll = false;
@@ -142,7 +136,7 @@ class _PostPageState extends State<PostPage> {
     if (state.didScrollPositionChange) return;
 
     if (state.status == PostStatus.success && state.post != null) {
-      if (!userChanged) widget.onPostUpdated?.call(state.post!);
+      widget.onPostUpdated?.call(state.post!);
       setState(() {});
     }
 
@@ -158,8 +152,6 @@ class _PostPageState extends State<PostPage> {
     final thunderState = context.read<ThunderBloc>().state;
 
     final account = context.read<PostBloc>().account;
-
-    originalUser ??= context.read<ProfileBloc>().state.account;
 
     return BlocConsumer<PostBloc, PostState>(
       listenWhen: listenWhen,
@@ -243,7 +235,6 @@ class _PostPageState extends State<PostPage> {
                             text: state.post?.body ?? '',
                           );
                         },
-                        onUserChanged: () => userChanged = true,
                         onPostChanged: (post) => context.read<PostBloc>().add(GetPostEvent(post: post)),
                         highlightedCommentId: this.highlightedCommentId,
                         commentPath: widget.commentPath,

--- a/lib/src/features/post/presentation/utils/post.dart
+++ b/lib/src/features/post/presentation/utils/post.dart
@@ -174,11 +174,10 @@ Future<ThunderPost> parsePost(ThunderPost post, bool fetchImageDimensions, bool 
     media.thumbnailUrl = url;
   }
 
-  if (fetchImageDimensions && media.thumbnailUrl != null) {
+  if (size == null && fetchImageDimensions && media.thumbnailUrl != null) {
     // If the instance does not contain image metadata, we'll do some additional checks
     try {
       int imageDimensionTimeout = UserPreferences.getLocalSetting(LocalSettings.imageDimensionTimeout) ?? 2;
-
       size = await retrieveImageDimensions(imageUrl: media.thumbnailUrl ?? media.mediaUrl).timeout(Duration(seconds: imageDimensionTimeout));
     } catch (e) {
       debugPrint('${media.thumbnailUrl ?? media.originalUrl} - $e: Falling back to default image size');

--- a/lib/src/features/post/presentation/utils/post.dart
+++ b/lib/src/features/post/presentation/utils/post.dart
@@ -170,7 +170,7 @@ Future<ThunderPost> parsePost(ThunderPost post, bool fetchImageDimensions, bool 
     // Now check to see if there is a thumbnail image. If there is, we'll use that for the image
     media.thumbnailUrl = thumbnailUrl;
   } else if (isImage) {
-    // Finally, ff there is no thumbnail image, but the url is an image, we'll use that for the thumbnailUrl
+    // Finally, if there is no thumbnail image, but the url is an image, we'll use that for the thumbnailUrl
     media.thumbnailUrl = url;
   }
 

--- a/lib/src/shared/images/image_preview.dart
+++ b/lib/src/shared/images/image_preview.dart
@@ -4,6 +4,7 @@ import 'package:flutter/material.dart';
 
 import 'package:extended_image/extended_image.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:gif_view/gif_view.dart';
 
 import 'package:thunder/src/core/enums/image_caching_mode.dart';
 import 'package:thunder/src/core/enums/media_type.dart';
@@ -150,35 +151,48 @@ class _ImageContent extends StatelessWidget {
   Widget build(BuildContext context) {
     final devicePixelRatio = MediaQuery.devicePixelRatioOf(context).ceil();
 
-    Widget image = ExtendedImage.network(
-      url,
-      height: height,
-      width: width,
-      fit: fit,
-      color: viewed == true ? const Color.fromRGBO(255, 255, 255, 0.55) : null,
-      colorBlendMode: viewed == true ? BlendMode.modulate : null,
-      cache: true,
-      clearMemoryCacheWhenDispose: imageCachingMode == ImageCachingMode.relaxed,
-      cacheWidth: width != null ? (width! * devicePixelRatio).toInt() : null,
-      cacheHeight: height != null ? (height! * devicePixelRatio).toInt() : null,
-      loadStateChanged: (ExtendedImageState state) {
-        switch (state.extendedImageLoadState) {
-          case LoadState.loading:
-            controller.reset();
-            return const SizedBox.shrink();
-          case LoadState.completed:
-            if (state.wasSynchronouslyLoaded) return state.completedWidget;
+    Widget image = SizedBox.shrink();
 
-            controller.forward();
-            return _FadeInImage(controller: controller, child: state.completedWidget);
-          case LoadState.failed:
-            controller.reset();
-            state.imageProvider.evict();
+    if (url.endsWith('.gif')) {
+      image = RepaintBoundary(
+        child: GifView.network(
+          url,
+          height: height,
+          width: width,
+          fit: fit,
+        ),
+      );
+    } else {
+      image = ExtendedImage.network(
+        url,
+        height: height,
+        width: width,
+        fit: fit,
+        color: viewed == true ? const Color.fromRGBO(255, 255, 255, 0.55) : null,
+        colorBlendMode: viewed == true ? BlendMode.modulate : null,
+        cache: true,
+        clearMemoryCacheWhenDispose: imageCachingMode == ImageCachingMode.relaxed,
+        cacheWidth: width != null ? (width! * devicePixelRatio).toInt() : null,
+        cacheHeight: height != null ? (height! * devicePixelRatio).toInt() : null,
+        loadStateChanged: (ExtendedImageState state) {
+          switch (state.extendedImageLoadState) {
+            case LoadState.loading:
+              controller.reset();
+              return const SizedBox.shrink();
+            case LoadState.completed:
+              if (state.wasSynchronouslyLoaded) return state.completedWidget;
 
-            return ImagePreviewError(mediaType: mediaType, blur: blur == true, viewed: viewed == true);
-        }
-      },
-    );
+              controller.forward();
+              return _FadeInImage(controller: controller, child: state.completedWidget);
+            case LoadState.failed:
+              controller.reset();
+              state.imageProvider.evict();
+
+              return ImagePreviewError(mediaType: mediaType, blur: blur == true, viewed: viewed == true);
+          }
+        },
+      );
+    }
 
     if (blur == true) return _BlurredImage(child: image);
     return image;

--- a/lib/src/shared/images/image_preview.dart
+++ b/lib/src/shared/images/image_preview.dart
@@ -2,17 +2,14 @@ import 'dart:ui';
 
 import 'package:flutter/material.dart';
 
-import 'package:extended_image/extended_image.dart';
-import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:cached_network_image/cached_network_image.dart';
 import 'package:gif_view/gif_view.dart';
 
-import 'package:thunder/src/core/enums/image_caching_mode.dart';
 import 'package:thunder/src/core/enums/media_type.dart';
-import 'package:thunder/src/app/bloc/thunder_bloc.dart';
 import 'package:thunder/src/shared/utils/media/image.dart';
 
 /// Displays a preview of an image.
-class ImagePreview extends StatefulWidget {
+class ImagePreview extends StatelessWidget {
   /// The URL of the image to display.
   final String url;
 
@@ -53,55 +50,26 @@ class ImagePreview extends StatefulWidget {
   });
 
   @override
-  State<ImagePreview> createState() => _ImagePreviewState();
-}
-
-class _ImagePreviewState extends State<ImagePreview> with SingleTickerProviderStateMixin {
-  /// The controller for the image fade animation.
-  late AnimationController _controller;
-
-  @override
-  void initState() {
-    super.initState();
-
-    _controller = AnimationController(
-      vsync: this,
-      duration: const Duration(milliseconds: 130),
-      lowerBound: 0.0,
-      upperBound: 1.0,
-    );
-  }
-
-  @override
-  void dispose() {
-    _controller.dispose();
-    super.dispose();
-  }
-
-  @override
   Widget build(BuildContext context) {
     // TODO: Move the logic for determining if the image is valid into data layer so that we don't need to re-evaluate this on every build.
-    final isValidImageUrl = widget.contentType != null || isImageUrl(widget.url);
-    final imageCachingMode = context.select((ThunderBloc bloc) => bloc.state.imageCachingMode);
+    final isValidImageUrl = contentType != null || isImageUrl(url);
 
     if (!isValidImageUrl) {
       return ImagePreviewError(
-        mediaType: widget.mediaType,
-        blur: widget.blur == true,
-        viewed: widget.viewed == true,
+        mediaType: mediaType,
+        blur: blur == true,
+        viewed: viewed == true,
       );
     }
 
     return _ImageContent(
-      url: widget.url,
-      width: widget.width,
-      height: widget.height,
-      fit: widget.fit,
-      viewed: widget.viewed,
-      blur: widget.blur,
-      mediaType: widget.mediaType,
-      imageCachingMode: imageCachingMode,
-      controller: _controller,
+      url: url,
+      width: width,
+      height: height,
+      fit: fit,
+      viewed: viewed,
+      blur: blur,
+      mediaType: mediaType,
     );
   }
 }
@@ -129,12 +97,6 @@ class _ImageContent extends StatelessWidget {
   /// The media type that the underlying image represents.
   final MediaType? mediaType;
 
-  /// The image caching mode.
-  final ImageCachingMode imageCachingMode;
-
-  /// The controller for the image fade animation.
-  final AnimationController controller;
-
   const _ImageContent({
     required this.url,
     required this.width,
@@ -143,8 +105,6 @@ class _ImageContent extends StatelessWidget {
     required this.viewed,
     required this.blur,
     required this.mediaType,
-    required this.imageCachingMode,
-    required this.controller,
   });
 
   @override
@@ -163,58 +123,23 @@ class _ImageContent extends StatelessWidget {
         ),
       );
     } else {
-      image = ExtendedImage.network(
-        url,
+      image = CachedNetworkImage(
+        imageUrl: url,
         height: height,
         width: width,
         fit: fit,
         color: viewed == true ? const Color.fromRGBO(255, 255, 255, 0.55) : null,
         colorBlendMode: viewed == true ? BlendMode.modulate : null,
-        cache: true,
-        clearMemoryCacheWhenDispose: imageCachingMode == ImageCachingMode.relaxed,
-        cacheWidth: width != null ? (width! * devicePixelRatio).toInt() : null,
-        cacheHeight: height != null ? (height! * devicePixelRatio).toInt() : null,
-        loadStateChanged: (ExtendedImageState state) {
-          switch (state.extendedImageLoadState) {
-            case LoadState.loading:
-              controller.reset();
-              return const SizedBox.shrink();
-            case LoadState.completed:
-              if (state.wasSynchronouslyLoaded) return state.completedWidget;
-
-              controller.forward();
-              return _FadeInImage(controller: controller, child: state.completedWidget);
-            case LoadState.failed:
-              controller.reset();
-              state.imageProvider.evict();
-
-              return ImagePreviewError(mediaType: mediaType, blur: blur == true, viewed: viewed == true);
-          }
-        },
+        fadeInDuration: const Duration(milliseconds: 130),
+        memCacheWidth: width != null ? (width! * devicePixelRatio).toInt() : null,
+        memCacheHeight: height != null ? (height! * devicePixelRatio).toInt() : null,
+        placeholder: (context, url) => const SizedBox.shrink(),
+        errorWidget: (context, url, error) => ImagePreviewError(mediaType: mediaType, blur: blur == true, viewed: viewed == true),
       );
     }
 
     if (blur == true) return _BlurredImage(child: image);
     return image;
-  }
-}
-
-/// A widget that fades in the child widget.
-class _FadeInImage extends StatelessWidget {
-  /// The controller for the fade animation.
-  final AnimationController controller;
-
-  /// The child widget to display.
-  final Widget child;
-
-  const _FadeInImage({required this.controller, required this.child});
-
-  @override
-  Widget build(BuildContext context) {
-    return FadeTransition(
-      opacity: controller,
-      child: child,
-    );
   }
 }
 

--- a/lib/src/shared/markdown/common_markdown_body.dart
+++ b/lib/src/shared/markdown/common_markdown_body.dart
@@ -164,9 +164,6 @@ class MarkdownImageWidget extends StatefulWidget {
   /// Holds a cache of previously retrieved SVG results
   static final Map<String, bool> _svgCache = {};
 
-  /// Holds a cache of previously retrieved image dimensions
-  static final Map<String, Size> _imageDimensionsCache = {};
-
   @override
   State<MarkdownImageWidget> createState() => _MarkdownImageWidgetState();
 }
@@ -177,6 +174,9 @@ class _MarkdownImageWidgetState extends State<MarkdownImageWidget> {
 
   /// The media type of the URL
   MediaType? mediaType;
+
+  /// The dimensions of the image
+  Size? dimensions;
 
   @override
   void initState() {
@@ -196,13 +196,11 @@ class _MarkdownImageWidgetState extends State<MarkdownImageWidget> {
 
   Future<void> _getImageDimensions() async {
     try {
-      if (MarkdownImageWidget._imageDimensionsCache.containsKey(uri)) return;
+      dimensions = await retrieveImageDimensions(imageUrl: uri!);
+      if (dimensions == null) return;
 
-      Size dimensions = await retrieveImageDimensions(imageUrl: uri);
-      dimensions = getScaledMediaSize(width: dimensions.width, height: dimensions.height, offset: 0, tabletMode: true)!;
-
-      MarkdownImageWidget._imageDimensionsCache[uri!] = dimensions;
-      setState(() {});
+      dimensions = getScaledMediaSize(width: dimensions!.width, height: dimensions!.height, offset: 0, tabletMode: true)!;
+      if (mounted) setState(() {});
     } catch (e) {
       debugPrint('Error getting image dimensions: $uri - $e');
     }
@@ -244,8 +242,8 @@ class _MarkdownImageWidgetState extends State<MarkdownImageWidget> {
                     mediaType: MediaType.image,
                     mediaUrl: uri,
                     nsfw: widget.nsfw,
-                    width: MarkdownImageWidget._imageDimensionsCache[uri]?.width,
-                    height: MarkdownImageWidget._imageDimensionsCache[uri]?.height,
+                    width: dimensions?.width,
+                    height: dimensions?.height,
                   ),
                 ),
         ],

--- a/lib/src/shared/utils/media/image.dart
+++ b/lib/src/shared/utils/media/image.dart
@@ -1,16 +1,18 @@
-import 'dart:typed_data';
-import 'dart:math';
 import 'dart:ui';
 
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 
 import 'package:extended_image/extended_image.dart';
+import 'package:flutter/services.dart';
 import 'package:http/http.dart' as http;
+import 'package:image/image.dart' as img;
 import 'package:image_picker/image_picker.dart';
 
+import 'package:thunder/src/core/cache/image_dimension_cache.dart';
 import 'package:thunder/src/shared/images/image_viewer.dart';
 
-/// Givent a URL, returns the proxied URL if it is a proxy URL. Otherwise, returns the original URL.
+/// Given a URL, returns the proxied URL if it is a proxy URL. Otherwise, returns the original URL.
 ///
 /// This is useful for handling thumbnail URLs that are proxied via /image_proxy.
 String fetchProxyImageUrl(String url) {
@@ -31,11 +33,7 @@ String fetchProxyImageUrl(String url) {
   return url;
 }
 
-String generateRandomHeroString({int? len}) {
-  Random r = Random();
-  return String.fromCharCodes(List.generate(len ?? 32, (index) => r.nextInt(33) + 89));
-}
-
+/// Determines if the given URL is an image URL
 bool isImageUrl(String url) {
   // '@jpeg' is added to support Bluesky's image URLs
   // e.g., https://cdn.bsky.app/img/feed_fullsize/plain/did:plc:wf7nfy2us3h5gpa7zfettmzl/bafkreib6k2uwcy52wi654fdfmfqakzqu54m4eq7vi6cwrolwud6yhehihy@jpeg?.jpg
@@ -60,6 +58,7 @@ bool isImageUrl(String url) {
   return false;
 }
 
+/// Determines if the given URL is an SVG
 Future<bool> isImageUrlSvg(String imageUrl) async {
   return isImageUriSvg(Uri.tryParse(imageUrl));
 }
@@ -82,30 +81,45 @@ Future<bool> isImageUriSvg(Uri? imageUri) async {
   }
 }
 
+/// Retrieves the size of the given image. Must provide either [url] or [bytes].
+/// This function should be ran on an isolate to avoid blocking the main thread. See [retrieveImageDimensions] for more information
+Future<Size> processImage(Map<String, dynamic> params) async {
+  final url = params['url'];
+  final bytes = params['bytes'];
+  final token = params['token'];
+
+  BackgroundIsolateBinaryMessenger.ensureInitialized(token);
+
+  Uint8List? data = bytes;
+
+  if (data == null) {
+    // The image provider should throw an error if a valid image is not found
+    // This is to catch cases where the URL may return a valid image, but the URL path does not conform to the expected format
+    final imageProvider = ExtendedNetworkImageProvider(url ?? '', cache: true, cacheRawData: true);
+
+    data = await imageProvider.getNetworkImageData();
+    if (data == null) throw Exception('Failed to retrieve image data from $url');
+  }
+
+  final image = img.decodeImage(data);
+  if (image == null) throw Exception('Failed to retrieve image data from $url');
+  return Size(image.width.toDouble(), image.height.toDouble());
+}
+
 /// Retrieves the size of the given image. Must provide either [imageUrl] or [imageBytes].
 Future<Size> retrieveImageDimensions({String? imageUrl, Uint8List? imageBytes}) async {
   assert(imageUrl != null || imageBytes != null);
 
   try {
-    if (imageBytes != null) {
-      final codec = await instantiateImageCodec(imageBytes);
-      final frame = await codec.getNextFrame();
-      final uiImage = frame.image;
+    Size? size = await ImageDimensionCache().get(imageUrl!);
+    if (size != null) return size;
 
-      return Size(uiImage.width.toDouble(), uiImage.height.toDouble());
-    }
+    final token = RootIsolateToken.instance;
+    size = await compute(processImage, {'url': imageUrl, 'bytes': imageBytes, 'token': token});
+    if (size == null) throw Exception('Failed to retrieve image dimensions from $imageUrl');
 
-    // The image provider should throw an error if a valid image is not found
-    // This is to catch cases where the URL may return a valid image, but the URL path does not conform to the expected format
-    final imageProvider = ExtendedNetworkImageProvider(imageUrl ?? '', cache: true, cacheRawData: true);
-    final imageData = await imageProvider.getNetworkImageData();
-    if (imageData == null) throw Exception('Failed to retrieve image data from $imageUrl');
-
-    final codec = await instantiateImageCodec(imageData);
-    final frame = await codec.getNextFrame();
-    final uiImage = frame.image;
-
-    return Size(uiImage.width.toDouble(), uiImage.height.toDouble());
+    ImageDimensionCache().set(imageUrl, size);
+    return size;
   } catch (e) {
     throw Exception('Failed to retrieve image dimensions from $imageUrl: $e');
   }
@@ -115,7 +129,7 @@ Size? getScaledMediaSize({double? width, double? height, double offset = 24.0, b
   if (width == null || height == null) return null;
   double mediaRatio = width / height;
 
-  FlutterView device = PlatformDispatcher.instance.views.first;
+  final device = PlatformDispatcher.instance.views.first;
 
   double screenWidth = (device.physicalSize.width / device.devicePixelRatio) - device.viewPadding.left - device.viewPadding.right - offset;
   double usableScreenWidth = tabletMode ? screenWidth / 2 - (offset + 8.0) : screenWidth;

--- a/lib/src/shared/utils/media/image.dart
+++ b/lib/src/shared/utils/media/image.dart
@@ -3,8 +3,8 @@ import 'dart:ui';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 
-import 'package:extended_image/extended_image.dart';
 import 'package:flutter/services.dart';
+import 'package:flutter_cache_manager/flutter_cache_manager.dart';
 import 'package:http/http.dart' as http;
 import 'package:image/image.dart' as img;
 import 'package:image_picker/image_picker.dart';
@@ -93,12 +93,8 @@ Future<Size> processImage(Map<String, dynamic> params) async {
   Uint8List? data = bytes;
 
   if (data == null) {
-    // The image provider should throw an error if a valid image is not found
-    // This is to catch cases where the URL may return a valid image, but the URL path does not conform to the expected format
-    final imageProvider = ExtendedNetworkImageProvider(url ?? '', cache: true, cacheRawData: true);
-
-    data = await imageProvider.getNetworkImageData();
-    if (data == null) throw Exception('Failed to retrieve image data from $url');
+    final file = await DefaultCacheManager().getSingleFile(url);
+    data = await file.readAsBytes();
   }
 
   final image = img.decodeImage(data);
@@ -111,7 +107,7 @@ Future<Size> retrieveImageDimensions({String? imageUrl, Uint8List? imageBytes}) 
   assert(imageUrl != null || imageBytes != null);
 
   try {
-    Size? size = await ImageDimensionCache().get(imageUrl!);
+    Size? size = ImageDimensionCache().get(imageUrl!);
     if (size != null) return size;
 
     final token = RootIsolateToken.instance;

--- a/lib/src/shared/widgets/media/media_view.dart
+++ b/lib/src/shared/widgets/media/media_view.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 
 import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:gif_view/gif_view.dart';
 
 import 'package:thunder/l10n/generated/app_localizations.dart';
 import 'package:thunder/src/core/models/media.dart';
@@ -86,6 +87,11 @@ class _MediaViewState extends State<MediaView> with TickerProviderStateMixin {
   void initState() {
     super.initState();
     _overlayAnimationController = AnimationController(duration: const Duration(milliseconds: 100), vsync: this);
+
+    // Pre-fetch GIF if it exists
+    if (widget.media.thumbnailUrl?.endsWith('.gif') ?? widget.media.imageUrl?.endsWith('.gif') ?? widget.media.originalUrl!.endsWith('.gif')) {
+      GifView.preFetchImage(NetworkImage(widget.media.thumbnailUrl ?? widget.media.imageUrl ?? widget.media.originalUrl!));
+    }
   }
 
   @override

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -974,7 +974,7 @@ packages:
     source: hosted
     version: "4.1.2"
   image:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: image
       sha256: "4e973fcf4caae1a4be2fa0a13157aa38a8f9cb049db6529aa00b4d71abc4d928"

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -885,6 +885,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.3.2"
+  gif_view:
+    dependency: "direct main"
+    description:
+      name: gif_view
+      sha256: "4c7e17c134719531dabab54af121e4600d63283f56f3aff57c16db54766b67bc"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.3"
   glob:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -91,6 +91,7 @@ dependencies:
   freezed_annotation: ^3.1.0
   freezed: ^3.2.2
   sqlite3_flutter_libs: ^0.5.39
+  gif_view: ^1.0.3
 
 dev_dependencies:
   flutter_test:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -92,6 +92,7 @@ dependencies:
   freezed: ^3.2.2
   sqlite3_flutter_libs: ^0.5.39
   gif_view: ^1.0.3
+  image: ^4.5.4
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Pull Request Description

This PR applies some additional improvements to how we handle image loading/logic.
- Extended image dimension caching to both markdown images and thumbnails (given that it does not already come from the API). This is now handled by `ImageDimensionCache`. Additionally, the image dimension logic is now handled within an isolate to help improve performance on the UI thread.
- Added proper support for GIFs. This change should fix issues where GIFs would sometimes animate too quickly.
- Refactored `MediaView` to use `CachedNetworkImage`. The `extended_image` package is now mostly used for the full page image previews to enable slide functionality).

Additionally:
- Moved API JSON parsing into its own isolate to improve performance on the main UI thread
- Fixed another issue where anonymous profiles were not able to access the instance page
- Fixed an issue where performing comment actions would cause the page to scroll (#1948)

<!--- Please describe what was changed -->

## Issue Being Fixed

<!-- Please describe the problem that is being fixed and, if applicable, reference a GitHub issue -->

Issue Number: N/A

## Screenshots / Recordings

<!-- This section is optional but highly recommended to show off your changes! -->

## Checklist

- [ ] If a new package was added, did you ensure it uses an appropriate license and is actively maintained?
- [ ] Did you use localized strings (and added appropriate descriptions) where applicable?
- [ ] Did you add `semanticLabel`s where applicable for accessibility?
