### PR TITLE
Adjust image cropping for full height images

### DIFF
--- a/lib/packages/ui/src/widgets/media/media_view.dart
+++ b/lib/packages/ui/src/widgets/media/media_view.dart
@@ -261,6 +261,12 @@ class _MediaViewState extends State<MediaView> with TickerProviderStateMixin {
         height = (widget.showFullHeightImages && !widget.allowUnconstrainedImageHeight) ? widget.media.height : null;
     }
 
+    final shouldContainTallFullHeightImage = widget.media.mediaType == ContentMediaType.image &&
+        widget.viewMode == ContentViewMode.comfortable &&
+        widget.showFullHeightImages &&
+        widget.media.height != null &&
+        widget.media.height! > getMaxHeight();
+
     Widget? child;
 
     if (widget.media.mediaType == ContentMediaType.link) {
@@ -410,7 +416,11 @@ class _MediaViewState extends State<MediaView> with TickerProviderStateMixin {
                 contentType: widget.media.contentType,
                 width: width,
                 height: height,
-                fit: widget.viewMode == ContentViewMode.compact ? BoxFit.cover : BoxFit.fitWidth,
+                fit: widget.viewMode == ContentViewMode.compact
+                    ? BoxFit.cover
+                    : shouldContainTallFullHeightImage
+                        ? BoxFit.contain
+                        : BoxFit.fitWidth,
                 mediaType: widget.media.mediaType,
                 viewed: widget.read,
                 blur: blurNSFWPreviews,


### PR DESCRIPTION
## Pull Request Description

This PR adjusts the cropping on full-height images to be fully contained when the image exceeds the device height.

<!--- Please describe what was changed -->

## Issue Being Fixed

<!-- Please describe the problem that is being fixed and, if applicable, reference a GitHub issue -->

Issue Number: #2048

## Screenshots / Recordings

<!-- This section is optional but highly recommended to show off your changes! -->

## Checklist

- [ ] If a new package was added, did you ensure it uses an appropriate license and is actively maintained?
- [ ] Did you use localized strings (and added appropriate descriptions) where applicable?
- [ ] Did you add `semanticLabel`s where applicable for accessibility?
