### PR TITLE
Fix duplicated posts displaying at the end of the feed

### DIFF
--- a/lib/src/features/feed/presentation/bloc/feed_bloc.dart
+++ b/lib/src/features/feed/presentation/bloc/feed_bloc.dart
@@ -575,7 +575,8 @@ class FeedBloc extends Bloc<FeedEvent, FeedState> {
       }
 
       // If the feed is already being fetched but it is not a reset, then just wait
-      if (state.status == FeedStatus.fetching) return;
+      // If the cursor is null, then we are at the end of the feed so we don't need to fetch any more
+      if (state.status == FeedStatus.fetching || state.cursor == null) return;
 
       // Handle fetching the next page of the feed
       emit(state.copyWith(status: FeedStatus.fetching));


### PR DESCRIPTION
## Pull Request Description

This PR fixes an issue where the end of the feed is duplicated. See https://lemmy.world/post/41170684 for more details.

<!--- Please describe what was changed -->

## Issue Being Fixed

<!-- Please describe the problem that is being fixed and, if applicable, reference a GitHub issue -->

Issue Number: https://lemmy.world/post/41170684

## Screenshots / Recordings

<!-- This section is optional but highly recommended to show off your changes! -->

## Checklist

- [ ] If a new package was added, did you ensure it uses an appropriate license and is actively maintained?
- [ ] Did you use localized strings (and added appropriate descriptions) where applicable?
- [ ] Did you add `semanticLabel`s where applicable for accessibility?
