### PR TITLE
Fix max password limit for PieFed

### DIFF
--- a/lib/src/core/enums/threadiverse_platform.dart
+++ b/lib/src/core/enums/threadiverse_platform.dart
@@ -2,6 +2,12 @@ enum ThreadiversePlatform {
   lemmy,
   piefed;
 
+  /// The maximum password length for the current platform. Lemmy restricts passwords to 60 characters, PieFed to 128 characters.
+  int get maxPasswordLength => switch (this) {
+        ThreadiversePlatform.lemmy => 60,
+        ThreadiversePlatform.piefed => 128,
+      };
+
   /// Converts a string value to ThreadiversePlatform enum
   static ThreadiversePlatform? fromString(String? value) {
     if (value == null) return null;

--- a/lib/src/features/account/presentation/pages/login_page.dart
+++ b/lib/src/features/account/presentation/pages/login_page.dart
@@ -339,7 +339,7 @@ class _LoginPageState extends State<LoginPage> with SingleTickerProviderStateMix
                             controller: _passwordTextEditingController,
                             obscureText: !showPassword,
                             enableSuggestions: false,
-                            maxLength: 60, // This is what lemmy retricts password length to
+                            maxLength: instanceInfo?.platform?.maxPasswordLength ?? ThreadiversePlatform.piefed.maxPasswordLength,
                             autofillHints: const [AutofillHints.password],
                             decoration: InputDecoration(
                               border: const OutlineInputBorder(),


### PR DESCRIPTION
## Pull Request Description

This PR fixes an issue where users using PieFed with passwords longer than 60 characters were unable to login. The password field is now dynamically set based on the platform (e.g., Lemmy/PieFed). By default, it will be max 128 characters long.

<!--- Please describe what was changed -->

## Issue Being Fixed

<!-- Please describe the problem that is being fixed and, if applicable, reference a GitHub issue -->

Issue Number:  #1992

## Screenshots / Recordings

<!-- This section is optional but highly recommended to show off your changes! -->

## Checklist

- [ ] If a new package was added, did you ensure it uses an appropriate license and is actively maintained?
- [ ] Did you use localized strings (and added appropriate descriptions) where applicable?
- [ ] Did you add `semanticLabel`s where applicable for accessibility?
