### PR TITLE
Improve image proxy handling and fallback

### DIFF
--- a/lib/src/shared/images/image_preview.dart
+++ b/lib/src/shared/images/image_preview.dart
@@ -3,12 +3,25 @@ import 'dart:ui';
 import 'package:flutter/material.dart';
 
 import 'package:cached_network_image/cached_network_image.dart';
+import 'package:thunder/src/app/utils/global_context.dart';
 
 import 'package:thunder/src/core/enums/media_type.dart';
 import 'package:thunder/src/shared/utils/media/image.dart';
 
+/// The loading state of an image preview.
+enum ImagePreviewState {
+  /// The image is currently loading.
+  loading,
+
+  /// The image has loaded successfully.
+  success,
+
+  /// The image failed to load.
+  error,
+}
+
 /// Displays a preview of an image.
-class ImagePreview extends StatelessWidget {
+class ImagePreview extends StatefulWidget {
   /// The URL of the image to display.
   final String url;
 
@@ -36,6 +49,13 @@ class ImagePreview extends StatelessWidget {
   /// Whether the image should be blurred.
   final bool? blur;
 
+  /// Whether to allow retrying with the original URL when a proxy URL fails.
+  /// When false, the error state will show an error icon without retry option.
+  final bool allowRetry;
+
+  /// Callback invoked when the image loading state changes.
+  final void Function(ImagePreviewState state)? onStateChanged;
+
   const ImagePreview({
     super.key,
     required this.url,
@@ -46,29 +66,82 @@ class ImagePreview extends StatelessWidget {
     this.mediaType,
     this.viewed,
     this.blur,
+    this.allowRetry = false,
+    this.onStateChanged,
   });
+
+  @override
+  State<ImagePreview> createState() => _ImagePreviewState();
+}
+
+class _ImagePreviewState extends State<ImagePreview> {
+  /// Whether we're using the fallback (original) URL instead of the proxy URL.
+  bool _useFallbackUrl = false;
+
+  /// The current loading state of the image.
+  ImagePreviewState _state = ImagePreviewState.loading;
+
+  /// The current URL being used to load the image.
+  String get _currentUrl {
+    if (_useFallbackUrl) return fetchProxyImageUrl(widget.url);
+    return widget.url;
+  }
+
+  /// Whether the current URL is a proxy URL that can be retried with the original URL.
+  bool get _canRetryWithOriginalUrl {
+    if (!widget.allowRetry) return false;
+    final originalUrl = fetchProxyImageUrl(widget.url);
+    return originalUrl != widget.url && !_useFallbackUrl;
+  }
+
+  void _retryWithOriginalUrl() {
+    setState(() {
+      _useFallbackUrl = true;
+      _state = ImagePreviewState.loading;
+    });
+    widget.onStateChanged?.call(ImagePreviewState.loading);
+  }
+
+  void _onImageLoaded() {
+    if (_state != ImagePreviewState.success) {
+      setState(() => _state = ImagePreviewState.success);
+      widget.onStateChanged?.call(ImagePreviewState.success);
+    }
+  }
+
+  void _onImageError() {
+    if (_state != ImagePreviewState.error) {
+      setState(() => _state = ImagePreviewState.error);
+      widget.onStateChanged?.call(ImagePreviewState.error);
+    }
+  }
 
   @override
   Widget build(BuildContext context) {
     // TODO: Move the logic for determining if the image is valid into data layer so that we don't need to re-evaluate this on every build.
-    final isValidImageUrl = contentType != null || isImageUrl(url);
+    final isValidImageUrl = widget.contentType != null || isImageUrl(widget.url);
 
     if (!isValidImageUrl) {
       return ImagePreviewError(
-        mediaType: mediaType,
-        blur: blur == true,
-        viewed: viewed == true,
+        mediaType: widget.mediaType,
+        blur: widget.blur == true,
+        viewed: widget.viewed == true,
       );
     }
 
     return _ImageContent(
-      url: url,
-      width: width,
-      height: height,
-      fit: fit,
-      viewed: viewed,
-      blur: blur,
-      mediaType: mediaType,
+      key: ValueKey(_currentUrl),
+      url: _currentUrl,
+      width: widget.width,
+      height: widget.height,
+      fit: widget.fit,
+      viewed: widget.viewed,
+      blur: widget.blur,
+      mediaType: widget.mediaType,
+      canRetry: _canRetryWithOriginalUrl,
+      onRetry: _retryWithOriginalUrl,
+      onLoaded: _onImageLoaded,
+      onError: _onImageError,
     );
   }
 }
@@ -96,7 +169,20 @@ class _ImageContent extends StatelessWidget {
   /// The media type that the underlying image represents.
   final MediaType? mediaType;
 
+  /// Whether the image can be retried with the original URL.
+  final bool canRetry;
+
+  /// Callback to retry loading the image with the original URL.
+  final VoidCallback? onRetry;
+
+  /// Callback when the image loads successfully.
+  final VoidCallback? onLoaded;
+
+  /// Callback when the image fails to load.
+  final VoidCallback? onError;
+
   const _ImageContent({
+    super.key,
     required this.url,
     required this.width,
     required this.height,
@@ -104,6 +190,10 @@ class _ImageContent extends StatelessWidget {
     required this.viewed,
     required this.blur,
     required this.mediaType,
+    this.canRetry = false,
+    this.onRetry,
+    this.onLoaded,
+    this.onError,
   });
 
   @override
@@ -121,7 +211,31 @@ class _ImageContent extends StatelessWidget {
       memCacheWidth: width != null ? (width! * devicePixelRatio).toInt() : null,
       memCacheHeight: height != null ? (height! * devicePixelRatio).toInt() : null,
       placeholder: (context, url) => const SizedBox.shrink(),
-      errorWidget: (context, url, error) => ImagePreviewError(mediaType: mediaType, blur: blur == true, viewed: viewed == true),
+      imageBuilder: (context, imageProvider) {
+        // Notify that the image loaded successfully
+        WidgetsBinding.instance.addPostFrameCallback((_) => onLoaded?.call());
+
+        return Image(
+          image: imageProvider,
+          height: height,
+          width: width,
+          fit: fit,
+          color: viewed == true ? const Color.fromRGBO(255, 255, 255, 0.55) : null,
+          colorBlendMode: viewed == true ? BlendMode.modulate : null,
+        );
+      },
+      errorWidget: (context, url, error) {
+        // Notify that the image failed to load
+        WidgetsBinding.instance.addPostFrameCallback((_) => onError?.call());
+
+        return ImagePreviewError(
+          mediaType: mediaType,
+          blur: blur == true,
+          viewed: viewed == true,
+          canRetry: canRetry,
+          onRetry: onRetry,
+        );
+      },
     );
 
     if (blur == true) return _BlurredImage(child: image);
@@ -157,7 +271,20 @@ class ImagePreviewError extends StatelessWidget {
   /// Whether the image has been viewed. This will affect the opacity of the image.
   final bool viewed;
 
-  const ImagePreviewError({super.key, this.mediaType, this.blur = false, this.viewed = false});
+  /// Whether the image can be retried with the original URL.
+  final bool canRetry;
+
+  /// Callback to retry loading the image with the original URL.
+  final VoidCallback? onRetry;
+
+  const ImagePreviewError({
+    super.key,
+    this.mediaType,
+    this.blur = false,
+    this.viewed = false,
+    this.canRetry = false,
+    this.onRetry,
+  });
 
   /// Returns the icon to display when the image fails to load.
   static IconData _getErrorIcon(MediaType? mediaType) {
@@ -178,16 +305,31 @@ class ImagePreviewError extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
+    final l10n = GlobalContext.l10n;
 
     // Don't display the associated icon if blur is enabled, otherwise there will be two icons displayed at once.
     if (blur) return const SizedBox.shrink();
 
+    final iconColor = theme.colorScheme.onSecondaryContainer.withValues(alpha: viewed ? 0.55 : 1.0);
+
+    // If we can retry with the original URL, make the entire area tappable
+    if (canRetry && onRetry != null) {
+      return GestureDetector(
+        onTap: onRetry,
+        behavior: HitTestBehavior.opaque,
+        child: Center(
+          child: Tooltip(
+            message: l10n.retry,
+            child: Icon(Icons.refresh_rounded, color: iconColor),
+          ),
+        ),
+      );
+    }
+
     return Center(
       child: Icon(
         _getErrorIcon(mediaType),
-        color: theme.colorScheme.onSecondaryContainer.withValues(
-          alpha: viewed ? 0.55 : 1.0,
-        ),
+        color: iconColor,
       ),
     );
   }

--- a/lib/src/shared/images/image_viewer.dart
+++ b/lib/src/shared/images/image_viewer.dart
@@ -6,7 +6,6 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 
-import 'package:expandable/expandable.dart';
 import 'package:extended_image/extended_image.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:gal/gal.dart';

--- a/lib/src/shared/utils/media/image.dart
+++ b/lib/src/shared/utils/media/image.dart
@@ -13,25 +13,49 @@ import 'package:image_picker/image_picker.dart';
 import 'package:thunder/src/core/cache/image_dimension_cache.dart';
 import 'package:thunder/src/shared/images/image_viewer.dart';
 
-/// Given a URL, returns the proxied URL if it is a proxy URL. Otherwise, returns the original URL.
+/// Given a URL, returns the original URL if it is a proxy URL. Otherwise, returns the original URL unchanged.
 ///
-/// This is useful for handling thumbnail URLs that are proxied via /image_proxy.
+/// This is useful for handling thumbnail URLs that are proxied via Lemmy's /image_proxy endpoint.
+/// When image proxying is enabled on an instance, thumbnail URLs may be in the format: `https://instance.com/api/v3/image_proxy?url=<encoded_original_url>`
+///
+/// This function extracts and returns the original URL so that images can be loaded directly, which helps when the proxy endpoint fails.
+/// It handles nested proxy URLs by recursively unwrapping until the original non-proxy URL is found.
 String fetchProxyImageUrl(String url) {
-  Uri uri;
+  String currentUrl = url;
 
+  // Keep unwrapping proxy URLs until we reach the original
+  while (true) {
+    Uri uri;
+
+    try {
+      uri = Uri.parse(currentUrl);
+    } catch (e) {
+      return currentUrl; // Return the current URL if parsing fails
+    }
+
+    // Handle image proxy URLs
+    if (isImageProxyUrl(currentUrl)) {
+      Uri? parsedUri = Uri.tryParse(uri.queryParameters['url'] ?? '');
+
+      if (parsedUri != null) {
+        currentUrl = parsedUri.toString();
+        continue; // Check if this URL is also a proxy
+      }
+    }
+
+    // No more proxy found, return the current URL
+    return currentUrl;
+  }
+}
+
+/// Checks if the given URL is an image proxy URL (contains /image_proxy endpoint)
+bool isImageProxyUrl(String url) {
   try {
-    uri = Uri.parse(url);
+    final uri = Uri.parse(url);
+    return uri.path.contains('/image_proxy') && uri.queryParameters.containsKey('url');
   } catch (e) {
-    return url; // Return the original URL if parsing fails
+    return false;
   }
-
-  // Handle thumbnail urls that are proxied via /image_proxy
-  if (uri.path == '/api/v3/image_proxy') {
-    Uri? parsedUri = Uri.tryParse(uri.queryParameters['url'] ?? '');
-    if (parsedUri != null) return parsedUri.toString();
-  }
-
-  return url;
 }
 
 /// Determines if the given URL is an image URL
@@ -40,10 +64,11 @@ bool isImageUrl(String url) {
   // e.g., https://cdn.bsky.app/img/feed_fullsize/plain/did:plc:wf7nfy2us3h5gpa7zfettmzl/bafkreib6k2uwcy52wi654fdfmfqakzqu54m4eq7vi6cwrolwud6yhehihy@jpeg?.jpg
   final imageExtensions = ['.png', '.jpg', '.jpeg', '.gif', '.bmp', '.webp', '.avif', '@jpeg'];
 
-  // If image proxying is enabled, we need to determine the original URL to see if that's an image
-  url = fetchProxyImageUrl(url);
+  // If it's an image proxy URL, it's an image URL. Otherwise, check the file extension of the URL.
+  if (isImageProxyUrl(url)) return true;
 
   Uri uri;
+
   try {
     uri = Uri.parse(url);
   } catch (e) {

--- a/lib/src/shared/widgets/media/media_view.dart
+++ b/lib/src/shared/widgets/media/media_view.dart
@@ -82,6 +82,9 @@ class _MediaViewState extends State<MediaView> with TickerProviderStateMixin {
   // An animation controller to animate the image overlay
   late final AnimationController _overlayAnimationController;
 
+  // The current state of the image preview
+  ImagePreviewState _imagePreviewState = ImagePreviewState.loading;
+
   @override
   void initState() {
     super.initState();
@@ -92,6 +95,10 @@ class _MediaViewState extends State<MediaView> with TickerProviderStateMixin {
   void dispose() {
     _overlayAnimationController.dispose();
     super.dispose();
+  }
+
+  void _onImagePreviewStateChanged(ImagePreviewState state) {
+    if (mounted) setState(() => _imagePreviewState = state);
   }
 
   /// Overlays the image as an ImageViewer
@@ -239,8 +246,8 @@ class _MediaViewState extends State<MediaView> with TickerProviderStateMixin {
       );
     }
 
-    // For images, add hold to peek gesture
-    if (widget.media.mediaType == MediaType.image) {
+    // For images, add hold to peek gesture (only when image is loaded successfully)
+    if (widget.media.mediaType == MediaType.image && _imagePreviewState == ImagePreviewState.success) {
       child = InkWell(
         splashColor: theme.colorScheme.primary.withValues(alpha: 0.4),
         borderRadius: BorderRadius.circular((widget.edgeToEdgeImages ? 0 : 12)),
@@ -348,6 +355,8 @@ class _MediaViewState extends State<MediaView> with TickerProviderStateMixin {
                 mediaType: widget.media.mediaType,
                 viewed: widget.read,
                 blur: blurNSFWPreviews,
+                allowRetry: widget.media.mediaType == MediaType.image,
+                onStateChanged: _onImagePreviewStateChanged,
               ),
               if (blurNSFWPreviews)
                 Column(


### PR DESCRIPTION
## Pull Request Description

This PR improves the current image proxy logic:
- Handles nested proxy image URLs (e.g., instance A has image proxy enabled and serves an image from instance B with image proxy enabled)
- Added ability to load image from original URL if the proxied image fails to load. This only applies to image posts.

<!--- Please describe what was changed -->

## Issue Being Fixed

<!-- Please describe the problem that is being fixed and, if applicable, reference a GitHub issue -->

Issue Number: #1904, workaround for some images in #2001

## Screenshots / Recordings

<!-- This section is optional but highly recommended to show off your changes! -->

## Checklist

- [ ] If a new package was added, did you ensure it uses an appropriate license and is actively maintained?
- [ ] Did you use localized strings (and added appropriate descriptions) where applicable?
- [ ] Did you add `semanticLabel`s where applicable for accessibility?
