### PR TITLE
Add ability to customize hold-to-peek image duration

### DIFF
--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -1381,6 +1381,14 @@
   "@imageDimensionTimeout": {
     "description": "Setting for how long to wait for the image dimensions to be fetched"
   },
+  "imagePeekDuration": "Image Peek Duration",
+  "@imagePeekDuration": {
+    "description": "Setting for image peek duration"
+  },
+  "imagePeekDurationDescription": "Duration of long press before image peek is triggered",
+  "@imagePeekDurationDescription": {
+    "description": "Description for image peek duration setting"
+  },
   "importDatabase": "Import Database",
   "@importDatabase": {
     "description": "Name of setting for importing the db"
@@ -1692,6 +1700,10 @@
   "me": "Me",
   "@me": {
     "description": "Label for the current user."
+  },
+  "media": "Media",
+  "@media": {
+    "description": "Describes a piece of media content (e.g., image, video)"
   },
   "medium": "Medium",
   "@medium": {

--- a/lib/l10n/generated/app_localizations.dart
+++ b/lib/l10n/generated/app_localizations.dart
@@ -2188,6 +2188,18 @@ abstract class AppLocalizations {
   /// **'Image Dimension Timeout'**
   String get imageDimensionTimeout;
 
+  /// Setting for image peek duration
+  ///
+  /// In en, this message translates to:
+  /// **'Image Peek Duration'**
+  String get imagePeekDuration;
+
+  /// Description for image peek duration setting
+  ///
+  /// In en, this message translates to:
+  /// **'Duration of long press before image peek is triggered'**
+  String get imagePeekDurationDescription;
+
   /// Name of setting for importing the db
   ///
   /// In en, this message translates to:
@@ -2637,6 +2649,12 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'Me'**
   String get me;
+
+  /// Describes a piece of media content (e.g., image, video)
+  ///
+  /// In en, this message translates to:
+  /// **'Media'**
+  String get media;
 
   /// Description for medium font scale
   ///

--- a/lib/l10n/generated/app_localizations_ar.dart
+++ b/lib/l10n/generated/app_localizations_ar.dart
@@ -1161,6 +1161,13 @@ class AppLocalizationsAr extends AppLocalizations {
   String get imageDimensionTimeout => 'Image Dimension Timeout';
 
   @override
+  String get imagePeekDuration => 'Image Peek Duration';
+
+  @override
+  String get imagePeekDurationDescription =>
+      'Duration of long press before image peek is triggered';
+
+  @override
   String get importDatabase => 'Import Database';
 
   @override
@@ -1425,6 +1432,9 @@ class AppLocalizationsAr extends AppLocalizations {
 
   @override
   String get me => 'Me';
+
+  @override
+  String get media => 'Media';
 
   @override
   String get medium => 'Medium';

--- a/lib/l10n/generated/app_localizations_be.dart
+++ b/lib/l10n/generated/app_localizations_be.dart
@@ -1169,6 +1169,13 @@ class AppLocalizationsBe extends AppLocalizations {
   String get imageDimensionTimeout => 'Image Dimension Timeout';
 
   @override
+  String get imagePeekDuration => 'Image Peek Duration';
+
+  @override
+  String get imagePeekDurationDescription =>
+      'Duration of long press before image peek is triggered';
+
+  @override
   String get importDatabase => 'Import Database';
 
   @override
@@ -1433,6 +1440,9 @@ class AppLocalizationsBe extends AppLocalizations {
 
   @override
   String get me => 'Me';
+
+  @override
+  String get media => 'Media';
 
   @override
   String get medium => 'Medium';

--- a/lib/l10n/generated/app_localizations_cs.dart
+++ b/lib/l10n/generated/app_localizations_cs.dart
@@ -1177,6 +1177,13 @@ class AppLocalizationsCs extends AppLocalizations {
   String get imageDimensionTimeout => 'Image Dimension Timeout';
 
   @override
+  String get imagePeekDuration => 'Image Peek Duration';
+
+  @override
+  String get imagePeekDurationDescription =>
+      'Duration of long press before image peek is triggered';
+
+  @override
   String get importDatabase => 'Import Database';
 
   @override
@@ -1436,6 +1443,9 @@ class AppLocalizationsCs extends AppLocalizations {
 
   @override
   String get me => 'Me';
+
+  @override
+  String get media => 'Media';
 
   @override
   String get medium => 'Střední';

--- a/lib/l10n/generated/app_localizations_de.dart
+++ b/lib/l10n/generated/app_localizations_de.dart
@@ -1186,6 +1186,13 @@ class AppLocalizationsDe extends AppLocalizations {
   String get imageDimensionTimeout => 'Zeitüberschreitung Bild Abmessungen';
 
   @override
+  String get imagePeekDuration => 'Image Peek Duration';
+
+  @override
+  String get imagePeekDurationDescription =>
+      'Duration of long press before image peek is triggered';
+
+  @override
   String get importDatabase => 'Datenbank importieren';
 
   @override
@@ -1454,6 +1461,9 @@ class AppLocalizationsDe extends AppLocalizations {
 
   @override
   String get me => 'Ich';
+
+  @override
+  String get media => 'Media';
 
   @override
   String get medium => 'Mittel';

--- a/lib/l10n/generated/app_localizations_en.dart
+++ b/lib/l10n/generated/app_localizations_en.dart
@@ -1169,6 +1169,13 @@ class AppLocalizationsEn extends AppLocalizations {
   String get imageDimensionTimeout => 'Image Dimension Timeout';
 
   @override
+  String get imagePeekDuration => 'Image Peek Duration';
+
+  @override
+  String get imagePeekDurationDescription =>
+      'Duration of long press before image peek is triggered';
+
+  @override
   String get importDatabase => 'Import Database';
 
   @override
@@ -1433,6 +1440,9 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get me => 'Me';
+
+  @override
+  String get media => 'Media';
 
   @override
   String get medium => 'Medium';

--- a/lib/l10n/generated/app_localizations_eo.dart
+++ b/lib/l10n/generated/app_localizations_eo.dart
@@ -1166,6 +1166,13 @@ class AppLocalizationsEo extends AppLocalizations {
   String get imageDimensionTimeout => 'Image Dimension Timeout';
 
   @override
+  String get imagePeekDuration => 'Image Peek Duration';
+
+  @override
+  String get imagePeekDurationDescription =>
+      'Duration of long press before image peek is triggered';
+
+  @override
   String get importDatabase => 'Import Database';
 
   @override
@@ -1423,6 +1430,9 @@ class AppLocalizationsEo extends AppLocalizations {
 
   @override
   String get me => 'Me';
+
+  @override
+  String get media => 'Media';
 
   @override
   String get medium => 'Medium';

--- a/lib/l10n/generated/app_localizations_es.dart
+++ b/lib/l10n/generated/app_localizations_es.dart
@@ -1194,6 +1194,13 @@ class AppLocalizationsEs extends AppLocalizations {
   String get imageDimensionTimeout => 'Tiempo de Espera de Dimensión de Imagen';
 
   @override
+  String get imagePeekDuration => 'Image Peek Duration';
+
+  @override
+  String get imagePeekDurationDescription =>
+      'Duration of long press before image peek is triggered';
+
+  @override
   String get importDatabase => 'Importar Base de Datos';
 
   @override
@@ -1461,6 +1468,9 @@ class AppLocalizationsEs extends AppLocalizations {
 
   @override
   String get me => 'Yo';
+
+  @override
+  String get media => 'Media';
 
   @override
   String get medium => 'Medio';

--- a/lib/l10n/generated/app_localizations_fi.dart
+++ b/lib/l10n/generated/app_localizations_fi.dart
@@ -1166,6 +1166,13 @@ class AppLocalizationsFi extends AppLocalizations {
   String get imageDimensionTimeout => 'Image Dimension Timeout';
 
   @override
+  String get imagePeekDuration => 'Image Peek Duration';
+
+  @override
+  String get imagePeekDurationDescription =>
+      'Duration of long press before image peek is triggered';
+
+  @override
   String get importDatabase => 'Import Database';
 
   @override
@@ -1423,6 +1430,9 @@ class AppLocalizationsFi extends AppLocalizations {
 
   @override
   String get me => 'Me';
+
+  @override
+  String get media => 'Media';
 
   @override
   String get medium => 'Medium';

--- a/lib/l10n/generated/app_localizations_fr.dart
+++ b/lib/l10n/generated/app_localizations_fr.dart
@@ -1196,6 +1196,13 @@ class AppLocalizationsFr extends AppLocalizations {
   String get imageDimensionTimeout => 'Image Dimension Timeout';
 
   @override
+  String get imagePeekDuration => 'Image Peek Duration';
+
+  @override
+  String get imagePeekDurationDescription =>
+      'Duration of long press before image peek is triggered';
+
+  @override
   String get importDatabase => 'Import Database';
 
   @override
@@ -1455,6 +1462,9 @@ class AppLocalizationsFr extends AppLocalizations {
 
   @override
   String get me => 'Me';
+
+  @override
+  String get media => 'Media';
 
   @override
   String get medium => 'Medium';

--- a/lib/l10n/generated/app_localizations_hu.dart
+++ b/lib/l10n/generated/app_localizations_hu.dart
@@ -1169,6 +1169,13 @@ class AppLocalizationsHu extends AppLocalizations {
   String get imageDimensionTimeout => 'Image Dimension Timeout';
 
   @override
+  String get imagePeekDuration => 'Image Peek Duration';
+
+  @override
+  String get imagePeekDurationDescription =>
+      'Duration of long press before image peek is triggered';
+
+  @override
   String get importDatabase => 'Import Database';
 
   @override
@@ -1433,6 +1440,9 @@ class AppLocalizationsHu extends AppLocalizations {
 
   @override
   String get me => 'Me';
+
+  @override
+  String get media => 'Media';
 
   @override
   String get medium => 'Medium';

--- a/lib/l10n/generated/app_localizations_it.dart
+++ b/lib/l10n/generated/app_localizations_it.dart
@@ -1175,6 +1175,13 @@ class AppLocalizationsIt extends AppLocalizations {
   String get imageDimensionTimeout => 'Timeout Dimensione Immagine';
 
   @override
+  String get imagePeekDuration => 'Image Peek Duration';
+
+  @override
+  String get imagePeekDurationDescription =>
+      'Duration of long press before image peek is triggered';
+
+  @override
   String get importDatabase => 'Importa Database';
 
   @override
@@ -1433,6 +1440,9 @@ class AppLocalizationsIt extends AppLocalizations {
 
   @override
   String get me => 'Io';
+
+  @override
+  String get media => 'Media';
 
   @override
   String get medium => 'Medio';

--- a/lib/l10n/generated/app_localizations_nb.dart
+++ b/lib/l10n/generated/app_localizations_nb.dart
@@ -1164,6 +1164,13 @@ class AppLocalizationsNb extends AppLocalizations {
   String get imageDimensionTimeout => 'Image Dimension Timeout';
 
   @override
+  String get imagePeekDuration => 'Image Peek Duration';
+
+  @override
+  String get imagePeekDurationDescription =>
+      'Duration of long press before image peek is triggered';
+
+  @override
   String get importDatabase => 'Import Database';
 
   @override
@@ -1414,6 +1421,9 @@ class AppLocalizationsNb extends AppLocalizations {
 
   @override
   String get me => 'Me';
+
+  @override
+  String get media => 'Media';
 
   @override
   String get medium => 'Medium';

--- a/lib/l10n/generated/app_localizations_nl.dart
+++ b/lib/l10n/generated/app_localizations_nl.dart
@@ -1180,6 +1180,13 @@ class AppLocalizationsNl extends AppLocalizations {
   String get imageDimensionTimeout => 'Time-out voor afbeeldings­afmetingen';
 
   @override
+  String get imagePeekDuration => 'Image Peek Duration';
+
+  @override
+  String get imagePeekDurationDescription =>
+      'Duration of long press before image peek is triggered';
+
+  @override
   String get importDatabase => 'Database importeren';
 
   @override
@@ -1445,6 +1452,9 @@ class AppLocalizationsNl extends AppLocalizations {
 
   @override
   String get me => 'Ik';
+
+  @override
+  String get media => 'Media';
 
   @override
   String get medium => 'Gemiddeld';

--- a/lib/l10n/generated/app_localizations_pl.dart
+++ b/lib/l10n/generated/app_localizations_pl.dart
@@ -1180,6 +1180,13 @@ class AppLocalizationsPl extends AppLocalizations {
   String get imageDimensionTimeout => 'Image Dimension Timeout';
 
   @override
+  String get imagePeekDuration => 'Image Peek Duration';
+
+  @override
+  String get imagePeekDurationDescription =>
+      'Duration of long press before image peek is triggered';
+
+  @override
   String get importDatabase => 'Import Database';
 
   @override
@@ -1438,6 +1445,9 @@ class AppLocalizationsPl extends AppLocalizations {
 
   @override
   String get me => 'Me';
+
+  @override
+  String get media => 'Media';
 
   @override
   String get medium => 'Średnie';

--- a/lib/l10n/generated/app_localizations_pt.dart
+++ b/lib/l10n/generated/app_localizations_pt.dart
@@ -1178,6 +1178,13 @@ class AppLocalizationsPt extends AppLocalizations {
   String get imageDimensionTimeout => 'Image Dimension Timeout';
 
   @override
+  String get imagePeekDuration => 'Image Peek Duration';
+
+  @override
+  String get imagePeekDurationDescription =>
+      'Duration of long press before image peek is triggered';
+
+  @override
   String get importDatabase => 'Importar base de dados';
 
   @override
@@ -1442,6 +1449,9 @@ class AppLocalizationsPt extends AppLocalizations {
 
   @override
   String get me => 'Me';
+
+  @override
+  String get media => 'Media';
 
   @override
   String get medium => 'Medium';

--- a/lib/l10n/generated/app_localizations_ru.dart
+++ b/lib/l10n/generated/app_localizations_ru.dart
@@ -1180,6 +1180,13 @@ class AppLocalizationsRu extends AppLocalizations {
   String get imageDimensionTimeout => 'Image Dimension Timeout';
 
   @override
+  String get imagePeekDuration => 'Image Peek Duration';
+
+  @override
+  String get imagePeekDurationDescription =>
+      'Duration of long press before image peek is triggered';
+
+  @override
   String get importDatabase => 'Import Database';
 
   @override
@@ -1437,6 +1444,9 @@ class AppLocalizationsRu extends AppLocalizations {
 
   @override
   String get me => 'Я';
+
+  @override
+  String get media => 'Media';
 
   @override
   String get medium => 'Средний';

--- a/lib/l10n/generated/app_localizations_sk.dart
+++ b/lib/l10n/generated/app_localizations_sk.dart
@@ -1177,6 +1177,13 @@ class AppLocalizationsSk extends AppLocalizations {
   String get imageDimensionTimeout => 'Image Dimension Timeout';
 
   @override
+  String get imagePeekDuration => 'Image Peek Duration';
+
+  @override
+  String get imagePeekDurationDescription =>
+      'Duration of long press before image peek is triggered';
+
+  @override
   String get importDatabase => 'Import Database';
 
   @override
@@ -1444,6 +1451,9 @@ class AppLocalizationsSk extends AppLocalizations {
 
   @override
   String get me => 'Me';
+
+  @override
+  String get media => 'Media';
 
   @override
   String get medium => 'Medium';

--- a/lib/l10n/generated/app_localizations_sv.dart
+++ b/lib/l10n/generated/app_localizations_sv.dart
@@ -1163,6 +1163,13 @@ class AppLocalizationsSv extends AppLocalizations {
   String get imageDimensionTimeout => 'Image Dimension Timeout';
 
   @override
+  String get imagePeekDuration => 'Image Peek Duration';
+
+  @override
+  String get imagePeekDurationDescription =>
+      'Duration of long press before image peek is triggered';
+
+  @override
   String get importDatabase => 'Import Database';
 
   @override
@@ -1420,6 +1427,9 @@ class AppLocalizationsSv extends AppLocalizations {
 
   @override
   String get me => 'Me';
+
+  @override
+  String get media => 'Media';
 
   @override
   String get medium => 'Medium';

--- a/lib/l10n/generated/app_localizations_ta.dart
+++ b/lib/l10n/generated/app_localizations_ta.dart
@@ -1185,6 +1185,13 @@ class AppLocalizationsTa extends AppLocalizations {
   String get imageDimensionTimeout => 'பட பரிமாண நேரம் முடிந்தது';
 
   @override
+  String get imagePeekDuration => 'Image Peek Duration';
+
+  @override
+  String get imagePeekDurationDescription =>
+      'Duration of long press before image peek is triggered';
+
+  @override
   String get importDatabase => 'தரவுத்தளத்தை இறக்குமதி செய்யுங்கள்';
 
   @override
@@ -1454,6 +1461,9 @@ class AppLocalizationsTa extends AppLocalizations {
 
   @override
   String get me => 'நான்';
+
+  @override
+  String get media => 'Media';
 
   @override
   String get medium => 'சராசரி';

--- a/lib/l10n/generated/app_localizations_tr.dart
+++ b/lib/l10n/generated/app_localizations_tr.dart
@@ -1177,6 +1177,13 @@ class AppLocalizationsTr extends AppLocalizations {
   String get imageDimensionTimeout => 'Resim Boyutu Zaman Aşımı';
 
   @override
+  String get imagePeekDuration => 'Image Peek Duration';
+
+  @override
+  String get imagePeekDurationDescription =>
+      'Duration of long press before image peek is triggered';
+
+  @override
   String get importDatabase => 'Veritabanını İçe Aktar';
 
   @override
@@ -1441,6 +1448,9 @@ class AppLocalizationsTr extends AppLocalizations {
 
   @override
   String get me => 'Ben';
+
+  @override
+  String get media => 'Media';
 
   @override
   String get medium => 'Orta';

--- a/lib/l10n/generated/app_localizations_uk.dart
+++ b/lib/l10n/generated/app_localizations_uk.dart
@@ -1171,6 +1171,13 @@ class AppLocalizationsUk extends AppLocalizations {
   String get imageDimensionTimeout => 'Image Dimension Timeout';
 
   @override
+  String get imagePeekDuration => 'Image Peek Duration';
+
+  @override
+  String get imagePeekDurationDescription =>
+      'Duration of long press before image peek is triggered';
+
+  @override
   String get importDatabase => 'Import Database';
 
   @override
@@ -1428,6 +1435,9 @@ class AppLocalizationsUk extends AppLocalizations {
 
   @override
   String get me => 'Me';
+
+  @override
+  String get media => 'Media';
 
   @override
   String get medium => 'Medium';

--- a/lib/l10n/generated/app_localizations_zh.dart
+++ b/lib/l10n/generated/app_localizations_zh.dart
@@ -1169,6 +1169,13 @@ class AppLocalizationsZh extends AppLocalizations {
   String get imageDimensionTimeout => 'Image Dimension Timeout';
 
   @override
+  String get imagePeekDuration => 'Image Peek Duration';
+
+  @override
+  String get imagePeekDurationDescription =>
+      'Duration of long press before image peek is triggered';
+
+  @override
   String get importDatabase => 'Import Database';
 
   @override
@@ -1433,6 +1440,9 @@ class AppLocalizationsZh extends AppLocalizations {
 
   @override
   String get me => 'Me';
+
+  @override
+  String get media => 'Media';
 
   @override
   String get medium => 'Medium';

--- a/lib/src/app/bloc/thunder_bloc.dart
+++ b/lib/src/app/bloc/thunder_bloc.dart
@@ -233,7 +233,7 @@ class ThunderBloc extends Bloc<ThunderEvent, ThunderState> {
       bool enableFullScreenSwipeNavigationGesture = UserPreferences.getLocalSetting(LocalSettings.enableFullScreenSwipeNavigationGesture) ?? true;
 
       // Image Peek Settings
-      int imagePeekDuration = UserPreferences.getLocalSetting(LocalSettings.imagePeekDuration) ?? 500;
+      int imagePeekDuration = UserPreferences.getLocalSetting(LocalSettings.imagePeekDuration) ?? 300;
 
       /// -------------------------- FAB Related Settings --------------------------
       bool enableFeedsFab = UserPreferences.getLocalSetting(LocalSettings.enableFeedsFab) ?? true;

--- a/lib/src/app/bloc/thunder_bloc.dart
+++ b/lib/src/app/bloc/thunder_bloc.dart
@@ -232,6 +232,9 @@ class ThunderBloc extends Bloc<ThunderEvent, ThunderState> {
 
       bool enableFullScreenSwipeNavigationGesture = UserPreferences.getLocalSetting(LocalSettings.enableFullScreenSwipeNavigationGesture) ?? true;
 
+      // Image Peek Settings
+      int imagePeekDuration = UserPreferences.getLocalSetting(LocalSettings.imagePeekDuration) ?? 500;
+
       /// -------------------------- FAB Related Settings --------------------------
       bool enableFeedsFab = UserPreferences.getLocalSetting(LocalSettings.enableFeedsFab) ?? true;
       bool enablePostsFab = UserPreferences.getLocalSetting(LocalSettings.enablePostsFab) ?? true;
@@ -400,6 +403,9 @@ class ThunderBloc extends Bloc<ThunderEvent, ThunderState> {
         rightSecondaryCommentGesture: rightSecondaryCommentGesture,
 
         enableFullScreenSwipeNavigationGesture: enableFullScreenSwipeNavigationGesture,
+
+        // Image Peek Settings
+        imagePeekDuration: imagePeekDuration,
 
         /// -------------------------- FAB Related Settings --------------------------
         enablePostsFab: enablePostsFab,

--- a/lib/src/app/bloc/thunder_state.dart
+++ b/lib/src/app/bloc/thunder_state.dart
@@ -119,6 +119,9 @@ class ThunderState extends Equatable {
     this.rightSecondaryCommentGesture = SwipeAction.save,
     this.enableFullScreenSwipeNavigationGesture = true,
 
+    // Image Peek Settings
+    this.imagePeekDuration = 500,
+
     // Theme Settings
     this.themeType = ThemeType.system,
     this.selectedTheme = CustomThemeType.deepBlue,
@@ -316,6 +319,10 @@ class ThunderState extends Equatable {
 
   final bool enableFullScreenSwipeNavigationGesture;
 
+  // Image Peek Settings
+  /// Duration in milliseconds before image peek is triggered (default: 500ms)
+  final int imagePeekDuration;
+
   /// -------------------------- FAB Related Settings --------------------------
   final bool enableFeedsFab;
   final bool enablePostsFab;
@@ -498,6 +505,9 @@ class ThunderState extends Equatable {
     SwipeAction? rightSecondaryCommentGesture,
     bool? enableFullScreenSwipeNavigationGesture,
 
+    // Image Peek Settings
+    int? imagePeekDuration,
+
     /// -------------------------- FAB Related Settings --------------------------
     bool? enableFeedsFab,
     bool? enablePostsFab,
@@ -668,6 +678,9 @@ class ThunderState extends Equatable {
       rightSecondaryPostGesture: rightSecondaryPostGesture ?? this.rightSecondaryPostGesture,
 
       enableFullScreenSwipeNavigationGesture: enableFullScreenSwipeNavigationGesture ?? this.enableFullScreenSwipeNavigationGesture,
+
+      // Image Peek Settings
+      imagePeekDuration: imagePeekDuration ?? this.imagePeekDuration,
 
       // Comment Gestures
       enableCommentGestures: enableCommentGestures ?? this.enableCommentGestures,
@@ -858,6 +871,9 @@ class ThunderState extends Equatable {
         rightSecondaryCommentGesture,
 
         enableFullScreenSwipeNavigationGesture,
+
+        // Image Peek Settings
+        imagePeekDuration,
 
         /// -------------------------- FAB Related Settings --------------------------
         enableFeedsFab,

--- a/lib/src/app/bloc/thunder_state.dart
+++ b/lib/src/app/bloc/thunder_state.dart
@@ -120,7 +120,7 @@ class ThunderState extends Equatable {
     this.enableFullScreenSwipeNavigationGesture = true,
 
     // Image Peek Settings
-    this.imagePeekDuration = 500,
+    this.imagePeekDuration = 300,
 
     // Theme Settings
     this.themeType = ThemeType.system,
@@ -320,7 +320,7 @@ class ThunderState extends Equatable {
   final bool enableFullScreenSwipeNavigationGesture;
 
   // Image Peek Settings
-  /// Duration in milliseconds before image peek is triggered (default: 500ms)
+  /// Duration in milliseconds before image peek is triggered (default: 300ms)
   final int imagePeekDuration;
 
   /// -------------------------- FAB Related Settings --------------------------

--- a/lib/src/core/enums/local_settings.dart
+++ b/lib/src/core/enums/local_settings.dart
@@ -357,6 +357,9 @@ enum LocalSettings {
   enableFullScreenSwipeNavigationGesture(
       name: 'setting_gesture_enable_fullscreen_navigation_gesture', key: 'fullscreenSwipeGestures', category: LocalSettingsCategories.gestures, subCategory: LocalSettingsSubCategories.navigation),
 
+  // Image Peek Settings
+  imagePeekDuration(name: 'setting_gesture_image_peek_duration', key: 'imagePeekDuration', category: LocalSettingsCategories.gestures, subCategory: LocalSettingsSubCategories.posts),
+
   /// -------------------------- FAB Related Settings --------------------------
   enableFeedsFab(name: 'setting_enable_feed_fab', key: 'enableFloatingButtonOnFeeds', category: LocalSettingsCategories.floatingActionButton, subCategory: LocalSettingsSubCategories.feed),
   enablePostsFab(name: 'setting_enable_post_fab', key: 'enableFloatingButtonOnPosts', category: LocalSettingsCategories.floatingActionButton, subCategory: LocalSettingsSubCategories.feed),
@@ -577,6 +580,7 @@ extension LocalizationExt on AppLocalizations {
       'rightLongSwipe': rightLongSwipe,
       'commentSwipeActions': commentSwipeActions,
       'fullscreenSwipeGestures': fullscreenSwipeGestures,
+      'imagePeekDuration': imagePeekDuration,
       'enableFloatingButtonOnFeeds': enableFloatingButtonOnFeeds,
       'enableFloatingButtonOnPosts': enableFloatingButtonOnPosts,
       'backToTop': backToTop,

--- a/lib/src/features/settings/presentation/pages/gesture_settings_page.dart
+++ b/lib/src/features/settings/presentation/pages/gesture_settings_page.dart
@@ -45,6 +45,9 @@ class _GestureSettingsPageState extends State<GestureSettingsPage> with TickerPr
 
   bool enableFullScreenSwipeNavigationGesture = true;
 
+  // Image Peek Settings
+  int imagePeekDuration = 500;
+
   /// Loading
   bool isLoading = true;
 
@@ -131,6 +134,10 @@ class _GestureSettingsPageState extends State<GestureSettingsPage> with TickerPr
         await prefs.setBool(LocalSettings.enableFullScreenSwipeNavigationGesture.name, value);
         setState(() => enableFullScreenSwipeNavigationGesture = value);
         break;
+      case LocalSettings.imagePeekDuration:
+        await prefs.setInt(LocalSettings.imagePeekDuration.name, value);
+        setState(() => imagePeekDuration = value);
+        break;
       default:
         break;
     }
@@ -164,6 +171,9 @@ class _GestureSettingsPageState extends State<GestureSettingsPage> with TickerPr
       rightSecondaryCommentGesture = SwipeAction.values.byName(prefs.getString(LocalSettings.commentGestureRightSecondary.name) ?? SwipeAction.save.name);
 
       enableFullScreenSwipeNavigationGesture = prefs.getBool(LocalSettings.enableFullScreenSwipeNavigationGesture.name) ?? true;
+
+      // Image Peek Settings
+      imagePeekDuration = prefs.getInt(LocalSettings.imagePeekDuration.name) ?? 500;
 
       isLoading = false;
     });
@@ -233,7 +243,7 @@ class _GestureSettingsPageState extends State<GestureSettingsPage> with TickerPr
                       padding: const EdgeInsets.only(left: 16.0, bottom: 8.0),
                       child: Text(
                         l10n.navigation,
-                        style: theme.textTheme.titleLarge,
+                        style: theme.textTheme.titleMedium,
                       ),
                     ),
                     ToggleOption(
@@ -260,7 +270,7 @@ class _GestureSettingsPageState extends State<GestureSettingsPage> with TickerPr
                       padding: const EdgeInsets.only(left: 16.0, bottom: 8.0),
                       child: Text(
                         l10n.sidebar,
-                        style: theme.textTheme.titleLarge,
+                        style: theme.textTheme.titleMedium,
                       ),
                     ),
                     ToggleOption(
@@ -297,8 +307,41 @@ class _GestureSettingsPageState extends State<GestureSettingsPage> with TickerPr
                     Padding(
                       padding: const EdgeInsets.only(left: 16.0, bottom: 8.0),
                       child: Text(
+                        l10n.media,
+                        style: theme.textTheme.titleMedium,
+                      ),
+                    ),
+                    ListOption(
+                      description: l10n.imagePeekDuration,
+                      subtitle: l10n.imagePeekDurationDescription,
+                      value: ListPickerItem(label: '${imagePeekDuration}ms', icon: Icons.touch_app_rounded, payload: imagePeekDuration),
+                      options: [
+                        ListPickerItem(icon: Icons.touch_app_rounded, label: '100ms', payload: 100),
+                        ListPickerItem(icon: Icons.touch_app_rounded, label: '200ms', payload: 200),
+                        ListPickerItem(icon: Icons.touch_app_rounded, label: '300ms', payload: 300),
+                        ListPickerItem(icon: Icons.touch_app_rounded, label: '400ms', payload: 400),
+                        ListPickerItem(icon: Icons.touch_app_rounded, label: '500ms', payload: 500),
+                      ],
+                      icon: Icons.touch_app_rounded,
+                      onChanged: (value) async => setPreferences(LocalSettings.imagePeekDuration, value.payload),
+                      highlightKey: settingToHighlightKey,
+                      setting: LocalSettings.imagePeekDuration,
+                      highlightedSetting: settingToHighlight,
+                    ),
+                  ],
+                ),
+              ),
+              Container(
+                padding: const EdgeInsets.fromLTRB(0.0, 8.0, 0.0, 8.0),
+                child: Column(
+                  mainAxisAlignment: MainAxisAlignment.start,
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Padding(
+                      padding: const EdgeInsets.only(left: 16.0, bottom: 8.0),
+                      child: Text(
                         l10n.posts,
-                        style: theme.textTheme.titleLarge,
+                        style: theme.textTheme.titleMedium,
                       ),
                     ),
                     Padding(
@@ -405,7 +448,7 @@ class _GestureSettingsPageState extends State<GestureSettingsPage> with TickerPr
                       padding: const EdgeInsets.only(left: 16.0, bottom: 8.0),
                       child: Text(
                         l10n.comments,
-                        style: theme.textTheme.titleLarge,
+                        style: theme.textTheme.titleMedium,
                       ),
                     ),
                     Padding(

--- a/lib/src/features/settings/presentation/pages/gesture_settings_page.dart
+++ b/lib/src/features/settings/presentation/pages/gesture_settings_page.dart
@@ -46,7 +46,7 @@ class _GestureSettingsPageState extends State<GestureSettingsPage> with TickerPr
   bool enableFullScreenSwipeNavigationGesture = true;
 
   // Image Peek Settings
-  int imagePeekDuration = 500;
+  int imagePeekDuration = 300;
 
   /// Loading
   bool isLoading = true;
@@ -173,7 +173,7 @@ class _GestureSettingsPageState extends State<GestureSettingsPage> with TickerPr
       enableFullScreenSwipeNavigationGesture = prefs.getBool(LocalSettings.enableFullScreenSwipeNavigationGesture.name) ?? true;
 
       // Image Peek Settings
-      imagePeekDuration = prefs.getInt(LocalSettings.imagePeekDuration.name) ?? 500;
+      imagePeekDuration = prefs.getInt(LocalSettings.imagePeekDuration.name) ?? 300;
 
       isLoading = false;
     });

--- a/lib/src/shared/widgets/media/media_view.dart
+++ b/lib/src/shared/widgets/media/media_view.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter/gestures.dart';
 
 import 'package:flutter_bloc/flutter_bloc.dart';
 
@@ -198,6 +199,7 @@ class _MediaViewState extends State<MediaView> with TickerProviderStateMixin {
     final l10n = AppLocalizations.of(context)!;
     final state = context.read<ThunderBloc>().state;
 
+    final imagePeekDurationMs = context.select((ThunderBloc bloc) => bloc.state.imagePeekDuration);
     final blurNSFWPreviews = widget.hideNsfwPreviews && widget.media.nsfw;
 
     double? width;
@@ -248,6 +250,8 @@ class _MediaViewState extends State<MediaView> with TickerProviderStateMixin {
 
     // For images, add hold to peek gesture (only when image is loaded successfully)
     if (widget.media.mediaType == MediaType.image && _imagePreviewState == ImagePreviewState.success) {
+      final imagePeekDuration = Duration(milliseconds: imagePeekDurationMs);
+
       child = InkWell(
         splashColor: theme.colorScheme.primary.withValues(alpha: 0.4),
         borderRadius: BorderRadius.circular((widget.edgeToEdgeImages ? 0 : 12)),
@@ -255,28 +259,36 @@ class _MediaViewState extends State<MediaView> with TickerProviderStateMixin {
           handleTap();
           showImage();
         },
-        child: GestureDetector(
-          onLongPressStart: (_) {
-            _overlayEntry = OverlayEntry(
-              builder: (context) {
-                return FadeTransition(
-                  opacity: _overlayAnimationController,
-                  child: ImageViewer(
-                    url: widget.media.thumbnailUrl ?? widget.media.mediaUrl,
-                    postId: widget.postId,
-                    navigateToPost: widget.navigateToPost,
-                    isPeek: true,
-                  ),
-                );
+        child: RawGestureDetector(
+          gestures: <Type, GestureRecognizerFactory>{
+            LongPressGestureRecognizer: GestureRecognizerFactoryWithHandlers<LongPressGestureRecognizer>(
+              () => LongPressGestureRecognizer(duration: imagePeekDuration),
+              (LongPressGestureRecognizer instance) {
+                instance
+                  ..onLongPressStart = (_) {
+                    _overlayEntry = OverlayEntry(
+                      builder: (context) {
+                        return FadeTransition(
+                          opacity: _overlayAnimationController,
+                          child: ImageViewer(
+                            url: widget.media.thumbnailUrl ?? widget.media.mediaUrl,
+                            postId: widget.postId,
+                            navigateToPost: widget.navigateToPost,
+                            isPeek: true,
+                          ),
+                        );
+                      },
+                    );
+                    Overlay.of(context).insert(_overlayEntry!);
+                    _overlayAnimationController.forward();
+                  }
+                  ..onLongPressEnd = (_) async {
+                    await _overlayAnimationController.reverse();
+                    _overlayEntry?.remove();
+                    _overlayEntry = null;
+                  };
               },
-            );
-            Overlay.of(context).insert(_overlayEntry!);
-            _overlayAnimationController.forward();
-          },
-          onLongPressEnd: (_) async {
-            await _overlayAnimationController.reverse();
-            _overlayEntry?.remove();
-            _overlayEntry = null;
+            ),
           },
         ),
       );


### PR DESCRIPTION
## Pull Request Description

This PR adds a new setting which allows configuring the hold-to-peek duration for images, and reduces the default duration to 300ms.

<!--- Please describe what was changed -->

## Issue Being Fixed

<!-- Please describe the problem that is being fixed and, if applicable, reference a GitHub issue -->

Issue Number: #1699

## Screenshots / Recordings

<!-- This section is optional but highly recommended to show off your changes! -->

## Checklist

- [ ] If a new package was added, did you ensure it uses an appropriate license and is actively maintained?
- [ ] Did you use localized strings (and added appropriate descriptions) where applicable?
- [ ] Did you add `semanticLabel`s where applicable for accessibility?
