### PR TITLE
Additional local notification improvements

### DIFF
--- a/lib/src/app/cubits/notifications_cubit/notifications_cubit.dart
+++ b/lib/src/app/cubits/notifications_cubit/notifications_cubit.dart
@@ -12,22 +12,38 @@ part 'notifications_state.dart';
 /// A cubit for handling notifications
 class NotificationsCubit extends Cubit<NotificationsState> {
   final Stream<NotificationResponse> notificationsStream;
+
   StreamSubscription<NotificationResponse>? _notificationsStreamSubscription;
 
   NotificationsCubit({required this.notificationsStream}) : super(const NotificationsState());
 
   void handleNotifications() {
+    if (_notificationsStreamSubscription != null) return; // Only set up the listener once - the stream is single-subscription
+
     _notificationsStreamSubscription = notificationsStream.listen((notificationResponse) async {
-      NotificationPayload? payload = notificationResponse.payload?.isNotEmpty == true ? NotificationPayload.fromJson(jsonDecode(notificationResponse.payload!)) : null;
+      final payload = notificationResponse.payload?.isNotEmpty == true ? NotificationPayload.fromJson(jsonDecode(notificationResponse.payload!)) : null;
 
-      // Check if this is a reply notification
-      if (payload?.inboxType == NotificationInboxType.reply) {
-        emit(state.copyWith(status: NotificationsStatus.reply, replyId: payload!.id, accountId: payload.accountId));
-      }
+      if (payload == null) return;
 
-      // Reset the state
-      emit(state.copyWith(status: NotificationsStatus.none, replyId: null, accountId: payload?.accountId));
+      // Map notification inbox type to status
+      final status = switch (payload.inboxType) {
+        NotificationInboxType.reply => NotificationsStatus.reply,
+        NotificationInboxType.mention => NotificationsStatus.mention,
+        NotificationInboxType.message => NotificationsStatus.message,
+      };
+
+      emit(state.copyWith(status: status, notificationId: payload.id, accountId: payload.accountId, pending: false));
     });
+  }
+
+  /// Marks the notification as pending. This is used when we need to switch accounts before navigating to the notification.
+  void setPending() {
+    emit(state.copyWith(pending: true));
+  }
+
+  /// Clears the notification state after navigation is complete
+  void clearNotification() {
+    emit(state.clear());
   }
 
   void dispose() {

--- a/lib/src/app/cubits/notifications_cubit/notifications_state.dart
+++ b/lib/src/app/cubits/notifications_cubit/notifications_state.dart
@@ -1,34 +1,51 @@
 part of 'notifications_cubit.dart';
 
-enum NotificationsStatus { none, reply }
+enum NotificationsStatus { none, reply, mention, message }
 
 class NotificationsState extends Equatable {
+  /// The status of the notification
   final NotificationsStatus status;
-  final int? replyId;
+
+  /// The ID of the notification (reply, mention, or message)
+  final int? notificationId;
+
+  /// The account ID associated with the notification
   final String? accountId;
+
+  /// Whether the notification is pending navigation (waiting for account switch to complete)
+  final bool pending;
 
   const NotificationsState({
     this.status = NotificationsStatus.none,
-    this.replyId,
+    this.notificationId,
     this.accountId,
+    this.pending = false,
   });
 
   NotificationsState copyWith({
-    required NotificationsStatus status,
-    required int? replyId,
-    required String? accountId,
+    NotificationsStatus? status,
+    int? notificationId,
+    String? accountId,
+    bool? pending,
   }) {
     return NotificationsState(
-      status: status,
-      replyId: replyId,
-      accountId: accountId,
+      status: status ?? this.status,
+      notificationId: notificationId ?? this.notificationId,
+      accountId: accountId ?? this.accountId,
+      pending: pending ?? this.pending,
+    );
+  }
+
+  /// Clears the notification state
+  NotificationsState clear() {
+    return const NotificationsState(
+      status: NotificationsStatus.none,
+      notificationId: null,
+      accountId: null,
+      pending: false,
     );
   }
 
   @override
-  List<dynamic> get props => [
-        status,
-        replyId,
-        accountId,
-      ];
+  List<dynamic> get props => [status, notificationId, accountId, pending];
 }

--- a/lib/src/app/pages/notifications_pages.dart
+++ b/lib/src/app/pages/notifications_pages.dart
@@ -2,59 +2,111 @@ import 'package:flutter/material.dart';
 
 import 'package:flutter_bloc/flutter_bloc.dart';
 
+import 'package:thunder/src/app/utils/global_context.dart';
+import 'package:thunder/src/core/models/thunder_private_message.dart';
 import 'package:thunder/src/features/account/account.dart';
 import 'package:thunder/src/features/comment/comment.dart';
-import 'package:thunder/l10n/generated/app_localizations.dart';
 import 'package:thunder/src/features/inbox/inbox.dart';
 import 'package:thunder/src/features/post/post.dart';
 import 'package:thunder/src/shared/utils/constants.dart';
 
-/// A page for displaying the result of reply notifications
-class NotificationsReplyPage extends StatelessWidget {
-  final List<ThunderComment> replies;
+/// A page for displaying notifications (replies, mentions, or messages)
+class NotificationsPage extends StatelessWidget {
+  /// The type of inbox notification to display
+  final InboxType inboxType;
 
-  const NotificationsReplyPage({super.key, required this.replies});
+  /// The list of comments (used for replies and mentions)
+  final List<ThunderComment> comments;
+
+  /// The list of private messages (used for messages)
+  final List<ThunderPrivateMessage> messages;
+
+  const NotificationsPage({
+    super.key,
+    required this.inboxType,
+    this.comments = const [],
+    this.messages = const [],
+  });
+
+  factory NotificationsPage.replies({Key? key, required List<ThunderComment> replies}) {
+    return NotificationsPage(key: key, inboxType: InboxType.replies, comments: replies);
+  }
+
+  factory NotificationsPage.mentions({Key? key, required List<ThunderComment> mentions}) {
+    return NotificationsPage(key: key, inboxType: InboxType.mentions, comments: mentions);
+  }
+
+  factory NotificationsPage.messages({Key? key, required List<ThunderPrivateMessage> messages}) {
+    return NotificationsPage(key: key, inboxType: InboxType.messages, messages: messages);
+  }
 
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
-    final l10n = AppLocalizations.of(context)!;
+    final l10n = GlobalContext.l10n;
 
     final account = context.select<ProfileBloc, Account>((bloc) => bloc.state.account);
 
     return MultiBlocProvider(
       providers: [
-        BlocProvider.value(value: InboxBloc.initWith(replies: replies, showUnreadOnly: true, account: account)),
+        BlocProvider.value(
+          value: inboxType == InboxType.messages
+              ? (InboxBloc(account: account)..add(const GetInboxEvent(reset: true, inboxType: InboxType.messages)))
+              : InboxBloc.initWith(replies: comments, showUnreadOnly: true, account: account),
+        ),
         BlocProvider.value(value: PostBloc(account: account)),
       ],
       child: BlocConsumer<InboxBloc, InboxState>(
         listener: (BuildContext context, InboxState state) {
-          if (state.replies.isEmpty && (ModalRoute.of(context)?.isCurrent ?? false)) {
+          final shouldPop = switch (inboxType) {
+            InboxType.replies => state.replies.isEmpty,
+            InboxType.mentions => state.replies.isEmpty,
+            InboxType.messages => state.privateMessages.isEmpty && state.status == InboxStatus.success,
+            InboxType.all => false,
+          };
+
+          if (shouldPop && (ModalRoute.of(context)?.isCurrent ?? false)) {
             Navigator.of(context).pop();
           }
         },
-        builder: (context, state) => Material(
-          child: NestedScrollView(
-            headerSliverBuilder: (BuildContext context, bool innerBoxIsScrolled) {
-              return [
-                SliverOverlapAbsorber(
-                  handle: NestedScrollView.sliverOverlapAbsorberHandleFor(context),
-                  sliver: SliverAppBar(
-                    pinned: true,
-                    centerTitle: false,
-                    toolbarHeight: APP_BAR_HEIGHT,
-                    forceElevated: innerBoxIsScrolled,
-                    title: ListTile(
-                      title: Text(l10n.inbox, style: theme.textTheme.titleLarge),
-                      subtitle: Text(l10n.reply(replies.length)),
+        builder: (context, state) {
+          final subtitle = switch (inboxType) {
+            InboxType.replies => l10n.reply(comments.length),
+            InboxType.mentions => l10n.mention(comments.length),
+            InboxType.messages => l10n.message(messages.length),
+            InboxType.all => '',
+          };
+
+          final body = switch (inboxType) {
+            InboxType.replies => InboxRepliesView(replies: state.replies),
+            InboxType.mentions => InboxMentionsView(mentions: state.replies),
+            InboxType.messages => InboxPrivateMessagesView(privateMessages: state.privateMessages.isEmpty ? messages : state.privateMessages),
+            InboxType.all => const SizedBox.shrink(),
+          };
+
+          return Material(
+            child: NestedScrollView(
+              headerSliverBuilder: (BuildContext context, bool innerBoxIsScrolled) {
+                return [
+                  SliverOverlapAbsorber(
+                    handle: NestedScrollView.sliverOverlapAbsorberHandleFor(context),
+                    sliver: SliverAppBar(
+                      pinned: true,
+                      centerTitle: false,
+                      toolbarHeight: APP_BAR_HEIGHT,
+                      forceElevated: innerBoxIsScrolled,
+                      title: ListTile(
+                        title: Text(l10n.inbox, style: theme.textTheme.titleLarge),
+                        subtitle: Text(subtitle),
+                      ),
                     ),
                   ),
-                ),
-              ];
-            },
-            body: InboxRepliesView(replies: state.replies),
-          ),
-        ),
+                ];
+              },
+              body: body,
+            ),
+          );
+        },
       ),
     );
   }

--- a/lib/src/app/pages/thunder_page.dart
+++ b/lib/src/app/pages/thunder_page.dart
@@ -94,6 +94,9 @@ class _ThunderState extends State<Thunder> {
         BlocProvider.of<DeepLinksCubit>(context).initialize();
         BlocProvider.of<NotificationsCubit>(context).handleNotifications();
       }
+
+      // Check for pending notification navigation after account switch
+      _checkPendingNotification();
     });
 
     BackButtonInterceptor.add(_handleBackButtonPress);
@@ -112,6 +115,37 @@ class _ThunderState extends State<Thunder> {
       duration: const Duration(milliseconds: 3500),
       closable: false,
     );
+  }
+
+  void _navigateToNotification(BuildContext context, NotificationsState state) {
+    switch (state.status) {
+      case NotificationsStatus.reply:
+        navigateToNotificationPage(context, inboxType: InboxType.replies, notificationId: state.notificationId, accountId: state.accountId);
+        break;
+      case NotificationsStatus.mention:
+        navigateToNotificationPage(context, inboxType: InboxType.mentions, notificationId: state.notificationId, accountId: state.accountId);
+        break;
+      case NotificationsStatus.message:
+        navigateToNotificationPage(context, inboxType: InboxType.messages, notificationId: state.notificationId, accountId: state.accountId);
+        break;
+      case NotificationsStatus.none:
+        break;
+    }
+  }
+
+  /// Checks for pending notification navigation after account switch.
+  void _checkPendingNotification() {
+    final cubit = context.read<NotificationsCubit>();
+    final state = cubit.state;
+
+    if (state.pending && state.status != NotificationsStatus.none) {
+      Future.delayed(const Duration(milliseconds: 200), () {
+        if (mounted) {
+          _navigateToNotification(context, state);
+          cubit.clearNotification();
+        }
+      });
+    }
   }
 
   FutureOr<bool> _handleBackButtonPress(bool stopDefaultButtonEvent, RouteInfo info) async {
@@ -158,10 +192,25 @@ class _ThunderState extends State<Thunder> {
     return MultiBlocListener(
       listeners: [
         BlocListener<NotificationsCubit, NotificationsState>(
+          listenWhen: (previous, current) {
+            final shouldListen = current.status != NotificationsStatus.none && !current.pending;
+            return shouldListen;
+          },
           listener: (context, state) {
-            if (state.status == NotificationsStatus.reply) {
-              navigateToNotificationReplyPage(context, replyId: state.replyId, accountId: state.accountId);
+            final currentAccountId = context.read<ProfileBloc>().state.account.id;
+            final notificationAccountId = state.accountId;
+
+            // Check if we need to switch accounts first
+            if (notificationAccountId != null && notificationAccountId != currentAccountId) {
+              // Mark as pending navigation and switch accounts
+              context.read<NotificationsCubit>().setPending();
+              context.read<ProfileBloc>().add(SwitchProfile(accountId: notificationAccountId, reload: true));
+              return;
             }
+
+            // Navigate directly and clear notification state
+            _navigateToNotification(context, state);
+            context.read<NotificationsCubit>().clearNotification();
           },
         ),
         BlocListener<DeepLinksCubit, DeepLinksState>(

--- a/lib/src/app/utils/navigation.dart
+++ b/lib/src/app/utils/navigation.dart
@@ -8,7 +8,7 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 
 import 'package:thunder/src/app/routing/swipeable_page_route.dart';
 import 'package:thunder/src/core/enums/comment_sort_type.dart';
-import 'package:thunder/src/core/enums/full_name.dart';
+import 'package:thunder/src/core/models/thunder_private_message.dart';
 import 'package:thunder/src/core/models/thunder_site_response.dart';
 import 'package:thunder/src/features/instance/instance.dart';
 import 'package:thunder/l10n/generated/app_localizations.dart';
@@ -444,55 +444,86 @@ Future<void> navigateToCreatePostPage(
   }
 }
 
-void navigateToNotificationReplyPage(BuildContext context, {required int? replyId, required String? accountId}) async {
+/// Navigates to a notifications page for the given [inboxType].
+///
+/// The [notificationId] is used to find and display a specific notification.
+/// If [notificationId] is null, all unread notifications of the given type will be shown.
+void navigateToNotificationPage(
+  BuildContext context, {
+  required InboxType inboxType,
+  required int? notificationId,
+  required String? accountId,
+}) async {
+  assert(inboxType == InboxType.replies || inboxType == InboxType.mentions || inboxType == InboxType.messages);
+
   // It can take a little while to set up notifications, so show a loading page
   showLoadingPage(context);
 
-  final ThunderBloc thunderBloc = context.read<ThunderBloc>();
-  final bool reduceAnimations = thunderBloc.state.reduceAnimations;
-  final AppLocalizations l10n = AppLocalizations.of(context)!;
-  Account? account = await fetchActiveProfile();
+  final thunderBloc = context.read<ThunderBloc>();
+  final reduceAnimations = thunderBloc.state.reduceAnimations;
 
-  if (account.id != accountId && accountId != null && context.mounted) {
-    // Switch to the notification's account without reloading the app
-    context.read<ProfileBloc>().add(SwitchProfile(accountId: accountId, reload: false));
-
-    // Set the account locally here so we don't have to wait for the event to complete
-    account = await Account.fetchAccount(accountId);
-
-    // Show the user a message indicating that we switched
-    showSnackbar(l10n.switchedAccount(generateUserFullName(context, account?.username, account?.displayName, account?.instance)));
+  if (accountId == null) {
+    hideLoadingPage(context);
+    return; // No account ID provided, so we can't do anything.
   }
 
-  // If account is still null, we can't do anything.
-  if (account == null || account.anonymous) return;
+  final account = await Account.fetchAccount(accountId);
+  if (account == null) {
+    if (context.mounted) hideLoadingPage(context);
+    return; // No account found, so we can't do anything.
+  }
 
-  List<ThunderComment> allReplies = [];
-  ThunderComment? specificReply;
+  final notificationRepository = NotificationRepositoryImpl(account: account);
 
-  bool doneFetching = false;
-  int currentPage = 1;
+  late final NotificationsPage notificationsPage;
 
-  // Load the notifications
-  while (!doneFetching) {
-    final getRepliesResponse = await NotificationRepositoryImpl(account: account).replies(
-      unread: replyId == null,
-      limit: 50,
-      sort: CommentSortType.new_,
-      page: currentPage,
-    );
+  if (inboxType == InboxType.messages) {
+    final messages = <ThunderPrivateMessage>[];
+    ThunderPrivateMessage? message;
 
-    allReplies.addAll(getRepliesResponse);
-    specificReply ??= getRepliesResponse.firstWhereOrNull((crv) => crv.id == replyId);
+    bool doneFetching = false;
+    int currentPage = 1;
 
-    doneFetching = specificReply != null || getRepliesResponse.isEmpty;
-    ++currentPage;
+    while (!doneFetching) {
+      final response = await notificationRepository.messages(
+        unread: notificationId == null,
+        limit: 50,
+        page: currentPage,
+      );
+
+      messages.addAll(response);
+      message ??= response.firstWhereOrNull((m) => m.id == notificationId);
+
+      doneFetching = message != null || response.isEmpty;
+      ++currentPage;
+    }
+
+    notificationsPage = NotificationsPage.messages(messages: message == null ? messages : [message]);
+  } else {
+    final comments = <ThunderComment>[];
+    ThunderComment? comment;
+
+    bool doneFetching = false;
+    int currentPage = 1;
+
+    while (!doneFetching) {
+      final response = inboxType == InboxType.replies
+          ? await notificationRepository.replies(unread: notificationId == null, limit: 50, sort: CommentSortType.new_, page: currentPage)
+          : await notificationRepository.mentions(unread: notificationId == null, limit: 50, sort: CommentSortType.new_, page: currentPage);
+
+      comments.addAll(response);
+      comment ??= response.firstWhereOrNull((c) => c.id == notificationId);
+
+      doneFetching = comment != null || response.isEmpty;
+      ++currentPage;
+    }
+
+    notificationsPage =
+        inboxType == InboxType.replies ? NotificationsPage.replies(replies: comment == null ? comments : [comment]) : NotificationsPage.mentions(mentions: comment == null ? comments : [comment]);
   }
 
   if (context.mounted) {
-    final NotificationsReplyPage notificationsReplyPage = NotificationsReplyPage(replies: specificReply == null ? allReplies : [specificReply]);
-
-    final SwipeablePageRoute route = SwipeablePageRoute(
+    final route = SwipeablePageRoute(
       transitionDuration: isLoadingPageShown
           ? Duration.zero
           : reduceAnimations
@@ -503,10 +534,8 @@ void navigateToNotificationReplyPage(BuildContext context, {required int? replyI
       canSwipe: !kIsWeb && Platform.isIOS || thunderBloc.state.enableFullScreenSwipeNavigationGesture,
       canOnlySwipeFromEdge: !thunderBloc.state.enableFullScreenSwipeNavigationGesture,
       builder: (context) => MultiBlocProvider(
-        providers: [
-          BlocProvider.value(value: thunderBloc),
-        ],
-        child: notificationsReplyPage,
+        providers: [BlocProvider.value(value: thunderBloc)],
+        child: notificationsPage,
       ),
     );
 

--- a/lib/src/features/notification/presentation/utils/android_notification.dart
+++ b/lib/src/features/notification/presentation/utils/android_notification.dart
@@ -9,14 +9,14 @@ import 'package:thunder/src/core/enums/local_settings.dart';
 import 'package:thunder/src/core/singletons/preferences.dart';
 import 'package:thunder/src/features/notification/notification.dart';
 
-const String _repliesChannelId = 'replies';
-const String _repliesChannelName = 'Replies';
+const String _repliesChannelId = 'inbox_replies';
+const String _repliesChannelName = 'Inbox Replies';
 
-const String _mentionsChannelId = 'mentions';
-const String _mentionsChannelName = 'Mentions';
+const String _mentionsChannelId = 'inbox_mentions';
+const String _mentionsChannelName = 'Inbox Mentions';
 
-const String _messagesChannelId = 'private_messages';
-const String _messagesChannelName = 'Private Messages';
+const String _messagesChannelId = 'inbox_messages';
+const String _messagesChannelName = 'Inbox Messages';
 
 const String _testChannelId = 'troubleshooting';
 const String _testChannelName = 'Troubleshooting';
@@ -25,7 +25,7 @@ const String _testChannelName = 'Troubleshooting';
 ///
 /// This displays an empty notification which will be used in conjunction with the [showAndroidNotification]
 /// to help display a group of notifications on Android.
-void showNotificationGroups({required NotificationType type, required List<Account> accounts, required List<NotificationInboxType> inboxTypes}) async {
+Future<void> showNotificationGroups({required NotificationType type, required List<Account> accounts, required List<NotificationInboxType> inboxTypes}) async {
   final flutterLocalNotificationsPlugin = FlutterLocalNotificationsPlugin();
   final userSeparator = FullNameSeparator.values.byName(UserPreferences.getLocalSetting(LocalSettings.userFormat) ?? FullNameSeparator.at.name);
   final useDisplayNamesForUsers = UserPreferences.getLocalSetting(LocalSettings.useDisplayNamesForUsers) ?? false;
@@ -83,7 +83,7 @@ void showNotificationGroups({required NotificationType type, required List<Accou
 
 /// Displays a single push notification on Android. When a notification is displayed, it will be grouped by the account id.
 /// This allows us to group notifications for a single account on Android.
-void showAndroidNotification({
+Future<void> showAndroidNotification({
   required int id,
   required BigTextStyleInformation bigTextStyleInformation,
   required Account account,

--- a/lib/src/features/notification/presentation/utils/local_notifications.dart
+++ b/lib/src/features/notification/presentation/utils/local_notifications.dart
@@ -1,17 +1,13 @@
-// Dart imports
 import 'dart:async';
 import 'dart:convert';
 
-// Flutter imports
 import 'package:flutter/material.dart';
 
-// Package imports
 import 'package:background_fetch/background_fetch.dart';
 import 'package:flutter_local_notifications/flutter_local_notifications.dart';
 import 'package:html/parser.dart';
 import 'package:markdown/markdown.dart';
 
-// Project imports
 import 'package:thunder/src/features/account/account.dart';
 import 'package:thunder/src/features/comment/comment.dart';
 import 'package:thunder/src/core/enums/comment_sort_type.dart';
@@ -38,7 +34,6 @@ void initLocalNotifications({required StreamController<NotificationResponse> con
 }
 
 /// This method polls for new inbox notifications (replies, mentions, messages) and displays them.
-/// It is intended to be invoked from a background fetch task.
 /// It will track when the last poll ran and ignore any notifications from before that time.
 ///
 /// If the user has not configured inbox notifications, it will do nothing. If no user is logged in, it will do nothing.
@@ -47,25 +42,28 @@ Future<void> pollNotificationsAndShow() async {
   // If we see this line outputted when notifications are disabled, then something is wrong with our configuration of background_fetch.
   debugPrint('Thunder - Background fetch - Running notification poll');
 
-  final FullNameSeparator userSeparator = FullNameSeparator.values.byName(UserPreferences.getLocalSetting(LocalSettings.userFormat) ?? FullNameSeparator.at.name);
-  final FullNameSeparator communitySeparator = FullNameSeparator.values.byName(UserPreferences.getLocalSetting(LocalSettings.communityFormat) ?? FullNameSeparator.dot.name);
-  final bool useDisplayNamesForUsers = UserPreferences.getLocalSetting(LocalSettings.useDisplayNamesForUsers) ?? false;
-  final bool useDisplayNamesForCommunities = UserPreferences.getLocalSetting(LocalSettings.useDisplayNamesForCommunities) ?? false;
+  final userFormat = UserPreferences.getLocalSetting(LocalSettings.userFormat) ?? FullNameSeparator.at.name;
+  final communityFormat = UserPreferences.getLocalSetting(LocalSettings.communityFormat) ?? FullNameSeparator.dot.name;
+  final useDisplayNamesForUsers = UserPreferences.getLocalSetting(LocalSettings.useDisplayNamesForUsers) ?? false;
+  final useDisplayNamesForCommunities = UserPreferences.getLocalSetting(LocalSettings.useDisplayNamesForCommunities) ?? false;
+
+  final userSeparator = FullNameSeparator.values.byName(userFormat);
+  final communitySeparator = FullNameSeparator.values.byName(communityFormat);
 
   final prefs = UserPreferences.instance.preferences;
 
   // Ensure that the db is initialized before attempting to access below.
   initializeDatabase();
 
-  List<Account> accounts = await Account.accounts();
-  DateTime lastPollTime = DateTime.tryParse(prefs.getString(_lastPollTimeId) ?? '') ?? DateTime.now();
+  final accounts = await Account.accounts();
+  final lastPollTime = DateTime.tryParse(prefs.getString(_lastPollTimeId) ?? '') ?? DateTime.now();
 
   // Track notifications by type for each account
-  Map<Account, List<ThunderComment>> replyNotifications = {};
-  Map<Account, List<ThunderComment>> mentionNotifications = {};
-  Map<Account, List<ThunderPrivateMessage>> messageNotifications = {};
+  final replyNotifications = <Account, List<ThunderComment>>{};
+  final mentionNotifications = <Account, List<ThunderComment>>{};
+  final messageNotifications = <Account, List<ThunderPrivateMessage>>{};
 
-  for (final Account account in accounts) {
+  for (final account in accounts) {
     // Skip anonymous accounts since they can't have notifications
     if (account.anonymous) continue;
 
@@ -73,8 +71,8 @@ Future<void> pollNotificationsAndShow() async {
 
     // Poll replies
     try {
-      final repliesResponse = await repository.replies(unread: true, limit: 50, sort: CommentSortType.old, page: 1);
-      final newReplies = repliesResponse.where((comment) => comment.published.isAfter(lastPollTime)).toList();
+      final replies = await repository.replies(unread: true, limit: 50, sort: CommentSortType.old, page: 1);
+      final newReplies = replies.where((comment) => comment.published.isAfter(lastPollTime)).toList();
       if (newReplies.isNotEmpty) replyNotifications[account] = newReplies;
     } catch (e) {
       debugPrint('Thunder - Background fetch - Error polling replies for account ${account.username}: $e');
@@ -82,8 +80,8 @@ Future<void> pollNotificationsAndShow() async {
 
     // Poll mentions
     try {
-      final mentionsResponse = await repository.mentions(unread: true, limit: 50, sort: CommentSortType.old, page: 1);
-      final newMentions = mentionsResponse.where((comment) => comment.published.isAfter(lastPollTime)).toList();
+      final mentions = await repository.mentions(unread: true, limit: 50, sort: CommentSortType.old, page: 1);
+      final newMentions = mentions.where((comment) => comment.published.isAfter(lastPollTime)).toList();
       if (newMentions.isNotEmpty) mentionNotifications[account] = newMentions;
     } catch (e) {
       debugPrint('Thunder - Background fetch - Error polling mentions for account ${account.username}: $e');
@@ -91,8 +89,8 @@ Future<void> pollNotificationsAndShow() async {
 
     // Poll messages
     try {
-      final messagesResponse = await repository.messages(unread: true, limit: 50, page: 1);
-      final newMessages = messagesResponse.where((message) => message.published.isAfter(lastPollTime)).toList();
+      final messages = await repository.messages(unread: true, limit: 50, page: 1);
+      final newMessages = messages.where((message) => message.published.isAfter(lastPollTime)).toList();
       if (newMessages.isNotEmpty) messageNotifications[account] = newMessages;
     } catch (e) {
       debugPrint('Thunder - Background fetch - Error polling messages for account ${account.username}: $e');
@@ -106,19 +104,21 @@ Future<void> pollNotificationsAndShow() async {
   }
 
   // Collect all accounts and their inbox types for notification groups
-  Set<Account> allAccounts = {...replyNotifications.keys, ...mentionNotifications.keys, ...messageNotifications.keys};
-  for (final account in allAccounts) {
-    List<NotificationInboxType> inboxTypes = [];
+  final notificationAccounts = {...replyNotifications.keys, ...mentionNotifications.keys, ...messageNotifications.keys};
+
+  for (final account in notificationAccounts) {
+    final inboxTypes = <NotificationInboxType>[];
+
     if (replyNotifications.containsKey(account)) inboxTypes.add(NotificationInboxType.reply);
     if (mentionNotifications.containsKey(account)) inboxTypes.add(NotificationInboxType.mention);
     if (messageNotifications.containsKey(account)) inboxTypes.add(NotificationInboxType.message);
 
-    showNotificationGroups(accounts: [account], inboxTypes: inboxTypes, type: NotificationType.local);
+    await showNotificationGroups(accounts: [account], inboxTypes: inboxTypes, type: NotificationType.local);
   }
 
   // Show reply notifications
   for (final entry in replyNotifications.entries) {
-    _showCommentNotifications(
+    await _showCommentNotifications(
       account: entry.key,
       comments: entry.value,
       inboxType: NotificationInboxType.reply,
@@ -131,7 +131,7 @@ Future<void> pollNotificationsAndShow() async {
 
   // Show mention notifications
   for (final entry in mentionNotifications.entries) {
-    _showCommentNotifications(
+    await _showCommentNotifications(
       account: entry.key,
       comments: entry.value,
       inboxType: NotificationInboxType.mention,
@@ -144,7 +144,7 @@ Future<void> pollNotificationsAndShow() async {
 
   // Show message notifications
   for (final entry in messageNotifications.entries) {
-    _showMessageNotifications(
+    await _showMessageNotifications(
       account: entry.key,
       messages: entry.value,
       userSeparator: userSeparator,
@@ -157,7 +157,7 @@ Future<void> pollNotificationsAndShow() async {
 }
 
 /// Helper function to show notifications for comments (replies and mentions)
-void _showCommentNotifications({
+Future<void> _showCommentNotifications({
   required Account account,
   required List<ThunderComment> comments,
   required NotificationInboxType inboxType,
@@ -165,13 +165,13 @@ void _showCommentNotifications({
   required FullNameSeparator communitySeparator,
   required bool useDisplayNamesForUsers,
   required bool useDisplayNamesForCommunities,
-}) {
+}) async {
   for (final comment in comments) {
-    final String commentContent = cleanCommentContent(comment);
-    final String htmlComment = cleanImagesFromHtml(markdownToHtml(commentContent));
-    final String plaintextComment = parse(parse(htmlComment).body?.text).documentElement?.text ?? commentContent;
+    final commentContent = cleanCommentContent(comment);
+    final htmlComment = cleanImagesFromHtml(markdownToHtml(commentContent));
+    final plaintextComment = parse(parse(htmlComment).body?.text).documentElement?.text ?? commentContent;
 
-    final BigTextStyleInformation bigTextStyleInformation = BigTextStyleInformation(
+    final bigTextStyleInformation = BigTextStyleInformation(
       '${comment.post?.name} · ${generateCommunityFullName(
         null,
         comment.community?.name,
@@ -199,7 +199,7 @@ void _showCommentNotifications({
       htmlFormatBigText: true,
     );
 
-    showAndroidNotification(
+    await showAndroidNotification(
       id: comment.id,
       account: account,
       bigTextStyleInformation: bigTextStyleInformation,
@@ -225,17 +225,17 @@ void _showCommentNotifications({
 }
 
 /// Helper function to show notifications for private messages
-void _showMessageNotifications({
+Future<void> _showMessageNotifications({
   required Account account,
   required List<ThunderPrivateMessage> messages,
   required FullNameSeparator userSeparator,
   required bool useDisplayNamesForUsers,
-}) {
+}) async {
   for (final message in messages) {
-    final String htmlContent = cleanImagesFromHtml(markdownToHtml(message.content));
-    final String plaintextContent = parse(parse(htmlContent).body?.text).documentElement?.text ?? message.content;
+    final htmlContent = cleanImagesFromHtml(markdownToHtml(message.content));
+    final plaintextContent = parse(parse(htmlContent).body?.text).documentElement?.text ?? message.content;
 
-    final BigTextStyleInformation bigTextStyleInformation = BigTextStyleInformation(
+    final bigTextStyleInformation = BigTextStyleInformation(
       htmlContent,
       contentTitle: generateUserFullName(
         null,
@@ -256,7 +256,7 @@ void _showMessageNotifications({
       htmlFormatBigText: true,
     );
 
-    showAndroidNotification(
+    await showAndroidNotification(
       id: message.id,
       account: account,
       bigTextStyleInformation: bigTextStyleInformation,


### PR DESCRIPTION
## Pull Request Description

This PR improves the logic for local notifications and applies the following changes:
- Fixed an issue where tapping on a notification would not work properly.
  - Previously, tapping on a notification would briefly show the notification page, and then immediately dismiss it. Additionally, tapping on a notification meant for a different profile would not switch over to the profile properly.
  - This regression was likely introduced when I refactored the profile switching logic. Tapping on a notification should now behave properly.
- Added notification pages for comment mentions and private messages
- Reverts the notification channel ids back to their previous values

<!--- Please describe what was changed -->

## Issue Being Fixed

<!-- Please describe the problem that is being fixed and, if applicable, reference a GitHub issue -->

Issue Number: N/A

## Screenshots / Recordings

<!-- This section is optional but highly recommended to show off your changes! -->

## Checklist

- [ ] If a new package was added, did you ensure it uses an appropriate license and is actively maintained?
- [ ] Did you use localized strings (and added appropriate descriptions) where applicable?
- [ ] Did you add `semanticLabel`s where applicable for accessibility?
