### PR TITLE
Remove archive.today alternative source

### DIFF
--- a/lib/src/app/shell/navigation/link_navigation_utils.dart
+++ b/lib/src/app/shell/navigation/link_navigation_utils.dart
@@ -341,7 +341,6 @@ List<({String sourceName, String link})> generateAlternateSources(String link) {
 }
 
 List<({String sourceName, MessageFormat template})> _alternateSources = [
-  (sourceName: 'Archive Today', template: MessageFormat('https://archive.today/{link}')),
   (sourceName: 'Internet Archive', template: MessageFormat('https://web.archive.org/save/{link}')),
   (sourceName: 'Ground News', template: MessageFormat('https://ground.news/find?url={link}')),
 ];


### PR DESCRIPTION
## Pull Request Description

This PR removes archive.today as an alternative source after the recent controversy surrounding it.

<!--- Please describe what was changed -->

## Issue Being Fixed

<!-- Please describe the problem that is being fixed and, if applicable, reference a GitHub issue -->

Issue Number: https://lemmy.world/post/43495098

## Screenshots / Recordings

<!-- This section is optional but highly recommended to show off your changes! -->

## Checklist

- [ ] If a new package was added, did you ensure it uses an appropriate license and is actively maintained?
- [ ] Did you use localized strings (and added appropriate descriptions) where applicable?
- [ ] Did you add `semanticLabel`s where applicable for accessibility?
