### PR TITLE
Fix Thunder import settings not applying in certain scenarios

### DIFF
--- a/lib/src/core/singletons/preferences.dart
+++ b/lib/src/core/singletons/preferences.dart
@@ -86,7 +86,7 @@ class UserPreferences {
         final prefs = instance.preferences;
 
         data.forEach((key, value) {
-          _setValue(prefs, key, value);
+          setValue(prefs, key, value);
         });
 
         return true;
@@ -100,7 +100,7 @@ class UserPreferences {
   }
 
   /// Helper method to set a value in SharedPreferences based on its type
-  static void _setValue(SharedPreferences prefs, String key, dynamic value) {
+  static void setValue(SharedPreferences prefs, String key, dynamic value) {
     if (value is int) {
       prefs.setInt(key, value);
     } else if (value is double) {
@@ -109,8 +109,8 @@ class UserPreferences {
       prefs.setBool(key, value);
     } else if (value is String) {
       prefs.setString(key, value);
-    } else if (value is List<String>) {
-      prefs.setStringList(key, value);
+    } else if (value is List) {
+      prefs.setStringList(key, value.map((e) => e.toString()).toList());
     }
   }
 


### PR DESCRIPTION
## Pull Request Description

This PR fixes an issue where importing Thunder settings would not be applied correctly for some settings. This mainly includes settings that are saved as lists (e.g., filters, post metadata order, etc.)

<!--- Please describe what was changed -->

## Issue Being Fixed

<!-- Please describe the problem that is being fixed and, if applicable, reference a GitHub issue -->

Issue Number: #2030

## Screenshots / Recordings

<!-- This section is optional but highly recommended to show off your changes! -->

## Checklist

- [ ] If a new package was added, did you ensure it uses an appropriate license and is actively maintained?
- [ ] Did you use localized strings (and added appropriate descriptions) where applicable?
- [ ] Did you add `semanticLabel`s where applicable for accessibility?
