### PR TITLE
Fix transparent colour option being available as an app theme

### DIFF
--- a/lib/src/core/enums/custom_theme_type.dart
+++ b/lib/src/core/enums/custom_theme_type.dart
@@ -3,7 +3,6 @@ import 'package:flutter/material.dart';
 import 'package:flex_color_scheme/flex_color_scheme.dart';
 
 enum CustomThemeType {
-  transparent(label: 'Transparent', primaryColor: Colors.transparent, secondaryColor: Colors.transparent, tertiaryColor: Colors.transparent),
   material(label: 'Material', primaryColor: FlexColor.materialLightPrimary, secondaryColor: FlexColor.materialLightPrimaryContainer, tertiaryColor: FlexColor.materialLightSecondaryContainer),
   materialHc(
       label: 'Material High Contrast',

--- a/lib/src/features/settings/presentation/pages/post_appearance_settings_page.dart
+++ b/lib/src/features/settings/presentation/pages/post_appearance_settings_page.dart
@@ -723,13 +723,10 @@ class _PostAppearanceSettingsPageState extends State<PostAppearanceSettingsPage>
                                         value: Color(customThemeType.primaryColor.toARGB32()),
                                         child: CircleAvatar(
                                           radius: 16.0,
-                                          backgroundColor: customThemeType == CustomThemeType.transparent
-                                              ? null
-                                              : Color.alphaBlend(
-                                                  theme.colorScheme.primaryContainer.withValues(alpha: 0.6),
-                                                  Color(customThemeType.primaryColor.toARGB32()),
-                                                ),
-                                          child: customThemeType == CustomThemeType.transparent ? Text(customThemeType.label[0].toUpperCase()) : null,
+                                          backgroundColor: Color.alphaBlend(
+                                            theme.colorScheme.primaryContainer.withValues(alpha: 0.6),
+                                            Color(customThemeType.primaryColor.toARGB32()),
+                                          ),
                                         ),
                                       ))
                                   .toList()
@@ -739,6 +736,14 @@ class _PostAppearanceSettingsPageState extends State<PostAppearanceSettingsPage>
                                     alignment: Alignment.center,
                                     value: null,
                                     child: CircleAvatar(radius: 16.0, child: Text('D')),
+                                  ),
+                                )
+                                ..insert(
+                                  1,
+                                  const DropdownMenuItem<Color?>(
+                                    alignment: Alignment.center,
+                                    value: Colors.transparent,
+                                    child: CircleAvatar(radius: 16.0, child: Text('T')),
                                   ),
                                 ),
                               onChanged: (Color? value) {

--- a/lib/src/shared/utils/preferences.dart
+++ b/lib/src/shared/utils/preferences.dart
@@ -171,6 +171,13 @@ Future<void> performSharedPreferencesMigration() async {
     await prefs.setBool(LocalSettings.usePureBlackTheme.name, true);
   }
 
+  // Reset transparent theme to default (transparent theme was removed as it made the app unusable)
+  String? accentColor = prefs.getString(LocalSettings.appThemeAccentColor.name);
+  if (accentColor == 'transparent') {
+    await prefs.remove(LocalSettings.appThemeAccentColor.name);
+    debugPrint('Reset transparent theme to default');
+  }
+
   // Remove scrapeMissingPreviews setting
   bool? scrapeMissingPreviews = prefs.getBool('setting_general_scrape_missing_previews');
   if (scrapeMissingPreviews != null) {


### PR DESCRIPTION
## Pull Request Description

This PR fixes an issue where the "Transparent" colour option was available in other areas outside of the divider colour setting. The transparent option is now scoped down to only show up in the divider colour setting. Additionally, I've added a setting migration to reset the app theme if the "Transparent" option was previously selected.

<!--- Please describe what was changed -->

## Issue Being Fixed

<!-- Please describe the problem that is being fixed and, if applicable, reference a GitHub issue -->

Issue Number: #1976

## Screenshots / Recordings

<!-- This section is optional but highly recommended to show off your changes! -->

## Checklist

- [ ] If a new package was added, did you ensure it uses an appropriate license and is actively maintained?
- [ ] Did you use localized strings (and added appropriate descriptions) where applicable?
- [ ] Did you add `semanticLabel`s where applicable for accessibility?
