### PR TITLE
Fix 16KB page size requirement

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1463,46 +1463,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.28.0"
-  screen_retriever:
-    dependency: transitive
-    description:
-      name: screen_retriever
-      sha256: "570dbc8e4f70bac451e0efc9c9bb19fa2d6799a11e6ef04f946d7886d2e23d0c"
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.2.0"
-  screen_retriever_linux:
-    dependency: transitive
-    description:
-      name: screen_retriever_linux
-      sha256: f7f8120c92ef0784e58491ab664d01efda79a922b025ff286e29aa123ea3dd18
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.2.0"
-  screen_retriever_macos:
-    dependency: transitive
-    description:
-      name: screen_retriever_macos
-      sha256: "71f956e65c97315dd661d71f828708bd97b6d358e776f1a30d5aa7d22d78a149"
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.2.0"
-  screen_retriever_platform_interface:
-    dependency: transitive
-    description:
-      name: screen_retriever_platform_interface
-      sha256: ee197f4581ff0d5608587819af40490748e1e39e648d7680ecf95c05197240c0
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.2.0"
-  screen_retriever_windows:
-    dependency: transitive
-    description:
-      name: screen_retriever_windows
-      sha256: "449ee257f03ca98a57288ee526a301a430a344a161f9202b4fcc38576716fe13"
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.2.0"
   screenshot:
     dependency: "direct main"
     description:
@@ -1792,42 +1752,26 @@ packages:
     dependency: "direct main"
     description:
       name: unifiedpush
-      sha256: "8ed9767f750a1dc6159a77e2171641d0cb825dc87682d1ce1b8618689b79f58e"
+      sha256: b52a0eff848d0446b9d521e0ad2f7bc76c4dda88d0f6ac0a79f1765ccfe37939
       url: "https://pub.dev"
     source: hosted
-    version: "6.2.0"
+    version: "6.1.0"
   unifiedpush_android:
     dependency: transitive
     description:
       name: unifiedpush_android
-      sha256: "2e6684e0a1a39ad8d6c7bc0d197954d50686acb1b1a7614b18ab0e0126f5492a"
+      sha256: "2af6a09a5fb9fdd97b61e704a587e88abcdb5f7ee2aea9a2c35e80159f9d586d"
       url: "https://pub.dev"
     source: hosted
-    version: "3.4.1"
-  unifiedpush_linux:
-    dependency: transitive
-    description:
-      name: unifiedpush_linux
-      sha256: c062d5eedd1cec70bcd33270cc4e01ae0ff6501f33d471167c06b34a968adfeb
-      url: "https://pub.dev"
-    source: hosted
-    version: "1.0.0"
+    version: "3.3.1"
   unifiedpush_platform_interface:
     dependency: transitive
     description:
       name: unifiedpush_platform_interface
-      sha256: "83372bc8d794b8b12ef6993b518d7be907dcfc2191bdf6de0ece5c4445d89880"
+      sha256: "5aa3eefc2699e4d8db6d723f0cfdfb56ac850487549a0b3b83574f4a89f33aab"
       url: "https://pub.dev"
     source: hosted
-    version: "4.0.0"
-  unifiedpush_storage_interface:
-    dependency: transitive
-    description:
-      name: unifiedpush_storage_interface
-      sha256: b8d423a4695efc616aa21d8ab48fb5ef99d6288c68b56282b8faac1579ceabd9
-      url: "https://pub.dev"
-    source: hosted
-    version: "1.0.0"
+    version: "3.1.0"
   universal_html:
     dependency: transitive
     description:
@@ -2020,22 +1964,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.0.3"
-  webcrypto:
-    dependency: transitive
-    description:
-      name: webcrypto
-      sha256: "6b43001c4110856ff7fa5e5e65e7b2d44bec1d8b54a4d84d5fa2c7622267c5c1"
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.6.0"
-  webpush_encryption:
-    dependency: transitive
-    description:
-      name: webpush_encryption
-      sha256: "5b83272b91acda6ae515fcd980c94f06bf413702282497c5a68f5dfc64fed27f"
-      url: "https://pub.dev"
-    source: hosted
-    version: "1.0.1"
   webview_flutter:
     dependency: "direct main"
     description:
@@ -2076,14 +2004,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "5.15.0"
-  window_manager:
-    dependency: transitive
-    description:
-      name: window_manager
-      sha256: "7eb6d6c4164ec08e1bf978d6e733f3cebe792e2a23fb07cbca25c2872bfdbdcd"
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.5.1"
   xdg_directories:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -69,7 +69,7 @@ dependencies:
   smooth_highlight: ^0.1.1
   stream_transform: ^2.1.0
   super_sliver_list: ^0.4.1
-  unifiedpush: ^6.0.2
+  unifiedpush: 6.1.0
   url_launcher: ^6.1.11
   # There is an intentional space between the packge name and colon below. Do not remove!
   version : ^3.0.2


### PR DESCRIPTION
## Pull Request Description

This PR fixes an issue where some libraries were not 16KB page size aligned. This issue comes from a transitive dependency on `unified_push` with version 6.2.0. `webcrypto.dart` package. For now, I've pinned the unified_push version to 6.1.0 which doesn't have the same issue.

<!--- Please describe what was changed -->

## Issue Being Fixed

<!-- Please describe the problem that is being fixed and, if applicable, reference a GitHub issue -->

Issue Number: N/A

## Screenshots / Recordings

<!-- This section is optional but highly recommended to show off your changes! -->

## Checklist

- [ ] If a new package was added, did you ensure it uses an appropriate license and is actively maintained?
- [ ] Did you use localized strings (and added appropriate descriptions) where applicable?
- [ ] Did you add `semanticLabel`s where applicable for accessibility?
