### PR TITLE
Move back to page-based pagination for Lemmy feeds

### DIFF
--- a/lib/src/core/network/lemmy_api.dart
+++ b/lib/src/core/network/lemmy_api.dart
@@ -205,6 +205,7 @@ class LemmyApi {
 
   /// Fetches a list of posts from the Lemmy API
   Future<Map<String, dynamic>> getPosts({
+    int? page,
     String? cursor,
     int? limit,
     FeedListType? feedListType,
@@ -214,16 +215,18 @@ class LemmyApi {
     bool? showHidden,
     bool? showSaved,
   }) async {
-    final queryParams = {
+    Map<String, dynamic> queryParams = {
       'type_': feedListType?.value,
       'sort': postSortType?.value,
       'page_cursor': cursor,
+      'page': page,
       'limit': limit,
       'community_name': communityName,
       'community_id': communityId,
-      'saved_only': showSaved,
-      'show_hidden': showHidden,
     };
+
+    if (showSaved == true) queryParams['saved_only'] = showSaved;
+    if (showHidden == true) queryParams['show_hidden'] = showHidden;
 
     final json = await _request(HttpMethod.get, '/api/v3/post/list', queryParams);
     return {

--- a/lib/src/features/feed/presentation/bloc/feed_bloc.dart
+++ b/lib/src/features/feed/presentation/bloc/feed_bloc.dart
@@ -4,6 +4,7 @@ import 'package:bloc/bloc.dart';
 import 'package:bloc_concurrency/bloc_concurrency.dart';
 import 'package:equatable/equatable.dart';
 import 'package:stream_transform/stream_transform.dart';
+import 'package:thunder/src/core/network/lemmy_api.dart';
 
 import 'package:thunder/src/features/account/account.dart';
 import 'package:thunder/src/features/comment/comment.dart';
@@ -655,7 +656,7 @@ class FeedBloc extends Bloc<FeedEvent, FeedState> {
       ));
     } catch (e) {
       debugPrint('Error fetching feed: $e');
-      return emit(state.copyWith(status: FeedStatus.failure, message: e.toString()));
+      return emit(state.copyWith(status: FeedStatus.failure, message: e is LemmyApiException ? e.message : e.toString()));
     }
   }
 

--- a/lib/src/features/post/data/repositories/post_repository.dart
+++ b/lib/src/features/post/data/repositories/post_repository.dart
@@ -166,8 +166,13 @@ class PostRepositoryImpl implements PostRepository {
   }) async {
     switch (account.platform) {
       case ThreadiversePlatform.lemmy:
-        return await lemmy.getPosts(
-          cursor: cursor,
+        // Use page-based pagination for Lemmy for 0.19.x instances as there are some performance issues with cursor-based pagination.
+        // See https://github.com/LemmyNet/lemmy/issues/6171, https://lemmy.world/post/40266465/21176898
+        // TODO: Once 1.x.x is released, we can switch back to cursor-based pagination.
+        final page = cursor != null ? int.tryParse(cursor) ?? 1 : 1;
+
+        final response = await lemmy.getPosts(
+          page: page,
           limit: limit,
           postSortType: postSortType,
           feedListType: feedListType,
@@ -176,6 +181,13 @@ class PostRepositoryImpl implements PostRepository {
           showHidden: showHidden,
           showSaved: showSaved,
         );
+
+        // Return next page as string cursor for Lemmy
+        final nextPage = response['posts'].isNotEmpty ? (page + 1).toString() : null;
+        return {
+          'posts': response['posts'],
+          'next_page': nextPage,
+        };
       case ThreadiversePlatform.piefed:
         // PieFed uses integer page-based pagination. The cursor in this case is the page number.
         final page = cursor != null ? int.tryParse(cursor) ?? 1 : 1;


### PR DESCRIPTION
## Pull Request Description

This PR reverts back the change made in #1997 and brings back page-based pagination for Lemmy. It turns out that cursor-based pagination causes some issues in certain scenarios which lead to slow/incomplete requests when fetching the All/Local feeds.

For now, we'll keep page-based pagination and only switch over to cursor-based pagination once Lemmy v1.x is stable.

<!--- Please describe what was changed -->

## Issue Being Fixed

<!-- Please describe the problem that is being fixed and, if applicable, reference a GitHub issue -->

Issue Number: https://lemmy.world/post/40266465/21176898

## Screenshots / Recordings

<!-- This section is optional but highly recommended to show off your changes! -->

## Checklist

- [ ] If a new package was added, did you ensure it uses an appropriate license and is actively maintained?
- [ ] Did you use localized strings (and added appropriate descriptions) where applicable?
- [ ] Did you add `semanticLabel`s where applicable for accessibility?
