### PR TITLE
Update Android workflow to generate per ABI APKs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,8 +17,8 @@ jobs:
       - name: Install libsqlite3
         run: sudo apt-get -y install libsqlite3-0 libsqlite3-dev
 
-      - uses: actions/checkout@v3
-        with:  
+      - uses: actions/checkout@v4
+        with:
           submodules: 'recursive'
 
       - uses: subosito/flutter-action@v2
@@ -58,7 +58,7 @@ jobs:
 
       - name: Find all auto-generated files (.g.dart, .steps.dart, .freezed.dart)
         run: |
-          find . -name "*.g.dart" -o -name "*.steps.dart" -o -name "*.freezed.dart" > generated_files.txt
+          find lib -name "*.g.dart" -o -name "*.steps.dart" -o -name "*.freezed.dart" > generated_files.txt
           cat generated_files.txt
         id: find-generated-files
       

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,14 +50,14 @@ jobs:
           echo "tag=$TAG" >> $GITHUB_OUTPUT
           echo "Info: version=$VERSION | tag=${TAG} | prerelease=$PRERELEASE"
 
-      - name: Build Android APK (unsigned)
+      - name: Build Android APKs (unsigned)
         run: |
           sed -i 's/signingConfig signingConfigs.release//g' android/app/build.gradle
-          flutter build apk --release --flavor production --no-tree-shake-icons
+          flutter build apk --split-per-abi --release --flavor production
           rm ./build/app/outputs/flutter-apk/*.sha1
           ls -l ./build/app/outputs/flutter-apk/
 
-      - name: Sign Android APKs
+      - name: Sign Android Split APKs
         env:
           KEYSTORE_BASE64: ${{ secrets.KEYSTORE_BASE64 }}
           KEYSTORE_PASSWORD: ${{ secrets.KEYSTORE_PASSWORD }}
@@ -70,12 +70,24 @@ jobs:
             echo "${apk} | $(shasum -a 256 ${apk} | cut -d " " -f 1)"
           done
           rm apksign.keystore
-          echo "Finished signing Android APKs"
+          echo "Finished signing Android Split APKs"
         
-      - name: Rename Android APKs
+      - name: Rename Android Split APKs
         run: |
           for apk in ./build/app/outputs/flutter-apk/*-release*.apk; do
-          mv "$apk" "./build/app/outputs/flutter-apk/thunder-v${{ steps.generate-version-info.outputs.version }}.apk"
+            # Extract architecture from filename (e.g., app-arm64-v8a-production-release.apk -> arm64-v8a)
+            filename=$(basename "$apk")
+            arch="universal" # fallback
+            
+            if [[ "$filename" == *"-arm64-v8a-"* ]]; then
+              arch="arm64-v8a"
+            elif [[ "$filename" == *"-armeabi-v7a-"* ]]; then
+              arch="armeabi-v7a"
+            elif [[ "$filename" == *"-x86_64-"* ]]; then
+              arch="x86_64"
+            fi
+            
+            mv "$apk" "./build/app/outputs/flutter-apk/thunder-v${{ steps.generate-version-info.outputs.version }}-${arch}.apk"
           done
       
       - uses: actions/upload-artifact@v4
@@ -90,5 +102,5 @@ jobs:
           tag: "${{ steps.generate-version-info.outputs.tag }}"
           prerelease: ${{ steps.generate-version-info.outputs.prerelease }}
           draft: true
-          artifacts: ./build/app/outputs/flutter-apk/thunder-v*.apk
+          artifacts: ./build/app/outputs/flutter-apk/thunder-v${{ steps.generate-version-info.outputs.version }}-*.apk
           generateReleaseNotes: true

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,7 @@
 [submodule "packages/push"]
 	path = packages/push
 	url = https://github.com/thunder-app/push.git
+[submodule "flutter"]
+	path = flutter
+	url = https://github.com/flutter/flutter.git
+	branch = stable

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -11,7 +11,7 @@ include: package:flutter_lints/flutter.yaml
 analyzer:
   errors:
     use_build_context_synchronously: ignore
-  exclude: [packages/**]
+  exclude: [packages/**, flutter/**]
 
 linter:
   # The lint rules applied to this project can be customized in the

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -13,7 +13,7 @@ if (keystorePropertiesFile.exists()) {
 android {
     namespace "com.hjiangsu.thunder"
     compileSdkVersion rootProject.ext.compileSdkVersion
-    ndkVersion = "27.0.12077973"
+    ndkVersion = flutter.ndkVersion
 
     compileOptions {
         // The following line is required by flutter_local_notifications

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,6 +1,6 @@
 ext {
-    compileSdkVersion   = 35
-    targetSdkVersion    = 35
+    compileSdkVersion   = 36
+    targetSdkVersion    = 36
 }
 
 allprojects {

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -5,26 +5,26 @@ packages:
     dependency: transitive
     description:
       name: _fe_analyzer_shared
-      sha256: f0bb5d1648339c8308cc0b9838d8456b3cfe5c91f9dc1a735b4d003269e5da9a
+      sha256: dd3d2ad434b9510001d089e8de7556d50c834481b9abc2891a0184a8493a19dc
       url: "https://pub.dev"
     source: hosted
-    version: "88.0.0"
+    version: "89.0.0"
   analyzer:
     dependency: transitive
     description:
       name: analyzer
-      sha256: "0b7b9c329d2879f8f05d6c05b32ee9ec025f39b077864bdb5ac9a7b63418a98f"
+      sha256: c22b6e7726d1f9e5db58c7251606076a71ca0dbcf76116675edfadbec0c9e875
       url: "https://pub.dev"
     source: hosted
-    version: "8.1.1"
+    version: "8.2.0"
   android_intent_plus:
     dependency: "direct main"
     description:
       name: android_intent_plus
-      sha256: "2329378af63f49b985cb2e110ac784d08374f1e2b1984be77ba9325b1c8cce11"
+      sha256: "14a9f94c5825a528e8c38ee89a33dbeba947efbbf76f066c174f4f3ae4f48feb"
       url: "https://pub.dev"
     source: hosted
-    version: "5.3.1"
+    version: "6.0.0"
   ansicolor:
     dependency: transitive
     description:
@@ -169,30 +169,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "4.0.4"
-  build_resolvers:
-    dependency: transitive
-    description:
-      name: build_resolvers
-      sha256: "065445f16bde0abf5dab8ff20dcc6773125fe387a128cb175f77df756910b452"
-      url: "https://pub.dev"
-    source: hosted
-    version: "3.0.4"
   build_runner:
     dependency: "direct dev"
     description:
       name: build_runner
-      sha256: b1c7d812e9dd647d8dec0dc1041ec549f7bc2270d60cd1f8ec13f206c10227f8
+      sha256: "804c47c936df75e1911c19a4fb8c46fa8ff2b3099b9f2b2aa4726af3774f734b"
       url: "https://pub.dev"
     source: hosted
-    version: "2.7.2"
-  build_runner_core:
-    dependency: transitive
-    description:
-      name: build_runner_core
-      sha256: "59dc22b9724207519e6c8790fa706d7517dd8cff2d0d55da439c5ce7285200c9"
-      url: "https://pub.dev"
-    source: hosted
-    version: "9.3.2"
+    version: "2.8.0"
   built_collection:
     dependency: transitive
     description:
@@ -277,10 +261,10 @@ packages:
     dependency: transitive
     description:
       name: code_builder
-      sha256: "0ec10bf4a89e4c613960bf1e8b42c64127021740fb21640c29c909826a5eea3e"
+      sha256: "11654819532ba94c34de52ff5feb52bd81cba1de00ef2ed622fd50295f9d4243"
       url: "https://pub.dev"
     source: hosted
-    version: "4.10.1"
+    version: "4.11.0"
   collection:
     dependency: "direct main"
     description:
@@ -293,10 +277,10 @@ packages:
     dependency: "direct main"
     description:
       name: connectivity_plus
-      sha256: b5e72753cf63becce2c61fd04dfe0f1c430cc5278b53a1342dc5ad839eab29ec
+      sha256: "33bae12a398f841c6cda09d1064212957265869104c478e5ad51e2fb26c3973c"
       url: "https://pub.dev"
     source: hosted
-    version: "6.1.5"
+    version: "7.0.0"
   connectivity_plus_platform_interface:
     dependency: transitive
     description:
@@ -373,26 +357,26 @@ packages:
     dependency: "direct main"
     description:
       name: drift
-      sha256: "6aaea757f53bb035e8a3baedf3d1d53a79d6549a6c13d84f7546509da9372c7c"
+      sha256: "540cf382a3bfa99b76e51514db5b0ebcd81ce3679b7c1c9cb9478ff3735e47a1"
       url: "https://pub.dev"
     source: hosted
-    version: "2.28.1"
+    version: "2.28.2"
   drift_dev:
     dependency: "direct dev"
     description:
       name: drift_dev
-      sha256: d6646ee608b9f359b023ac329321bc9c63b098217291de079b8b2334a48abf39
+      sha256: "4db0eeedc7e8bed117a9f22d867ab7a3a294300fed5c269aac90d0b3545967ca"
       url: "https://pub.dev"
     source: hosted
-    version: "2.28.2"
+    version: "2.28.3"
   drift_flutter:
     dependency: "direct main"
     description:
       name: drift_flutter
-      sha256: b52bd710f809db11e25259d429d799d034ba1c5224ce6a73fe8419feb980d44c
+      sha256: b7534bf320aac5213259aac120670ba67b63a1fd010505babc436ff86083818f
       url: "https://pub.dev"
     source: hosted
-    version: "0.2.6"
+    version: "0.2.7"
   dynamic_color:
     dependency: "direct main"
     description:
@@ -746,10 +730,10 @@ packages:
     dependency: "direct main"
     description:
       name: flutter_local_notifications
-      sha256: a9966c850de5e445331b854fa42df96a8020066d67f125a5964cbc6556643f68
+      sha256: "7ed76be64e8a7d01dfdf250b8434618e2a028c9dfa2a3c41dc9b531d4b3fc8a5"
       url: "https://pub.dev"
     source: hosted
-    version: "19.4.1"
+    version: "19.4.2"
   flutter_local_notifications_linux:
     dependency: transitive
     description:
@@ -770,10 +754,10 @@ packages:
     dependency: transitive
     description:
       name: flutter_local_notifications_windows
-      sha256: ed46d7ae4ec9d19e4c8fa2badac5fe27ba87a3fe387343ce726f927af074ec98
+      sha256: "8d658f0d367c48bd420e7cf2d26655e2d1130147bca1eea917e576ca76668aaf"
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.2"
+    version: "1.0.3"
   flutter_localizations:
     dependency: transitive
     description: flutter
@@ -849,10 +833,10 @@ packages:
     dependency: "direct main"
     description:
       name: freezed
-      sha256: b6445822d9b3961a9d0f3def0b4297bd77314bdbfd1de0b62eaca27c93e9bc0f
+      sha256: "13065f10e135263a4f5a4391b79a8efc5fb8106f8dd555a9e49b750b45393d77"
       url: "https://pub.dev"
     source: hosted
-    version: "3.2.2"
+    version: "3.2.3"
   freezed_annotation:
     dependency: "direct main"
     description:
@@ -993,10 +977,10 @@ packages:
     dependency: transitive
     description:
       name: image_picker_android
-      sha256: "28f3987ca0ec702d346eae1d90eda59603a2101b52f1e234ded62cff1d5cfa6e"
+      sha256: "8dfe08ea7fcf7467dbaf6889e72eebd5e0d6711caae201fdac780eb45232cd02"
       url: "https://pub.dev"
     source: hosted
-    version: "0.8.13+1"
+    version: "0.8.13+3"
   image_picker_for_web:
     dependency: transitive
     description:
@@ -1073,10 +1057,10 @@ packages:
     dependency: "direct main"
     description:
       name: jovial_svg
-      sha256: "6791b1435547bdc0793081a166d41a8a313ebc61e4e5136fb7a3218781fb9e50"
+      sha256: "08dd24b800d48796c9c0227acb96eb00c6cacccb1d7de58d79fc924090049868"
       url: "https://pub.dev"
     source: hosted
-    version: "1.1.27"
+    version: "1.1.28"
   js:
     dependency: transitive
     description:
@@ -1106,10 +1090,10 @@ packages:
     dependency: transitive
     description:
       name: leak_tracker
-      sha256: "8dcda04c3fc16c14f48a7bb586d4be1f0d1572731b6d81d51772ef47c02081e0"
+      sha256: "33e2e26bdd85a0112ec15400c8cbffea70d0f9c3407491f672a2fad47915e2de"
       url: "https://pub.dev"
     source: hosted
-    version: "11.0.1"
+    version: "11.0.2"
   leak_tracker_flutter_testing:
     dependency: transitive
     description:
@@ -1404,10 +1388,10 @@ packages:
     dependency: transitive
     description:
       name: pool
-      sha256: "20fe868b6314b322ea036ba325e6fc0711a22948856475e2c2b6306e8ab39c2a"
+      sha256: "978783255c543aa3586a1b3c21f6e9d720eb315376a915872c61ef8b5c20177d"
       url: "https://pub.dev"
     source: hosted
-    version: "1.5.1"
+    version: "1.5.2"
   posix:
     dependency: transitive
     description:
@@ -1489,10 +1473,10 @@ packages:
     dependency: "direct main"
     description:
       name: share_plus
-      sha256: d7dc0630a923883c6328ca31b89aa682bacbf2f8304162d29f7c6aaff03a27a1
+      sha256: "3424e9d5c22fd7f7590254ba09465febd6f8827c8b19a44350de4ac31d92d3a6"
       url: "https://pub.dev"
     source: hosted
-    version: "11.1.0"
+    version: "12.0.0"
   share_plus_platform_interface:
     dependency: transitive
     description:
@@ -1513,10 +1497,10 @@ packages:
     dependency: transitive
     description:
       name: shared_preferences_android
-      sha256: a2608114b1ffdcbc9c120eb71a0e207c71da56202852d4aab8a5e30a82269e74
+      sha256: bd14436108211b0d4ee5038689a56d4ae3620fd72fd6036e113bf1345bc74d9e
       url: "https://pub.dev"
     source: hosted
-    version: "2.4.12"
+    version: "2.4.13"
   shared_preferences_foundation:
     dependency: transitive
     description:
@@ -1754,14 +1738,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.10.1"
-  timing:
-    dependency: transitive
-    description:
-      name: timing
-      sha256: "62ee18aca144e4a9f29d212f5a4c6a053be252b895ab14b5821996cff4ed90fe"
-      url: "https://pub.dev"
-    source: hosted
-    version: "1.0.2"
   typed_data:
     dependency: transitive
     description:
@@ -1822,10 +1798,10 @@ packages:
     dependency: transitive
     description:
       name: url_launcher_android
-      sha256: "69ee86740f2847b9a4ba6cffa74ed12ce500bbe2b07f3dc1e643439da60637b7"
+      sha256: "199bc33e746088546a39cc5f36bac5a278c5e53b40cb3196f99e7345fdcfae6b"
       url: "https://pub.dev"
     source: hosted
-    version: "6.3.18"
+    version: "6.3.22"
   url_launcher_ios:
     dependency: transitive
     description:
@@ -1998,10 +1974,10 @@ packages:
     dependency: "direct main"
     description:
       name: webview_flutter_android
-      sha256: "9a25f6b4313978ba1c2cda03a242eea17848174912cfb4d2d8ee84a556f248e3"
+      sha256: "3c4eb4fcc252b40c2b5ce7be20d0481428b70f3ff589b0a8b8aaeb64c6bed701"
       url: "https://pub.dev"
     source: hosted
-    version: "4.10.1"
+    version: "4.10.2"
   webview_flutter_platform_interface:
     dependency: transitive
     description:
@@ -2014,10 +1990,10 @@ packages:
     dependency: "direct main"
     description:
       name: webview_flutter_wkwebview
-      sha256: fb46db8216131a3e55bcf44040ca808423539bc6732e7ed34fb6d8044e3d512f
+      sha256: fea63576b3b7e02b2df8b78ba92b48ed66caec2bb041e9a0b1cbd586d5d80bfd
       url: "https://pub.dev"
     source: hosted
-    version: "3.23.0"
+    version: "3.23.1"
   win32:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -27,7 +27,7 @@ dependencies:
     git:
       url: https://github.com/veloce/l10n_esperanto
       ref: 62d45c60f7840a4591318bb477172136c999f946
-  android_intent_plus: ^5.0.1
+  android_intent_plus: ^6.0.0
   app_links: ^6.3.2
   auto_size_text: ^3.0.0
   back_button_interceptor: ^8.0.0
@@ -36,7 +36,7 @@ dependencies:
   bloc_concurrency: ^0.3.0
   cached_network_image: ^3.2.3
   collection: ^1.17.0
-  connectivity_plus: ^6.0.2
+  connectivity_plus: ^7.0.0
   dart_ping: ^9.0.0
   dart_ping_ios: ^4.0.0
   drift: ^2.28.1
@@ -72,7 +72,7 @@ dependencies:
   path_provider: ^2.1.5
   permission_handler: ^12.0.0+1
   screenshot: ^3.0.0
-  share_plus: ^11.0.0
+  share_plus: ^12.0.0
   shared_preferences: ^2.1.2
   smooth_highlight: ^0.1.1
   stream_transform: ^2.1.0

--- a/scripts/build.dart
+++ b/scripts/build.dart
@@ -26,7 +26,7 @@ void buildRelease() {
 
   // Build for Android
   print('\nStarting Android build...');
-  ProcessResult androidResult = Process.runSync('flutter', ['build', 'apk', '--release', '--flavor', 'production', '--no-tree-shake-icons']);
+  ProcessResult androidResult = Process.runSync('flutter', ['build', 'apk', '--split-per-abi', '--release', '--flavor', 'production']);
   stdout.write(androidResult.stdout);
   stderr.write(androidResult.stderr);
 
@@ -39,7 +39,7 @@ void buildRelease() {
 
   // Build for iOS
   print('\nStarting iOS build...');
-  ProcessResult iosResult = Process.runSync('flutter', ['build', 'ios', '--release', '--flavor', 'production', '--no-tree-shake-icons']);
+  ProcessResult iosResult = Process.runSync('flutter', ['build', 'ios', '--release', '--flavor', 'production']);
   stdout.write(iosResult.stdout);
   stderr.write(iosResult.stderr);
 
@@ -64,18 +64,41 @@ void removeBuildArtifacts() {
 }
 
 void createAPKFile(String version) {
-  print('\nCreating APK release file...');
+  print('\nCreating APK release files...');
 
   // Create the "release" directory
   Directory releaseDir = Directory('release');
   releaseDir.createSync();
 
-  // Copy the APK file to the "release" directory and rename it
-  File apkFile = File('build/app/outputs/flutter-apk/app-production-release.apk');
-  String newApkPath = '${releaseDir.path}/thunder-v$version.apk';
-  apkFile.copySync(newApkPath);
+  // Find all split APK files
+  Directory apkDir = Directory('build/app/outputs/flutter-apk');
+  List<FileSystemEntity> apkFiles = apkDir.listSync().where((file) => file is File && file.path.endsWith('.apk')).toList();
 
-  print('APK file copied and renamed successfully!');
+  if (apkFiles.isEmpty) {
+    print('No APK files found in build/app/outputs/flutter-apk/');
+    return;
+  }
+
+  // Copy each split APK file to the "release" directory with architecture suffix
+  for (FileSystemEntity apkFile in apkFiles) {
+    String fileName = apkFile.path.split('/').last;
+
+    // Extract architecture from filename (e.g., app-arm64-v8a-production-release.apk -> arm64-v8a)
+    String arch = 'universal'; // fallback
+    if (fileName.contains('-arm64-v8a-')) {
+      arch = 'arm64-v8a';
+    } else if (fileName.contains('-armeabi-v7a-')) {
+      arch = 'armeabi-v7a';
+    } else if (fileName.contains('-x86_64-')) {
+      arch = 'x86_64';
+    }
+
+    String newApkPath = '${releaseDir.path}/thunder-v$version-$arch.apk';
+    (apkFile as File).copySync(newApkPath);
+    print('Copied $fileName -> thunder-v$version-$arch.apk');
+  }
+
+  print('All APK files copied and renamed successfully!');
 }
 
 // Creates a IPA file from the flutter build


### PR DESCRIPTION
## Pull Request Description

This PR introduces split APK outputs for Android releases. With the recent changes to 16KB page sizes, the generated single APK file grew by a significant amount (from ~40MB to ~80MB). This change should reduce the final APK sizes to ~30MB.

Note: This change may require changes to how IzzyOnDroid detects releases.

<!--- Please describe what was changed -->

## Issue Being Fixed

<!-- Please describe the problem that is being fixed and, if applicable, reference a GitHub issue -->

Issue Number: N/A

## Screenshots / Recordings

<!-- This section is optional but highly recommended to show off your changes! -->

## Checklist

- [ ] If a new package was added, did you ensure it uses an appropriate license and is actively maintained?
- [ ] Did you use localized strings (and added appropriate descriptions) where applicable?
- [ ] Did you add `semanticLabel`s where applicable for accessibility?
