### PR TITLE
Fix search reset not applying in some cases

### DIFF
--- a/lib/src/features/search/presentation/pages/search_page.dart
+++ b/lib/src/features/search/presentation/pages/search_page.dart
@@ -92,15 +92,23 @@ class _SearchPageState extends State<SearchPage> with AutomaticKeepAliveClientMi
     if (scrollController.position.pixels >= scrollController.position.maxScrollExtent * 0.8) {
       final bloc = context.read<SearchBloc>();
       final favorites = context.read<ProfileBloc>().state.favorites;
+      final query = controller.text;
+
+      if (query.isEmpty && !bloc.state.viewingAll) return;
 
       if (bloc.state.status != SearchStatus.done) {
-        bloc.add(SearchContinued(query: controller.text, favoriteCommunities: favorites));
+        bloc.add(SearchContinued(query: query, favoriteCommunities: favorites));
       }
     }
   }
 
   void onSearchFieldChanged(String value) {
     final bloc = context.read<SearchBloc>();
+
+    if (value.isEmpty) {
+      bloc.add(const SearchReset());
+      return;
+    }
 
     // Auto-detect URL mode for post searches
     if (bloc.state.searchType == MetaSearchType.posts && Uri.tryParse(value)?.isAbsolute == true) {

--- a/lib/src/features/search/presentation/state/search_bloc.dart
+++ b/lib/src/features/search/presentation/state/search_bloc.dart
@@ -99,7 +99,20 @@ class SearchBloc extends Bloc<SearchEvent, SearchState> {
   }
 
   Future<void> _onSearchReset(SearchReset event, Emitter<SearchState> emit) async {
-    emit(state.copyWith(status: SearchStatus.initial, trendingCommunities: [], viewingAll: false));
+    emit(state.copyWith(
+      status: SearchStatus.initial,
+      communities: null,
+      trendingCommunities: const <ThunderCommunity>[],
+      users: null,
+      comments: null,
+      posts: null,
+      instances: null,
+      message: null,
+      errorReason: null,
+      page: 1,
+      hasReachedMax: false,
+      viewingAll: false,
+    ));
     await _onTrendingCommunitiesRequested(const TrendingCommunitiesRequested(), emit);
   }
 
@@ -218,6 +231,8 @@ class SearchBloc extends Bloc<SearchEvent, SearchState> {
   }
 
   Future<void> _onSearchContinued(SearchContinued event, Emitter<SearchState> emit) async {
+    if (event.query.isEmpty && !state.viewingAll) return;
+
     // Early exit if pagination is exhausted
     if (state.hasReachedMax) return;
 
@@ -334,7 +349,7 @@ class SearchBloc extends Bloc<SearchEvent, SearchState> {
       final message = getExceptionErrorMessage(e);
       return emit(state.copyWith(
         status: SearchStatus.trending,
-        trendingCommunities: [],
+        trendingCommunities: const <ThunderCommunity>[],
         message: message,
         errorReason: AppErrorReason.unexpected(
           message: message,


### PR DESCRIPTION
## Pull Request Description

This PR fixes an issue where clearing the search input would not reset the search state.

<!--- Please describe what was changed -->

## Issue Being Fixed

<!-- Please describe the problem that is being fixed and, if applicable, reference a GitHub issue -->

Issue Number: N/A

## Screenshots / Recordings

<!-- This section is optional but highly recommended to show off your changes! -->

## Checklist

- [ ] If a new package was added, did you ensure it uses an appropriate license and is actively maintained?
- [ ] Did you use localized strings (and added appropriate descriptions) where applicable?
- [ ] Did you add `semanticLabel`s where applicable for accessibility?
