### PR TITLE
Increase video player scrubbing timeline height

### DIFF
--- a/lib/src/shared/utils/video_player/src/thunder_video_player.dart
+++ b/lib/src/shared/utils/video_player/src/thunder_video_player.dart
@@ -353,7 +353,7 @@ class _VideoPlayerControlsState extends State<VideoPlayerControls> {
             ],
           ),
           Container(
-            height: 5.0,
+            height: 8.0,
             margin: const EdgeInsets.only(left: 8.0, right: 8.0, bottom: 16.0),
             decoration: BoxDecoration(borderRadius: BorderRadius.circular(16.0)),
             clipBehavior: Clip.hardEdge,


### PR DESCRIPTION
## Pull Request Description

This is a minor PR which increases the height of Thunder's video player timeline. This should allow users to more easily scrub through a video.

<!--- Please describe what was changed -->

## Issue Being Fixed

<!-- Please describe the problem that is being fixed and, if applicable, reference a GitHub issue -->

Issue Number: https://lemmy.world/post/37544377

## Screenshots / Recordings

<!-- This section is optional but highly recommended to show off your changes! -->

## Checklist

- [ ] If a new package was added, did you ensure it uses an appropriate license and is actively maintained?
- [ ] Did you use localized strings (and added appropriate descriptions) where applicable?
- [ ] Did you add `semanticLabel`s where applicable for accessibility?
