### PR TITLE
Fix inbox mark as read not updating UI correctly

### DIFF
--- a/lib/src/features/inbox/presentation/widgets/inbox_mentions_view.dart
+++ b/lib/src/features/inbox/presentation/widgets/inbox_mentions_view.dart
@@ -48,6 +48,7 @@ class _InboxMentionsViewState extends State<InboxMentionsView> {
               assert(comment.read != null, 'Comment should have a read status');
 
               return Column(
+                key: ValueKey<int>(comment.replyMentionId!),
                 children: [
                   CommentReference(
                     comment: comment,

--- a/lib/src/features/inbox/presentation/widgets/inbox_private_messages_view.dart
+++ b/lib/src/features/inbox/presentation/widgets/inbox_private_messages_view.dart
@@ -50,6 +50,7 @@ class _InboxPrivateMessagesViewState extends State<InboxPrivateMessagesView> {
             itemCount: widget.privateMessages.length,
             itemBuilder: (context, index) {
               return Card(
+                key: ValueKey<int>(widget.privateMessages[index].id),
                 child: Padding(
                   padding: const EdgeInsets.symmetric(horizontal: 12.0, vertical: 12.0),
                   child: Column(

--- a/lib/src/features/inbox/presentation/widgets/inbox_replies_view.dart
+++ b/lib/src/features/inbox/presentation/widgets/inbox_replies_view.dart
@@ -49,6 +49,7 @@ class _InboxRepliesViewState extends State<InboxRepliesView> {
               assert(reply.read != null, 'Reply should have a read status');
 
               return Column(
+                key: ValueKey<int>(reply.replyMentionId!),
                 children: [
                   CommentReference(
                     comment: reply,


### PR DESCRIPTION
## Pull Request Description

This PR fixes an issue where marking an inbox item as read would cause the UI to update incorrectly. The underlying logic for updating the inbox item was correct, but there were some issues when removing the inbox item from the state. To fix this, a key has been added to all the inbox items which should fix the issue.

<!--- Please describe what was changed -->

## Issue Being Fixed

<!-- Please describe the problem that is being fixed and, if applicable, reference a GitHub issue -->

Issue Number: #1975

## Screenshots / Recordings

<!-- This section is optional but highly recommended to show off your changes! -->

## Checklist

- [ ] If a new package was added, did you ensure it uses an appropriate license and is actively maintained?
- [ ] Did you use localized strings (and added appropriate descriptions) where applicable?
- [ ] Did you add `semanticLabel`s where applicable for accessibility?
