### PR TITLE
Ability to toggle alt text and fullscreen in image viewer

### DIFF
--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -3752,5 +3752,6 @@
   "youMustSelectAJsonFile": "You must select a .json file.",
   "@youMustSelectAJsonFile": {
     "description": "Error message shown to user when they attempt to import a JSON file that doesn't have the right extension"
-  }
+  },
+  "fullscreen": "Fullscreen"
 }

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -1275,6 +1275,10 @@
   },
   "fullScreenNavigationSwipeDescription": "Swipe anywhere to go back when left-to-right gestures are disabled",
   "@fullScreenNavigationSwipeDescription": {},
+  "fullscreen": "Fullscreen",
+  "@fullscreen": {
+    "description": "Action for entering fullscreen"
+  },
   "fullscreenSwipeGestures": "Fullscreen Swipe Gestures",
   "@fullscreenSwipeGestures": {
     "description": "Setting for fullscreen swipe gestures"
@@ -3752,6 +3756,5 @@
   "youMustSelectAJsonFile": "You must select a .json file.",
   "@youMustSelectAJsonFile": {
     "description": "Error message shown to user when they attempt to import a JSON file that doesn't have the right extension"
-  },
-  "fullscreen": "Fullscreen"
+  }
 }

--- a/lib/l10n/generated/app_localizations.dart
+++ b/lib/l10n/generated/app_localizations.dart
@@ -2012,6 +2012,12 @@ abstract class AppLocalizations {
   /// **'Swipe anywhere to go back when left-to-right gestures are disabled'**
   String get fullScreenNavigationSwipeDescription;
 
+  /// Action for entering fullscreen
+  ///
+  /// In en, this message translates to:
+  /// **'Fullscreen'**
+  String get fullscreen;
+
   /// Setting for fullscreen swipe gestures
   ///
   /// In en, this message translates to:
@@ -5737,12 +5743,6 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'You must select a .json file.'**
   String get youMustSelectAJsonFile;
-
-  /// No description provided for @fullscreen.
-  ///
-  /// In en, this message translates to:
-  /// **'Fullscreen'**
-  String get fullscreen;
 }
 
 class _AppLocalizationsDelegate

--- a/lib/l10n/generated/app_localizations.dart
+++ b/lib/l10n/generated/app_localizations.dart
@@ -5737,6 +5737,12 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'You must select a .json file.'**
   String get youMustSelectAJsonFile;
+
+  /// No description provided for @fullscreen.
+  ///
+  /// In en, this message translates to:
+  /// **'Fullscreen'**
+  String get fullscreen;
 }
 
 class _AppLocalizationsDelegate

--- a/lib/l10n/generated/app_localizations_ar.dart
+++ b/lib/l10n/generated/app_localizations_ar.dart
@@ -1070,6 +1070,9 @@ class AppLocalizationsAr extends AppLocalizations {
       'Swipe anywhere to go back when left-to-right gestures are disabled';
 
   @override
+  String get fullscreen => 'Fullscreen';
+
+  @override
   String get fullscreenSwipeGestures => 'Fullscreen Swipe Gestures';
 
   @override
@@ -3181,7 +3184,4 @@ class AppLocalizationsAr extends AppLocalizations {
 
   @override
   String get youMustSelectAJsonFile => 'You must select a .json file.';
-
-  @override
-  String get fullscreen => 'Fullscreen';
 }

--- a/lib/l10n/generated/app_localizations_ar.dart
+++ b/lib/l10n/generated/app_localizations_ar.dart
@@ -3181,4 +3181,7 @@ class AppLocalizationsAr extends AppLocalizations {
 
   @override
   String get youMustSelectAJsonFile => 'You must select a .json file.';
+
+  @override
+  String get fullscreen => 'Fullscreen';
 }

--- a/lib/l10n/generated/app_localizations_cs.dart
+++ b/lib/l10n/generated/app_localizations_cs.dart
@@ -1086,6 +1086,9 @@ class AppLocalizationsCs extends AppLocalizations {
       'Swipněte kdekoliv pro návrat zpět, pokud jsou gesta z leva do prava vypnutá';
 
   @override
+  String get fullscreen => 'Fullscreen';
+
+  @override
   String get fullscreenSwipeGestures => 'Celoobrazovková Swipovací Gesta';
 
   @override
@@ -3186,7 +3189,4 @@ class AppLocalizationsCs extends AppLocalizations {
 
   @override
   String get youMustSelectAJsonFile => 'You must select a .json file.';
-
-  @override
-  String get fullscreen => 'Fullscreen';
 }

--- a/lib/l10n/generated/app_localizations_cs.dart
+++ b/lib/l10n/generated/app_localizations_cs.dart
@@ -3186,4 +3186,7 @@ class AppLocalizationsCs extends AppLocalizations {
 
   @override
   String get youMustSelectAJsonFile => 'You must select a .json file.';
+
+  @override
+  String get fullscreen => 'Fullscreen';
 }

--- a/lib/l10n/generated/app_localizations_de.dart
+++ b/lib/l10n/generated/app_localizations_de.dart
@@ -3230,4 +3230,7 @@ class AppLocalizationsDe extends AppLocalizations {
 
   @override
   String get youMustSelectAJsonFile => 'Du musst eine JSON-Datei auswählen.';
+
+  @override
+  String get fullscreen => 'Fullscreen';
 }

--- a/lib/l10n/generated/app_localizations_de.dart
+++ b/lib/l10n/generated/app_localizations_de.dart
@@ -1095,6 +1095,9 @@ class AppLocalizationsDe extends AppLocalizations {
       'Wische irgendwohin, um zurückzugehen, wenn die Links-nach-Rechts-Gesten deaktiviert sind';
 
   @override
+  String get fullscreen => 'Fullscreen';
+
+  @override
   String get fullscreenSwipeGestures => 'Wischgesten im Vollbildmodus';
 
   @override
@@ -3230,7 +3233,4 @@ class AppLocalizationsDe extends AppLocalizations {
 
   @override
   String get youMustSelectAJsonFile => 'Du musst eine JSON-Datei auswählen.';
-
-  @override
-  String get fullscreen => 'Fullscreen';
 }

--- a/lib/l10n/generated/app_localizations_en.dart
+++ b/lib/l10n/generated/app_localizations_en.dart
@@ -1078,6 +1078,9 @@ class AppLocalizationsEn extends AppLocalizations {
       'Swipe anywhere to go back when left-to-right gestures are disabled';
 
   @override
+  String get fullscreen => 'Fullscreen';
+
+  @override
   String get fullscreenSwipeGestures => 'Fullscreen Swipe Gestures';
 
   @override
@@ -3189,9 +3192,6 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get youMustSelectAJsonFile => 'You must select a .json file.';
-
-  @override
-  String get fullscreen => 'Fullscreen';
 }
 
 /// The translations for English, as used in Australia (`en_AU`).

--- a/lib/l10n/generated/app_localizations_en.dart
+++ b/lib/l10n/generated/app_localizations_en.dart
@@ -3189,6 +3189,9 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get youMustSelectAJsonFile => 'You must select a .json file.';
+
+  @override
+  String get fullscreen => 'Fullscreen';
 }
 
 /// The translations for English, as used in Australia (`en_AU`).

--- a/lib/l10n/generated/app_localizations_eo.dart
+++ b/lib/l10n/generated/app_localizations_eo.dart
@@ -1075,6 +1075,9 @@ class AppLocalizationsEo extends AppLocalizations {
       'Ŝovumu ie ajn por reiri kiam gestoj de maldekstre al dekstre estas malŝaltitaj';
 
   @override
+  String get fullscreen => 'Fullscreen';
+
+  @override
   String get fullscreenSwipeGestures => 'Fullscreen Swipe Gestures';
 
   @override
@@ -3171,7 +3174,4 @@ class AppLocalizationsEo extends AppLocalizations {
 
   @override
   String get youMustSelectAJsonFile => 'You must select a .json file.';
-
-  @override
-  String get fullscreen => 'Fullscreen';
 }

--- a/lib/l10n/generated/app_localizations_eo.dart
+++ b/lib/l10n/generated/app_localizations_eo.dart
@@ -3171,4 +3171,7 @@ class AppLocalizationsEo extends AppLocalizations {
 
   @override
   String get youMustSelectAJsonFile => 'You must select a .json file.';
+
+  @override
+  String get fullscreen => 'Fullscreen';
 }

--- a/lib/l10n/generated/app_localizations_es.dart
+++ b/lib/l10n/generated/app_localizations_es.dart
@@ -3255,4 +3255,7 @@ class AppLocalizationsEs extends AppLocalizations {
 
   @override
   String get youMustSelectAJsonFile => 'You must select a .json file.';
+
+  @override
+  String get fullscreen => 'Fullscreen';
 }

--- a/lib/l10n/generated/app_localizations_es.dart
+++ b/lib/l10n/generated/app_localizations_es.dart
@@ -1102,6 +1102,9 @@ class AppLocalizationsEs extends AppLocalizations {
       'Desliza el dedo en cualquier lugar para volver atrás cuando los gestos de izquierda a derecha estén desactivados';
 
   @override
+  String get fullscreen => 'Fullscreen';
+
+  @override
   String get fullscreenSwipeGestures =>
       'Gestos de deslizamiento a pantalla completa';
 
@@ -3255,7 +3258,4 @@ class AppLocalizationsEs extends AppLocalizations {
 
   @override
   String get youMustSelectAJsonFile => 'You must select a .json file.';
-
-  @override
-  String get fullscreen => 'Fullscreen';
 }

--- a/lib/l10n/generated/app_localizations_fi.dart
+++ b/lib/l10n/generated/app_localizations_fi.dart
@@ -3175,4 +3175,7 @@ class AppLocalizationsFi extends AppLocalizations {
 
   @override
   String get youMustSelectAJsonFile => 'You must select a .json file.';
+
+  @override
+  String get fullscreen => 'Fullscreen';
 }

--- a/lib/l10n/generated/app_localizations_fi.dart
+++ b/lib/l10n/generated/app_localizations_fi.dart
@@ -1075,6 +1075,9 @@ class AppLocalizationsFi extends AppLocalizations {
       'Swipe anywhere to go back when left-to-right gestures are disabled';
 
   @override
+  String get fullscreen => 'Fullscreen';
+
+  @override
   String get fullscreenSwipeGestures => 'Fullscreen Swipe Gestures';
 
   @override
@@ -3175,7 +3178,4 @@ class AppLocalizationsFi extends AppLocalizations {
 
   @override
   String get youMustSelectAJsonFile => 'You must select a .json file.';
-
-  @override
-  String get fullscreen => 'Fullscreen';
 }

--- a/lib/l10n/generated/app_localizations_fr.dart
+++ b/lib/l10n/generated/app_localizations_fr.dart
@@ -3220,4 +3220,7 @@ class AppLocalizationsFr extends AppLocalizations {
 
   @override
   String get youMustSelectAJsonFile => 'You must select a .json file.';
+
+  @override
+  String get fullscreen => 'Fullscreen';
 }

--- a/lib/l10n/generated/app_localizations_fr.dart
+++ b/lib/l10n/generated/app_localizations_fr.dart
@@ -1104,6 +1104,9 @@ class AppLocalizationsFr extends AppLocalizations {
       'Balayer n\'importe où pour revenir en arrière lorsque les gestes de gauche à droite sont désactivés';
 
   @override
+  String get fullscreen => 'Fullscreen';
+
+  @override
   String get fullscreenSwipeGestures => 'Geste de balayage en plein écran';
 
   @override
@@ -3220,7 +3223,4 @@ class AppLocalizationsFr extends AppLocalizations {
 
   @override
   String get youMustSelectAJsonFile => 'You must select a .json file.';
-
-  @override
-  String get fullscreen => 'Fullscreen';
 }

--- a/lib/l10n/generated/app_localizations_hu.dart
+++ b/lib/l10n/generated/app_localizations_hu.dart
@@ -3189,4 +3189,7 @@ class AppLocalizationsHu extends AppLocalizations {
 
   @override
   String get youMustSelectAJsonFile => 'You must select a .json file.';
+
+  @override
+  String get fullscreen => 'Fullscreen';
 }

--- a/lib/l10n/generated/app_localizations_hu.dart
+++ b/lib/l10n/generated/app_localizations_hu.dart
@@ -1078,6 +1078,9 @@ class AppLocalizationsHu extends AppLocalizations {
       'Swipe anywhere to go back when left-to-right gestures are disabled';
 
   @override
+  String get fullscreen => 'Fullscreen';
+
+  @override
   String get fullscreenSwipeGestures => 'Fullscreen Swipe Gestures';
 
   @override
@@ -3189,7 +3192,4 @@ class AppLocalizationsHu extends AppLocalizations {
 
   @override
   String get youMustSelectAJsonFile => 'You must select a .json file.';
-
-  @override
-  String get fullscreen => 'Fullscreen';
 }

--- a/lib/l10n/generated/app_localizations_it.dart
+++ b/lib/l10n/generated/app_localizations_it.dart
@@ -1085,6 +1085,9 @@ class AppLocalizationsIt extends AppLocalizations {
       'Scorri ovunque per tornare indietro quando le azioni da sinistra-a-destra sono disabilitate';
 
   @override
+  String get fullscreen => 'Fullscreen';
+
+  @override
   String get fullscreenSwipeGestures => 'Gesti Swipe a Schermo Intero';
 
   @override
@@ -3190,7 +3193,4 @@ class AppLocalizationsIt extends AppLocalizations {
 
   @override
   String get youMustSelectAJsonFile => 'File .json necessario.';
-
-  @override
-  String get fullscreen => 'Fullscreen';
 }

--- a/lib/l10n/generated/app_localizations_it.dart
+++ b/lib/l10n/generated/app_localizations_it.dart
@@ -3190,4 +3190,7 @@ class AppLocalizationsIt extends AppLocalizations {
 
   @override
   String get youMustSelectAJsonFile => 'File .json necessario.';
+
+  @override
+  String get fullscreen => 'Fullscreen';
 }

--- a/lib/l10n/generated/app_localizations_nb.dart
+++ b/lib/l10n/generated/app_localizations_nb.dart
@@ -3171,4 +3171,7 @@ class AppLocalizationsNb extends AppLocalizations {
 
   @override
   String get youMustSelectAJsonFile => 'You must select a .json file.';
+
+  @override
+  String get fullscreen => 'Fullscreen';
 }

--- a/lib/l10n/generated/app_localizations_nb.dart
+++ b/lib/l10n/generated/app_localizations_nb.dart
@@ -1073,6 +1073,9 @@ class AppLocalizationsNb extends AppLocalizations {
       'Swipe anywhere to go back when left-to-right gestures are disabled';
 
   @override
+  String get fullscreen => 'Fullscreen';
+
+  @override
   String get fullscreenSwipeGestures => 'Fullscreen Swipe Gestures';
 
   @override
@@ -3171,7 +3174,4 @@ class AppLocalizationsNb extends AppLocalizations {
 
   @override
   String get youMustSelectAJsonFile => 'You must select a .json file.';
-
-  @override
-  String get fullscreen => 'Fullscreen';
 }

--- a/lib/l10n/generated/app_localizations_nl.dart
+++ b/lib/l10n/generated/app_localizations_nl.dart
@@ -1087,6 +1087,9 @@ class AppLocalizationsNl extends AppLocalizations {
       'Swipe anywhere to go back when left-to-right gestures are disabled';
 
   @override
+  String get fullscreen => 'Fullscreen';
+
+  @override
   String get fullscreenSwipeGestures => 'Veeg­gebaren in volledig scherm';
 
   @override
@@ -3194,7 +3197,4 @@ class AppLocalizationsNl extends AppLocalizations {
 
   @override
   String get youMustSelectAJsonFile => 'You must select a .json file.';
-
-  @override
-  String get fullscreen => 'Fullscreen';
 }

--- a/lib/l10n/generated/app_localizations_nl.dart
+++ b/lib/l10n/generated/app_localizations_nl.dart
@@ -3194,4 +3194,7 @@ class AppLocalizationsNl extends AppLocalizations {
 
   @override
   String get youMustSelectAJsonFile => 'You must select a .json file.';
+
+  @override
+  String get fullscreen => 'Fullscreen';
 }

--- a/lib/l10n/generated/app_localizations_pl.dart
+++ b/lib/l10n/generated/app_localizations_pl.dart
@@ -1088,6 +1088,9 @@ class AppLocalizationsPl extends AppLocalizations {
       'Przesuń gdziekolwiek by wrócić gdy gesty \"od lewej do prawej\" są wyłączone';
 
   @override
+  String get fullscreen => 'Fullscreen';
+
+  @override
   String get fullscreenSwipeGestures =>
       'Gesty Przesunięć W Trybie Pełnoekranowym';
 
@@ -3190,7 +3193,4 @@ class AppLocalizationsPl extends AppLocalizations {
 
   @override
   String get youMustSelectAJsonFile => 'You must select a .json file.';
-
-  @override
-  String get fullscreen => 'Fullscreen';
 }

--- a/lib/l10n/generated/app_localizations_pl.dart
+++ b/lib/l10n/generated/app_localizations_pl.dart
@@ -3190,4 +3190,7 @@ class AppLocalizationsPl extends AppLocalizations {
 
   @override
   String get youMustSelectAJsonFile => 'You must select a .json file.';
+
+  @override
+  String get fullscreen => 'Fullscreen';
 }

--- a/lib/l10n/generated/app_localizations_pt.dart
+++ b/lib/l10n/generated/app_localizations_pt.dart
@@ -1087,6 +1087,9 @@ class AppLocalizationsPt extends AppLocalizations {
       'Swipe anywhere to go back when left-to-right gestures are disabled';
 
   @override
+  String get fullscreen => 'Fullscreen';
+
+  @override
   String get fullscreenSwipeGestures => 'Fullscreen Swipe Gestures';
 
   @override
@@ -3198,9 +3201,6 @@ class AppLocalizationsPt extends AppLocalizations {
 
   @override
   String get youMustSelectAJsonFile => 'You must select a .json file.';
-
-  @override
-  String get fullscreen => 'Fullscreen';
 }
 
 /// The translations for Portuguese, as used in Brazil (`pt_BR`).

--- a/lib/l10n/generated/app_localizations_pt.dart
+++ b/lib/l10n/generated/app_localizations_pt.dart
@@ -3198,6 +3198,9 @@ class AppLocalizationsPt extends AppLocalizations {
 
   @override
   String get youMustSelectAJsonFile => 'You must select a .json file.';
+
+  @override
+  String get fullscreen => 'Fullscreen';
 }
 
 /// The translations for Portuguese, as used in Brazil (`pt_BR`).

--- a/lib/l10n/generated/app_localizations_ru.dart
+++ b/lib/l10n/generated/app_localizations_ru.dart
@@ -3189,4 +3189,7 @@ class AppLocalizationsRu extends AppLocalizations {
 
   @override
   String get youMustSelectAJsonFile => 'You must select a .json file.';
+
+  @override
+  String get fullscreen => 'Fullscreen';
 }

--- a/lib/l10n/generated/app_localizations_ru.dart
+++ b/lib/l10n/generated/app_localizations_ru.dart
@@ -1089,6 +1089,9 @@ class AppLocalizationsRu extends AppLocalizations {
       'Проведите пальцем в любом месте, чтобы вернуться назад, когда жесты слева направо отключены';
 
   @override
+  String get fullscreen => 'Fullscreen';
+
+  @override
   String get fullscreenSwipeGestures => 'Fullscreen Swipe Gestures';
 
   @override
@@ -3189,7 +3192,4 @@ class AppLocalizationsRu extends AppLocalizations {
 
   @override
   String get youMustSelectAJsonFile => 'You must select a .json file.';
-
-  @override
-  String get fullscreen => 'Fullscreen';
 }

--- a/lib/l10n/generated/app_localizations_sk.dart
+++ b/lib/l10n/generated/app_localizations_sk.dart
@@ -1086,6 +1086,9 @@ class AppLocalizationsSk extends AppLocalizations {
       'Potiahnite prstom kdekoľvek, aby ste sa vrátili späť, keď sú gestá zľava doprava vypnuté';
 
   @override
+  String get fullscreen => 'Fullscreen';
+
+  @override
   String get fullscreenSwipeGestures => 'Gestá posunutia obrazovky';
 
   @override
@@ -3190,7 +3193,4 @@ class AppLocalizationsSk extends AppLocalizations {
 
   @override
   String get youMustSelectAJsonFile => 'You must select a .json file.';
-
-  @override
-  String get fullscreen => 'Fullscreen';
 }

--- a/lib/l10n/generated/app_localizations_sk.dart
+++ b/lib/l10n/generated/app_localizations_sk.dart
@@ -3190,4 +3190,7 @@ class AppLocalizationsSk extends AppLocalizations {
 
   @override
   String get youMustSelectAJsonFile => 'You must select a .json file.';
+
+  @override
+  String get fullscreen => 'Fullscreen';
 }

--- a/lib/l10n/generated/app_localizations_sv.dart
+++ b/lib/l10n/generated/app_localizations_sv.dart
@@ -1072,6 +1072,9 @@ class AppLocalizationsSv extends AppLocalizations {
       'Swipe anywhere to go back when left-to-right gestures are disabled';
 
   @override
+  String get fullscreen => 'Fullscreen';
+
+  @override
   String get fullscreenSwipeGestures => 'Fullscreen Swipe Gestures';
 
   @override
@@ -3175,7 +3178,4 @@ class AppLocalizationsSv extends AppLocalizations {
 
   @override
   String get youMustSelectAJsonFile => 'You must select a .json file.';
-
-  @override
-  String get fullscreen => 'Fullscreen';
 }

--- a/lib/l10n/generated/app_localizations_sv.dart
+++ b/lib/l10n/generated/app_localizations_sv.dart
@@ -3175,4 +3175,7 @@ class AppLocalizationsSv extends AppLocalizations {
 
   @override
   String get youMustSelectAJsonFile => 'You must select a .json file.';
+
+  @override
+  String get fullscreen => 'Fullscreen';
 }

--- a/lib/l10n/generated/app_localizations_ta.dart
+++ b/lib/l10n/generated/app_localizations_ta.dart
@@ -3240,4 +3240,7 @@ class AppLocalizationsTa extends AppLocalizations {
   @override
   String get youMustSelectAJsonFile =>
       'நீங்கள் ஒரு .json கோப்பைத் தேர்ந்தெடுக்க வேண்டும்.';
+
+  @override
+  String get fullscreen => 'Fullscreen';
 }

--- a/lib/l10n/generated/app_localizations_ta.dart
+++ b/lib/l10n/generated/app_localizations_ta.dart
@@ -1093,6 +1093,9 @@ class AppLocalizationsTa extends AppLocalizations {
       'இடமிருந்து வலமாக சைகைகள் முடக்கப்பட்டிருக்கும் போது திரும்பிச் செல்ல எங்கும் ச்வைப் செய்யவும்';
 
   @override
+  String get fullscreen => 'Fullscreen';
+
+  @override
   String get fullscreenSwipeGestures => 'முழுத்திரை ச்வைப் சைகைகள்';
 
   @override
@@ -3240,7 +3243,4 @@ class AppLocalizationsTa extends AppLocalizations {
   @override
   String get youMustSelectAJsonFile =>
       'நீங்கள் ஒரு .json கோப்பைத் தேர்ந்தெடுக்க வேண்டும்.';
-
-  @override
-  String get fullscreen => 'Fullscreen';
 }

--- a/lib/l10n/generated/app_localizations_tr.dart
+++ b/lib/l10n/generated/app_localizations_tr.dart
@@ -3201,4 +3201,7 @@ class AppLocalizationsTr extends AppLocalizations {
 
   @override
   String get youMustSelectAJsonFile => 'Bir .json dosyası seçmelisiniz.';
+
+  @override
+  String get fullscreen => 'Fullscreen';
 }

--- a/lib/l10n/generated/app_localizations_tr.dart
+++ b/lib/l10n/generated/app_localizations_tr.dart
@@ -1086,6 +1086,9 @@ class AppLocalizationsTr extends AppLocalizations {
       'Soldan sağa hareketler devre dışı bırakıldığında geri gitmek için herhangi bir yere kaydırın';
 
   @override
+  String get fullscreen => 'Fullscreen';
+
+  @override
   String get fullscreenSwipeGestures => 'Tam Ekran Kaydırma Hareketleri';
 
   @override
@@ -3201,7 +3204,4 @@ class AppLocalizationsTr extends AppLocalizations {
 
   @override
   String get youMustSelectAJsonFile => 'Bir .json dosyası seçmelisiniz.';
-
-  @override
-  String get fullscreen => 'Fullscreen';
 }

--- a/lib/l10n/generated/app_localizations_uk.dart
+++ b/lib/l10n/generated/app_localizations_uk.dart
@@ -1080,6 +1080,9 @@ class AppLocalizationsUk extends AppLocalizations {
       'Swipe anywhere to go back when left-to-right gestures are disabled';
 
   @override
+  String get fullscreen => 'Fullscreen';
+
+  @override
   String get fullscreenSwipeGestures => 'Fullscreen Swipe Gestures';
 
   @override
@@ -3185,7 +3188,4 @@ class AppLocalizationsUk extends AppLocalizations {
 
   @override
   String get youMustSelectAJsonFile => 'You must select a .json file.';
-
-  @override
-  String get fullscreen => 'Fullscreen';
 }

--- a/lib/l10n/generated/app_localizations_uk.dart
+++ b/lib/l10n/generated/app_localizations_uk.dart
@@ -3185,4 +3185,7 @@ class AppLocalizationsUk extends AppLocalizations {
 
   @override
   String get youMustSelectAJsonFile => 'You must select a .json file.';
+
+  @override
+  String get fullscreen => 'Fullscreen';
 }

--- a/lib/l10n/generated/app_localizations_zh.dart
+++ b/lib/l10n/generated/app_localizations_zh.dart
@@ -3189,6 +3189,9 @@ class AppLocalizationsZh extends AppLocalizations {
 
   @override
   String get youMustSelectAJsonFile => 'You must select a .json file.';
+
+  @override
+  String get fullscreen => 'Fullscreen';
 }
 
 /// The translations for Chinese, using the Han script (`zh_Hans`).

--- a/lib/l10n/generated/app_localizations_zh.dart
+++ b/lib/l10n/generated/app_localizations_zh.dart
@@ -1078,6 +1078,9 @@ class AppLocalizationsZh extends AppLocalizations {
       'Swipe anywhere to go back when left-to-right gestures are disabled';
 
   @override
+  String get fullscreen => 'Fullscreen';
+
+  @override
   String get fullscreenSwipeGestures => 'Fullscreen Swipe Gestures';
 
   @override
@@ -3189,9 +3192,6 @@ class AppLocalizationsZh extends AppLocalizations {
 
   @override
   String get youMustSelectAJsonFile => 'You must select a .json file.';
-
-  @override
-  String get fullscreen => 'Fullscreen';
 }
 
 /// The translations for Chinese, using the Han script (`zh_Hans`).

--- a/lib/src/shared/images/image_viewer.dart
+++ b/lib/src/shared/images/image_viewer.dart
@@ -443,6 +443,7 @@ class _ImageViewerState extends State<ImageViewer> with TickerProviderStateMixin
                           Padding(
                             padding: const EdgeInsets.all(4.0),
                             child: IconButton(
+                              tooltip: l10n.share,
                               onPressed: fullscreen
                                   ? null
                                   : () async {
@@ -480,7 +481,7 @@ class _ImageViewerState extends State<ImageViewer> with TickerProviderStateMixin
                                     )
                                   : Icon(
                                       Icons.share_rounded,
-                                      semanticLabel: "Share",
+                                      semanticLabel: l10n.share,
                                       color: Colors.white.withValues(alpha: 0.90),
                                     ),
                             ),
@@ -489,6 +490,7 @@ class _ImageViewerState extends State<ImageViewer> with TickerProviderStateMixin
                           Padding(
                             padding: const EdgeInsets.all(4.0),
                             child: IconButton(
+                              tooltip: l10n.save,
                               onPressed: (downloaded || isSavingMedia || fullscreen || widget.url == null || kIsWeb)
                                   ? null
                                   : () async {
@@ -547,13 +549,14 @@ class _ImageViewerState extends State<ImageViewer> with TickerProviderStateMixin
                           Padding(
                             padding: const EdgeInsets.all(4.0),
                             child: IconButton(
+                              tooltip: l10n.comments,
                               onPressed: () {
                                 Navigator.pop(context);
                                 widget.navigateToPost!();
                               },
                               icon: Icon(
                                 Icons.chat_rounded,
-                                semanticLabel: "Comments",
+                                semanticLabel: l10n.comments,
                                 color: Colors.white.withValues(alpha: 0.90),
                               ),
                             ),
@@ -562,17 +565,19 @@ class _ImageViewerState extends State<ImageViewer> with TickerProviderStateMixin
                           Padding(
                             padding: const EdgeInsets.all(4.0),
                             child: IconButton(
+                              tooltip: l10n.altText,
                               onPressed: () => setState(() => showAltText = !showAltText),
                               icon: Icon(
                                 Icons.text_fields,
                                 semanticLabel: l10n.altText,
-                                color: Colors.white.withValues(alpha: 0.90),
+                                color: Colors.white.withValues(alpha: showAltText ? 0.90 : 0.5),
                               ),
                             ),
                           ),
                         Padding(
                           padding: const EdgeInsets.all(4.0),
                           child: IconButton(
+                            tooltip: l10n.fullscreen,
                             onPressed: () {
                               if (fullscreen) {
                                 exitFullScreen();
@@ -602,7 +607,7 @@ class _ImageViewerState extends State<ImageViewer> with TickerProviderStateMixin
                 duration: const Duration(milliseconds: 200),
                 child: Padding(
                   padding: const EdgeInsets.all(16),
-                  child: ImageAltTextWrapper(altText: widget.altText!),
+                  child: ImageAltText(text: widget.altText!),
                 ),
               ),
             ),
@@ -612,112 +617,18 @@ class _ImageViewerState extends State<ImageViewer> with TickerProviderStateMixin
   }
 }
 
-class ImageAltTextWrapper extends StatefulWidget {
-  final String altText;
-
-  const ImageAltTextWrapper({super.key, required this.altText});
-
-  @override
-  State<ImageAltTextWrapper> createState() => _ImageAltTextWrapperState();
-}
-
-class _ImageAltTextWrapperState extends State<ImageAltTextWrapper> {
-  final GlobalKey textKey = GlobalKey();
-  bool altTextIsLong = false;
-
-  @override
-  void initState() {
-    super.initState();
-
-    WidgetsBinding.instance.addPostFrameCallback((_) {
-      setState(() {
-        altTextIsLong = (textKey.currentContext?.size?.height ?? 0) > 40;
-      });
-    });
-  }
-
-  @override
-  Widget build(BuildContext context) {
-    final ThemeData theme = Theme.of(context);
-    final AppLocalizations l10n = AppLocalizations.of(context)!;
-
-    return AnimatedCrossFade(
-      crossFadeState: altTextIsLong ? CrossFadeState.showSecond : CrossFadeState.showFirst,
-      duration: const Duration(milliseconds: 250),
-      firstChild: ImageAltText(key: textKey, altText: widget.altText),
-      secondChild: ExpandableNotifier(
-        child: Expandable(
-          expanded: Column(
-            crossAxisAlignment: CrossAxisAlignment.stretch,
-            children: [
-              ImageAltText(altText: widget.altText),
-              ExpandableButton(
-                theme: const ExpandableThemeData(useInkWell: false),
-                child: Text(
-                  l10n.showLess,
-                  style: theme.textTheme.bodySmall?.copyWith(
-                    color: Colors.white.withValues(alpha: 0.5),
-                  ),
-                ),
-              ),
-            ],
-          ),
-          collapsed: Stack(
-            children: [
-              LimitedBox(
-                maxHeight: 60,
-                child: ShaderMask(
-                  shaderCallback: (bounds) {
-                    return const LinearGradient(
-                      begin: Alignment.topCenter,
-                      end: Alignment.bottomCenter,
-                      colors: [
-                        Colors.black,
-                        Colors.transparent,
-                        Colors.transparent,
-                      ],
-                      stops: [0.0, 0.8, 1.0],
-                    ).createShader(bounds);
-                  },
-                  blendMode: BlendMode.dstIn,
-                  child: ImageAltText(altText: widget.altText),
-                ),
-              ),
-              Positioned(
-                bottom: 0,
-                child: ExpandableButton(
-                  theme: const ExpandableThemeData(useInkWell: false),
-                  child: Text(
-                    l10n.showMore,
-                    style: theme.textTheme.bodySmall?.copyWith(
-                      color: Colors.white.withValues(alpha: 0.5),
-                    ),
-                  ),
-                ),
-              ),
-            ],
-          ),
-        ),
-      ),
-    );
-  }
-}
-
 class ImageAltText extends StatelessWidget {
-  final String altText;
+  /// The text to display
+  final String text;
 
-  const ImageAltText({
-    super.key,
-    required this.altText,
-  });
+  const ImageAltText({super.key, required this.text});
 
   @override
   Widget build(BuildContext context) {
-    final ThemeData theme = Theme.of(context);
+    final theme = Theme.of(context);
 
     return Text(
-      key: key,
-      altText,
+      text,
       style: theme.textTheme.bodyMedium?.copyWith(
         color: Colors.white.withValues(alpha: 0.90),
         shadows: [

--- a/lib/src/shared/images/image_viewer.dart
+++ b/lib/src/shared/images/image_viewer.dart
@@ -22,14 +22,22 @@ import 'package:thunder/src/app/bloc/thunder_bloc.dart';
 import 'package:thunder/src/shared/utils/media/image.dart';
 
 class ImageViewer extends StatefulWidget {
+  /// The URL of the image to display
   final String? url;
+
+  /// The bytes of the image to display
   final Uint8List? bytes;
+
+  /// The ID of the post to navigate to
   final int? postId;
+
+  /// The function to navigate to the post
   final void Function()? navigateToPost;
+
+  /// The alt text of the image
   final String? altText;
 
   /// Whether this image viewer is being shown within the context of a peek.
-  /// This would cause us to hide unnecsesary things like the buttons at the bottom.
   final bool isPeek;
 
   const ImageViewer({
@@ -47,8 +55,9 @@ class ImageViewer extends StatefulWidget {
 }
 
 class _ImageViewerState extends State<ImageViewer> with TickerProviderStateMixin {
-  GlobalKey<ExtendedImageSlidePageState> slidePagekey = GlobalKey<ExtendedImageSlidePageState>();
-  final GlobalKey<ExtendedImageGestureState> gestureKey = GlobalKey<ExtendedImageGestureState>();
+  final slidePagekey = GlobalKey<ExtendedImageSlidePageState>();
+  final gestureKey = GlobalKey<ExtendedImageGestureState>();
+
   bool downloaded = false;
   double slideTransparency = 0.92;
   double imageTransparency = 1.0;
@@ -67,34 +76,21 @@ class _ImageViewerState extends State<ImageViewer> with TickerProviderStateMixin
   late double imageHeight = 0;
   late double maxZoomLevel = 3;
 
+  /// Whether to show the alt text at the bottom of the image viewer
+  bool showAltText = false;
+
   void _maybeSlide(BuildContext context) {
-    setState(() {
-      maybeSlideZooming = true;
-    });
-    Timer(const Duration(milliseconds: 500), () {
-      if (context.mounted) {
-        setState(() {
-          maybeSlideZooming = false;
-        });
-      }
-    });
+    setState(() => maybeSlideZooming = true);
+    Timer(const Duration(milliseconds: 500), () => context.mounted ? setState(() => maybeSlideZooming = false) : null);
   }
 
   void enterFullScreen() {
-    setState(() {
-      fullscreen = true;
-    });
-    Timer(const Duration(milliseconds: 400), () {
-      if (fullscreen) {
-        SystemChrome.setEnabledSystemUIMode(SystemUiMode.manual, overlays: []);
-      }
-    });
+    setState(() => fullscreen = true);
+    if (fullscreen) SystemChrome.setEnabledSystemUIMode(SystemUiMode.manual, overlays: []);
   }
 
   void exitFullScreen() {
-    setState(() {
-      fullscreen = false;
-    });
+    setState(() => fullscreen = false);
     SystemChrome.setEnabledSystemUIMode(SystemUiMode.edgeToEdge, overlays: SystemUiOverlay.values);
   }
 
@@ -128,12 +124,13 @@ class _ImageViewerState extends State<ImageViewer> with TickerProviderStateMixin
 
   @override
   Widget build(BuildContext context) {
-    final ThunderState thunderState = context.read<ThunderBloc>().state;
-    final AppLocalizations l10n = AppLocalizations.of(context)!;
+    final thunderState = context.read<ThunderBloc>().state;
+    final l10n = AppLocalizations.of(context)!;
 
     AnimationController animationController = AnimationController(duration: const Duration(milliseconds: 140), vsync: this);
     Function() animationListener = () {};
     Animation? animation;
+
     return PopScope(
       onPopInvokedWithResult: (didPop, result) {
         if (didPop) {
@@ -152,6 +149,7 @@ class _ImageViewerState extends State<ImageViewer> with TickerProviderStateMixin
           ),
           AnimatedContainer(
             duration: const Duration(milliseconds: 400),
+            curve: Curves.easeInOutCubicEmphasized,
             color: fullscreen ? Colors.black : Colors.black.withValues(alpha: slideTransparency),
           ),
           Positioned.fill(
@@ -560,13 +558,42 @@ class _ImageViewerState extends State<ImageViewer> with TickerProviderStateMixin
                               ),
                             ),
                           ),
+                        if (widget.altText?.isNotEmpty == true)
+                          Padding(
+                            padding: const EdgeInsets.all(4.0),
+                            child: IconButton(
+                              onPressed: () => setState(() => showAltText = !showAltText),
+                              icon: Icon(
+                                Icons.text_fields,
+                                semanticLabel: l10n.altText,
+                                color: Colors.white.withValues(alpha: 0.90),
+                              ),
+                            ),
+                          ),
+                        Padding(
+                          padding: const EdgeInsets.all(4.0),
+                          child: IconButton(
+                            onPressed: () {
+                              if (fullscreen) {
+                                exitFullScreen();
+                              } else {
+                                enterFullScreen();
+                              }
+                            },
+                            icon: Icon(
+                              Icons.fullscreen,
+                              semanticLabel: l10n.fullscreen,
+                              color: Colors.white.withValues(alpha: 0.90),
+                            ),
+                          ),
+                        ),
                       ],
                     ),
                   ),
                 ),
               ],
             ),
-          if (widget.altText?.isNotEmpty == true)
+          if (widget.altText?.isNotEmpty == true && showAltText)
             Positioned(
               bottom: kBottomNavigationBarHeight + 25,
               width: MediaQuery.sizeOf(context).width,


### PR DESCRIPTION
## Pull Request Description

<!--- Please describe what was changed -->

This PR adds action buttons to toggle alt-text and fullscreen within the image viewer. By default, alt text will be hidden unless the user toggles it on. This option will only show up for images that have alt-text.

## Issue Being Fixed

<!-- Please describe the problem that is being fixed and, if applicable, reference a GitHub issue -->

Issue Number: #1963

## Screenshots / Recordings

| | |
|-|-|
|<img width="1170" height="2532" alt="simulator_screenshot_65978934-56EC-49B2-9395-A5F35A564363" src="https://github.com/user-attachments/assets/f21bed6b-5bed-4a10-b2d1-254591381126" />|<img width="1170" height="2532" alt="simulator_screenshot_FB5AE816-798C-466D-9763-5B51F7DB2073" src="https://github.com/user-attachments/assets/152cc689-88a1-4aa5-b1e1-29a5df2fc1f7" />|

<!-- This section is optional but highly recommended to show off your changes! -->

## Checklist

- [ ] If a new package was added, did you ensure it uses an appropriate license and is actively maintained?
- [ ] Did you use localized strings (and added appropriate descriptions) where applicable?
- [ ] Did you add `semanticLabel`s where applicable for accessibility?
