### PR TITLE
Add support for .avif image formats

### DIFF
--- a/lib/src/shared/utils/media/image.dart
+++ b/lib/src/shared/utils/media/image.dart
@@ -38,7 +38,7 @@ String fetchProxyImageUrl(String url) {
 bool isImageUrl(String url) {
   // '@jpeg' is added to support Bluesky's image URLs
   // e.g., https://cdn.bsky.app/img/feed_fullsize/plain/did:plc:wf7nfy2us3h5gpa7zfettmzl/bafkreib6k2uwcy52wi654fdfmfqakzqu54m4eq7vi6cwrolwud6yhehihy@jpeg?.jpg
-  final imageExtensions = ['.png', '.jpg', '.jpeg', '.gif', '.bmp', '.webp', '@jpeg'];
+  final imageExtensions = ['.png', '.jpg', '.jpeg', '.gif', '.bmp', '.webp', '.avif', '@jpeg'];
 
   // If image proxying is enabled, we need to determine the original URL to see if that's an image
   url = fetchProxyImageUrl(url);


### PR DESCRIPTION
## Pull Request Description

This PR adds support for `.avif` image formats. Thunder was not displaying the proper image thumbnails for certain instances that were returning back `.avif` files (e.g., lemmy.zip).

<!--- Please describe what was changed -->

## Issue Being Fixed

<!-- Please describe the problem that is being fixed and, if applicable, reference a GitHub issue -->

Issue Number: #1993

## Screenshots / Recordings

<!-- This section is optional but highly recommended to show off your changes! -->

## Checklist

- [ ] If a new package was added, did you ensure it uses an appropriate license and is actively maintained?
- [ ] Did you use localized strings (and added appropriate descriptions) where applicable?
- [ ] Did you add `semanticLabel`s where applicable for accessibility?
