### PR TITLE
Fix settings search elevation

### DIFF
--- a/lib/src/features/settings/presentation/pages/settings_page.dart
+++ b/lib/src/features/settings/presentation/pages/settings_page.dart
@@ -61,6 +61,7 @@ class _SettingsPageState extends State<SettingsPage> {
                 child: SearchAnchor.bar(
                   searchController: searchController,
                   barHintText: l10n.search,
+                  barElevation: const WidgetStatePropertyAll(0.0),
                   suggestionsBuilder: (BuildContext context, SearchController controller) {
                     final theme = Theme.of(context);
 


### PR DESCRIPTION
## Pull Request Description

<!--- Please describe what was changed -->

Hey, I'm popping back in! 😊 I noticed that the search widget on the settings page has an elevation now. I'm not sure if the change was intentional, but it no longer matches the search page. It looks like the change was lost when the structure was reorganized (https://github.com/thunder-app/thunder/pull/1924/files#diff-70c4cf2c8269388c5f6753ba0c9b01e972187c04800f701e7cd9dd0494e67b31L69).

## Issue Being Fixed

<!-- Please describe the problem that is being fixed and, if applicable, reference a GitHub issue -->

Issue Number: N/A

## Screenshots / Recordings

<!-- This section is optional but highly recommended to show off your changes! -->

### Before

| <img width="398" height="862" alt="image" src="https://github.com/user-attachments/assets/1a17e175-1bd8-4026-9c01-e978f6e5ab14" /> |
| - |

### After

| <img width="398" height="862" alt="image" src="https://github.com/user-attachments/assets/3bf38871-999f-45eb-b42f-4ca12a2aaba3" /> |
| - |

## Checklist

- [ ] If a new package was added, did you ensure it uses an appropriate license and is actively maintained?
- [ ] Did you use localized strings (and added appropriate descriptions) where applicable?
- [ ] Did you add `semanticLabel`s where applicable for accessibility?
