### PR TITLE
Fix spoiler tag markdown rendering

### DIFF
--- a/lib/src/shared/markdown/markdown_spoiler.dart
+++ b/lib/src/shared/markdown/markdown_spoiler.dart
@@ -158,7 +158,7 @@ class _SpoilerWidgetState extends State<SpoilerWidget> {
     final theme = Theme.of(context);
     final state = context.read<ThunderBloc>().state;
 
-    return Ink(
+    return Container(
       decoration: BoxDecoration(
         color: getBackgroundColor(context),
         borderRadius: const BorderRadius.all(Radius.elliptical(5, 5)),
@@ -174,32 +174,35 @@ class _SpoilerWidgetState extends State<SpoilerWidget> {
   }
 
   Widget _buildSpoilerHeader(AppLocalizations l10n, ThemeData theme, ThunderState state) {
-    return InkWell(
-      borderRadius: const BorderRadius.all(Radius.elliptical(5, 5)),
-      onTap: () {
-        expandableController.toggle();
-        setState(() {});
-      },
-      child: Padding(
-        padding: const EdgeInsets.symmetric(vertical: 4.0),
-        child: Row(
-          mainAxisAlignment: MainAxisAlignment.spaceBetween,
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            Icon(
-              expandableController.expanded ? Icons.expand_more_rounded : Icons.chevron_right_rounded,
-              semanticLabel: expandableController.expanded ? l10n.collapseSpoiler : l10n.expandSpoiler,
-              size: 20,
-            ),
-            const SizedBox(width: 5),
-            Expanded(
-              child: ScalableText(
-                widget.title ?? l10n.spoiler,
-                fontScale: state.contentFontSizeScale,
-                style: theme.textTheme.bodyMedium?.copyWith(fontWeight: FontWeight.bold),
+    return Material(
+      color: Colors.transparent,
+      child: InkWell(
+        borderRadius: const BorderRadius.all(Radius.elliptical(5, 5)),
+        onTap: () {
+          expandableController.toggle();
+          setState(() {});
+        },
+        child: Padding(
+          padding: const EdgeInsets.symmetric(vertical: 4.0),
+          child: Row(
+            mainAxisAlignment: MainAxisAlignment.spaceBetween,
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Icon(
+                expandableController.expanded ? Icons.expand_more_rounded : Icons.chevron_right_rounded,
+                semanticLabel: expandableController.expanded ? l10n.collapseSpoiler : l10n.expandSpoiler,
+                size: 20,
               ),
-            ),
-          ],
+              const SizedBox(width: 5),
+              Expanded(
+                child: ScalableText(
+                  widget.title ?? l10n.spoiler,
+                  fontScale: state.contentFontSizeScale,
+                  style: theme.textTheme.bodyMedium?.copyWith(fontWeight: FontWeight.bold),
+                ),
+              ),
+            ],
+          ),
         ),
       ),
     );


### PR DESCRIPTION
## Pull Request Description

This PR fixes an issue where the background of the spoiler markdown is shown when the post body is collapsed. Wrapping the InkWell in a Material widget seems to have fixed the issue.

<!--- Please describe what was changed -->

## Issue Being Fixed

<!-- Please describe the problem that is being fixed and, if applicable, reference a GitHub issue -->

Issue Number: #1974

## Screenshots / Recordings

<!-- This section is optional but highly recommended to show off your changes! -->

## Checklist

- [ ] If a new package was added, did you ensure it uses an appropriate license and is actively maintained?
- [ ] Did you use localized strings (and added appropriate descriptions) where applicable?
- [ ] Did you add `semanticLabel`s where applicable for accessibility?
