### PR TITLE
Improve link bottom sheet preview logic

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -13,8 +13,6 @@ PODS:
   - flutter_inappwebview_ios/Core (0.0.1):
     - Flutter
     - OrderedSet (~> 6.0.3)
-  - flutter_keyboard_visibility (0.0.1):
-    - Flutter
   - flutter_sharing_intent (1.0.1):
     - Flutter
   - OrderedSet (6.0.3)
@@ -27,7 +25,6 @@ DEPENDENCIES:
   - flutter_file_dialog (from `.symlinks/plugins/flutter_file_dialog/ios`)
   - flutter_icmp_ping (from `.symlinks/plugins/flutter_icmp_ping/ios`)
   - flutter_inappwebview_ios (from `.symlinks/plugins/flutter_inappwebview_ios/ios`)
-  - flutter_keyboard_visibility (from `.symlinks/plugins/flutter_keyboard_visibility/ios`)
   - flutter_sharing_intent (from `.symlinks/plugins/flutter_sharing_intent/ios`)
   - permission_handler_apple (from `.symlinks/plugins/permission_handler_apple/ios`)
 
@@ -46,8 +43,6 @@ EXTERNAL SOURCES:
     :path: ".symlinks/plugins/flutter_icmp_ping/ios"
   flutter_inappwebview_ios:
     :path: ".symlinks/plugins/flutter_inappwebview_ios/ios"
-  flutter_keyboard_visibility:
-    :path: ".symlinks/plugins/flutter_keyboard_visibility/ios"
   flutter_sharing_intent:
     :path: ".symlinks/plugins/flutter_sharing_intent/ios"
   permission_handler_apple:
@@ -59,7 +54,6 @@ SPEC CHECKSUMS:
   flutter_file_dialog: ca8d7fbd1772d4f0c2777b4ab20a7787ef4e7dd8
   flutter_icmp_ping: 47c1df3440c18ddd39fc457e607bb3b42d4a339f
   flutter_inappwebview_ios: b89ba3482b96fb25e00c967aae065701b66e9b99
-  flutter_keyboard_visibility: 4625131e43015dbbe759d9b20daaf77e0e3f6619
   flutter_sharing_intent: 0c1e53949f09fa8df8ac2268505687bde8ff264c
   OrderedSet: e539b66b644ff081c73a262d24ad552a69be3a94
   permission_handler_apple: 4ed2196e43d0651e8ff7ca3483a069d469701f2d

--- a/lib/src/features/comment/presentation/pages/create_comment_page.dart
+++ b/lib/src/features/comment/presentation/pages/create_comment_page.dart
@@ -6,7 +6,7 @@ import 'package:flutter/material.dart';
 
 // Package imports
 import 'package:flutter_bloc/flutter_bloc.dart';
-import 'package:flutter_keyboard_visibility/flutter_keyboard_visibility.dart';
+import 'package:keyboard_detection/keyboard_detection.dart';
 import 'package:markdown_editor/markdown_editor.dart';
 
 // Project imports
@@ -87,8 +87,8 @@ class _CreateCommentPageState extends State<CreateCommentPage> with WidgetsBindi
   /// The focus node for the body. This is used to keep track of the position of the cursor when toggling preview
   final FocusNode _bodyFocusNode = FocusNode();
 
-  /// The keyboard visibility controller used to determine if the keyboard is visible at a given time
-  final keyboardVisibilityController = KeyboardVisibilityController();
+  /// Tracks keyboard visibility during preview toggles.
+  final KeyboardDetectionController _keyboardDetectionController = KeyboardDetectionController();
 
   /// Whether to view source for posts or comments
   bool viewSource = false;
@@ -287,274 +287,277 @@ class _CreateCommentPageState extends State<CreateCommentPage> with WidgetsBindi
                 onTap: () {
                   FocusManager.instance.primaryFocus?.unfocus();
                 },
-                child: Scaffold(
-                  resizeToAvoidBottomInset: false,
-                  appBar: AppBar(
-                    title: Text(widget.comment != null ? l10n.editComment : l10n.createComment),
-                    toolbarHeight: APP_BAR_HEIGHT,
-                    centerTitle: false,
-                  ),
-                  body: SafeArea(
-                    bottom: false,
-                    child: Column(
-                      crossAxisAlignment: CrossAxisAlignment.start,
-                      children: <Widget>[
-                        Expanded(
-                          child: SingleChildScrollView(
-                            child: Column(
-                              crossAxisAlignment: CrossAxisAlignment.start,
-                              children: <Widget>[
-                                if (post != null)
-                                  Padding(
-                                    padding: const EdgeInsets.only(left: 8.0, right: 8.0, bottom: 16.0),
-                                    child: Container(
-                                      padding: const EdgeInsets.only(top: 6.0, bottom: 12.0),
-                                      decoration: BoxDecoration(
-                                        color: getBackgroundColor(context),
-                                        borderRadius: const BorderRadius.all(Radius.circular(8.0)),
-                                      ),
-                                      child: PostBody(
-                                        post: post!,
-                                        crossPosts: const [],
-                                        viewSource: viewSource,
-                                        onViewSourceToggled: () => setState(() => viewSource = !viewSource),
-                                        showQuickPostActionBar: false,
-                                        selectable: true,
-                                        showReplyEditorButtons: true,
-                                        onSelectionChanged: (selection) => replyViewSelection = selection,
-                                      ),
-                                    ),
-                                  ),
-                                if (parentComment != null) ...[
-                                  Padding(
-                                    padding: const EdgeInsets.only(left: 8.0, right: 8.0, bottom: 16.0),
-                                    child: Container(
-                                      decoration: BoxDecoration(
-                                        color: getBackgroundColor(context),
-                                        borderRadius: const BorderRadius.all(Radius.circular(8.0)),
-                                      ),
-                                      child: CommentContent(
-                                        account: account,
-                                        comment: parentComment!,
-                                        hidden: false,
-                                        viewSource: viewSource,
-                                        onViewSourceToggled: () => setState(() => viewSource = !viewSource),
-                                        selectable: true,
-                                        showReplyEditorButtons: true,
-                                        onSelectionChanged: (selection) => replyViewSelection = selection,
+                child: KeyboardDetection(
+                  controller: _keyboardDetectionController,
+                  child: Scaffold(
+                    resizeToAvoidBottomInset: false,
+                    appBar: AppBar(
+                      title: Text(widget.comment != null ? l10n.editComment : l10n.createComment),
+                      toolbarHeight: APP_BAR_HEIGHT,
+                      centerTitle: false,
+                    ),
+                    body: SafeArea(
+                      bottom: false,
+                      child: Column(
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        children: <Widget>[
+                          Expanded(
+                            child: SingleChildScrollView(
+                              child: Column(
+                                crossAxisAlignment: CrossAxisAlignment.start,
+                                children: <Widget>[
+                                  if (post != null)
+                                    Padding(
+                                      padding: const EdgeInsets.only(left: 8.0, right: 8.0, bottom: 16.0),
+                                      child: Container(
+                                        padding: const EdgeInsets.only(top: 6.0, bottom: 12.0),
+                                        decoration: BoxDecoration(
+                                          color: getBackgroundColor(context),
+                                          borderRadius: const BorderRadius.all(Radius.circular(8.0)),
+                                        ),
+                                        child: PostBody(
+                                          post: post!,
+                                          crossPosts: const [],
+                                          viewSource: viewSource,
+                                          onViewSourceToggled: () => setState(() => viewSource = !viewSource),
+                                          showQuickPostActionBar: false,
+                                          selectable: true,
+                                          showReplyEditorButtons: true,
+                                          onSelectionChanged: (selection) => replyViewSelection = selection,
+                                        ),
                                       ),
                                     ),
+                                  if (parentComment != null) ...[
+                                    Padding(
+                                      padding: const EdgeInsets.only(left: 8.0, right: 8.0, bottom: 16.0),
+                                      child: Container(
+                                        decoration: BoxDecoration(
+                                          color: getBackgroundColor(context),
+                                          borderRadius: const BorderRadius.all(Radius.circular(8.0)),
+                                        ),
+                                        child: CommentContent(
+                                          account: account,
+                                          comment: parentComment!,
+                                          hidden: false,
+                                          viewSource: viewSource,
+                                          onViewSourceToggled: () => setState(() => viewSource = !viewSource),
+                                          selectable: true,
+                                          showReplyEditorButtons: true,
+                                          onSelectionChanged: (selection) => replyViewSelection = selection,
+                                        ),
+                                      ),
+                                    ),
+                                  ],
+                                  Column(
+                                    crossAxisAlignment: CrossAxisAlignment.start,
+                                    children: [
+                                      Padding(
+                                        padding: const EdgeInsets.only(left: 16.0),
+                                        child: UserSelector(
+                                          account: account,
+                                          postActorId: post?.apId,
+                                          onPostChanged: (ThunderPost post) {
+                                            setState(() {
+                                              this.post = post;
+                                              postId = post.id;
+                                            });
+                                            _onDraftInputChanged();
+                                          },
+                                          parentCommentActorId: parentComment?.apId,
+                                          onParentCommentChanged: (ThunderComment parentComment) {
+                                            setState(() {
+                                              this.parentComment = parentComment;
+                                              postId = parentComment.postId;
+                                              parentCommentId = parentComment.id;
+                                            });
+                                            _onDraftInputChanged();
+                                          },
+                                          onUserChanged: (account) {
+                                            setState(() {
+                                              userChanged = featureAccountState.effectiveAccount.id != account.id;
+                                            });
+
+                                            context.read<FeatureAccountCubit>().setOverride(account);
+                                            _onDraftInputChanged();
+                                          },
+                                          enableAccountSwitching: widget.comment == null,
+                                        ),
+                                      ),
+                                      const SizedBox(height: 10),
+                                      Padding(
+                                        padding: const EdgeInsets.symmetric(horizontal: 16.0),
+                                        child: LanguageSelector(
+                                          account: account,
+                                          languageId: languageId,
+                                          onLanguageSelected: (ThunderLanguage? language) {
+                                            setState(() => languageId = language?.id);
+                                            _onDraftInputChanged();
+                                          },
+                                        ),
+                                      ),
+                                      const SizedBox(height: 10),
+                                      AnimatedCrossFade(
+                                        firstChild: Padding(
+                                          padding: const EdgeInsets.all(8.0),
+                                          child: Container(
+                                            width: double.infinity,
+                                            padding: const EdgeInsets.all(8.0),
+                                            decoration: BoxDecoration(
+                                              color: getBackgroundColor(context),
+                                              borderRadius: const BorderRadius.all(Radius.circular(8.0)),
+                                            ),
+                                            child: CommonMarkdownBody(body: _bodyTextController.text, isComment: true),
+                                          ),
+                                        ),
+                                        secondChild: Padding(
+                                          padding: const EdgeInsets.symmetric(horizontal: 16.0),
+                                          child: MarkdownTextInputField(
+                                            controller: _bodyTextController,
+                                            focusNode: _bodyFocusNode,
+                                            label: l10n.comment,
+                                            minLines: 8,
+                                            maxLines: null,
+                                            textStyle: theme.textTheme.bodyLarge,
+                                            spellCheckConfiguration: const SpellCheckConfiguration.disabled(),
+                                          ),
+                                        ),
+                                        crossFadeState: showPreview ? CrossFadeState.showFirst : CrossFadeState.showSecond,
+                                        duration: const Duration(milliseconds: 120),
+                                        excludeBottomFocus: false,
+                                      )
+                                    ],
                                   ),
                                 ],
-                                Column(
-                                  crossAxisAlignment: CrossAxisAlignment.start,
-                                  children: [
-                                    Padding(
-                                      padding: const EdgeInsets.only(left: 16.0),
-                                      child: UserSelector(
-                                        account: account,
-                                        postActorId: post?.apId,
-                                        onPostChanged: (ThunderPost post) {
-                                          setState(() {
-                                            this.post = post;
-                                            postId = post.id;
-                                          });
-                                          _onDraftInputChanged();
+                              ),
+                            ),
+                          ),
+                          const Divider(height: 1),
+                          Container(
+                            color: theme.cardColor,
+                            margin: EdgeInsets.only(bottom: MediaQuery.of(context).viewInsets.bottom),
+                            child: Row(
+                              children: [
+                                Expanded(
+                                  child: IgnorePointer(
+                                    ignoring: showPreview,
+                                    child: MarkdownToolbar(
+                                      controller: _bodyTextController,
+                                      focusNode: _bodyFocusNode,
+                                      actions: const [
+                                        MarkdownType.image,
+                                        MarkdownType.link,
+                                        MarkdownType.bold,
+                                        MarkdownType.italic,
+                                        MarkdownType.blockquote,
+                                        MarkdownType.strikethrough,
+                                        MarkdownType.title,
+                                        MarkdownType.list,
+                                        MarkdownType.separator,
+                                        MarkdownType.code,
+                                        MarkdownType.spoiler,
+                                        MarkdownType.username,
+                                        MarkdownType.community,
+                                      ],
+                                      customTapActions: {
+                                        MarkdownType.username: () {
+                                          showUserInputDialog(
+                                            context,
+                                            title: l10n.username,
+                                            account: account,
+                                            onUserSelected: (ThunderUser user) {
+                                              _bodyTextController.text = _bodyTextController.text.replaceRange(
+                                                _bodyTextController.selection.end,
+                                                _bodyTextController.selection.end,
+                                                '[@${user.name}@${fetchInstanceNameFromUrl(user.actorId)}](${user.actorId})',
+                                              );
+                                            },
+                                          );
                                         },
-                                        parentCommentActorId: parentComment?.apId,
-                                        onParentCommentChanged: (ThunderComment parentComment) {
-                                          setState(() {
-                                            this.parentComment = parentComment;
-                                            postId = parentComment.postId;
-                                            parentCommentId = parentComment.id;
-                                          });
-                                          _onDraftInputChanged();
+                                        MarkdownType.community: () {
+                                          showCommunityInputDialog(
+                                            context,
+                                            title: l10n.community,
+                                            account: account,
+                                            onCommunitySelected: (ThunderCommunity community) {
+                                              _bodyTextController.text = _bodyTextController.text.replaceRange(
+                                                _bodyTextController.selection.end,
+                                                _bodyTextController.selection.end,
+                                                '!${community.name}@${fetchInstanceNameFromUrl(community.actorId)}',
+                                              );
+                                            },
+                                          );
                                         },
-                                        onUserChanged: (account) {
-                                          setState(() {
-                                            userChanged = featureAccountState.effectiveAccount.id != account.id;
-                                          });
+                                      },
+                                      imageIsLoading: state.status == CreateCommentStatus.imageUploadInProgress,
+                                      customImageButtonAction: () async {
+                                        if (state.status == CreateCommentStatus.imageUploadInProgress) {
+                                          return;
+                                        }
 
-                                          context.read<FeatureAccountCubit>().setOverride(account);
-                                          _onDraftInputChanged();
-                                        },
-                                        enableAccountSwitching: widget.comment == null,
+                                        List<String> imagesPath = await selectImagesToUpload(allowMultiple: true);
+                                        if (context.mounted) {
+                                          context.read<CreateCommentCubit>().uploadImages(imagesPath);
+                                        }
+                                      },
+                                      getAlternativeSelection: () => replyViewSelection,
+                                    ),
+                                  ),
+                                ),
+                                Padding(
+                                  padding: const EdgeInsets.only(bottom: 2.0, top: 2.0, left: 4.0, right: 2.0),
+                                  child: IconButton(
+                                    onPressed: () {
+                                      if (!showPreview) {
+                                        setState(() => wasKeyboardVisible = _keyboardDetectionController.stateAsBool(true) ?? false);
+                                        FocusManager.instance.primaryFocus?.unfocus();
+                                      }
+
+                                      setState(() => showPreview = !showPreview);
+                                      if (!showPreview && wasKeyboardVisible) {
+                                        _bodyFocusNode.requestFocus();
+                                      }
+                                    },
+                                    icon: Icon(
+                                      showPreview ? Icons.visibility_off_rounded : Icons.visibility,
+                                      color: theme.colorScheme.onSecondary,
+                                      semanticLabel: l10n.postTogglePreview,
+                                    ),
+                                    style: ElevatedButton.styleFrom(backgroundColor: theme.colorScheme.secondaryContainer),
+                                  ),
+                                ),
+                                Padding(
+                                  padding: const EdgeInsets.only(bottom: 2.0, top: 2.0, left: 2.0, right: 8.0),
+                                  child: SizedBox(
+                                    width: 60,
+                                    child: IconButton(
+                                      onPressed: isSubmitButtonDisabled || state.status == CreateCommentStatus.submitting ? null : () => _onCreateComment(context),
+                                      icon: state.status == CreateCommentStatus.submitting
+                                          ? const SizedBox(
+                                              height: 20,
+                                              width: 20,
+                                              child: CircularProgressIndicator(),
+                                            )
+                                          : Icon(
+                                              widget.comment != null ? Icons.edit_rounded : Icons.send_rounded,
+                                              color: theme.colorScheme.onSecondary,
+                                              semanticLabel: widget.comment != null ? l10n.editComment : l10n.createComment,
+                                            ),
+                                      style: ElevatedButton.styleFrom(
+                                        backgroundColor: theme.colorScheme.secondary,
+                                        disabledBackgroundColor: getBackgroundColor(context),
                                       ),
                                     ),
-                                    const SizedBox(height: 10),
-                                    Padding(
-                                      padding: const EdgeInsets.symmetric(horizontal: 16.0),
-                                      child: LanguageSelector(
-                                        account: account,
-                                        languageId: languageId,
-                                        onLanguageSelected: (ThunderLanguage? language) {
-                                          setState(() => languageId = language?.id);
-                                          _onDraftInputChanged();
-                                        },
-                                      ),
-                                    ),
-                                    const SizedBox(height: 10),
-                                    AnimatedCrossFade(
-                                      firstChild: Padding(
-                                        padding: const EdgeInsets.all(8.0),
-                                        child: Container(
-                                          width: double.infinity,
-                                          padding: const EdgeInsets.all(8.0),
-                                          decoration: BoxDecoration(
-                                            color: getBackgroundColor(context),
-                                            borderRadius: const BorderRadius.all(Radius.circular(8.0)),
-                                          ),
-                                          child: CommonMarkdownBody(body: _bodyTextController.text, isComment: true),
-                                        ),
-                                      ),
-                                      secondChild: Padding(
-                                        padding: const EdgeInsets.symmetric(horizontal: 16.0),
-                                        child: MarkdownTextInputField(
-                                          controller: _bodyTextController,
-                                          focusNode: _bodyFocusNode,
-                                          label: l10n.comment,
-                                          minLines: 8,
-                                          maxLines: null,
-                                          textStyle: theme.textTheme.bodyLarge,
-                                          spellCheckConfiguration: const SpellCheckConfiguration.disabled(),
-                                        ),
-                                      ),
-                                      crossFadeState: showPreview ? CrossFadeState.showFirst : CrossFadeState.showSecond,
-                                      duration: const Duration(milliseconds: 120),
-                                      excludeBottomFocus: false,
-                                    )
-                                  ],
+                                  ),
                                 ),
                               ],
                             ),
                           ),
-                        ),
-                        const Divider(height: 1),
-                        Container(
-                          color: theme.cardColor,
-                          margin: EdgeInsets.only(bottom: MediaQuery.of(context).viewInsets.bottom),
-                          child: Row(
-                            children: [
-                              Expanded(
-                                child: IgnorePointer(
-                                  ignoring: showPreview,
-                                  child: MarkdownToolbar(
-                                    controller: _bodyTextController,
-                                    focusNode: _bodyFocusNode,
-                                    actions: const [
-                                      MarkdownType.image,
-                                      MarkdownType.link,
-                                      MarkdownType.bold,
-                                      MarkdownType.italic,
-                                      MarkdownType.blockquote,
-                                      MarkdownType.strikethrough,
-                                      MarkdownType.title,
-                                      MarkdownType.list,
-                                      MarkdownType.separator,
-                                      MarkdownType.code,
-                                      MarkdownType.spoiler,
-                                      MarkdownType.username,
-                                      MarkdownType.community,
-                                    ],
-                                    customTapActions: {
-                                      MarkdownType.username: () {
-                                        showUserInputDialog(
-                                          context,
-                                          title: l10n.username,
-                                          account: account,
-                                          onUserSelected: (ThunderUser user) {
-                                            _bodyTextController.text = _bodyTextController.text.replaceRange(
-                                              _bodyTextController.selection.end,
-                                              _bodyTextController.selection.end,
-                                              '[@${user.name}@${fetchInstanceNameFromUrl(user.actorId)}](${user.actorId})',
-                                            );
-                                          },
-                                        );
-                                      },
-                                      MarkdownType.community: () {
-                                        showCommunityInputDialog(
-                                          context,
-                                          title: l10n.community,
-                                          account: account,
-                                          onCommunitySelected: (ThunderCommunity community) {
-                                            _bodyTextController.text = _bodyTextController.text.replaceRange(
-                                              _bodyTextController.selection.end,
-                                              _bodyTextController.selection.end,
-                                              '!${community.name}@${fetchInstanceNameFromUrl(community.actorId)}',
-                                            );
-                                          },
-                                        );
-                                      },
-                                    },
-                                    imageIsLoading: state.status == CreateCommentStatus.imageUploadInProgress,
-                                    customImageButtonAction: () async {
-                                      if (state.status == CreateCommentStatus.imageUploadInProgress) {
-                                        return;
-                                      }
-
-                                      List<String> imagesPath = await selectImagesToUpload(allowMultiple: true);
-                                      if (context.mounted) {
-                                        context.read<CreateCommentCubit>().uploadImages(imagesPath);
-                                      }
-                                    },
-                                    getAlternativeSelection: () => replyViewSelection,
-                                  ),
-                                ),
-                              ),
-                              Padding(
-                                padding: const EdgeInsets.only(bottom: 2.0, top: 2.0, left: 4.0, right: 2.0),
-                                child: IconButton(
-                                  onPressed: () {
-                                    if (!showPreview) {
-                                      setState(() => wasKeyboardVisible = keyboardVisibilityController.isVisible);
-                                      FocusManager.instance.primaryFocus?.unfocus();
-                                    }
-
-                                    setState(() => showPreview = !showPreview);
-                                    if (!showPreview && wasKeyboardVisible) {
-                                      _bodyFocusNode.requestFocus();
-                                    }
-                                  },
-                                  icon: Icon(
-                                    showPreview ? Icons.visibility_off_rounded : Icons.visibility,
-                                    color: theme.colorScheme.onSecondary,
-                                    semanticLabel: l10n.postTogglePreview,
-                                  ),
-                                  style: ElevatedButton.styleFrom(backgroundColor: theme.colorScheme.secondaryContainer),
-                                ),
-                              ),
-                              Padding(
-                                padding: const EdgeInsets.only(bottom: 2.0, top: 2.0, left: 2.0, right: 8.0),
-                                child: SizedBox(
-                                  width: 60,
-                                  child: IconButton(
-                                    onPressed: isSubmitButtonDisabled || state.status == CreateCommentStatus.submitting ? null : () => _onCreateComment(context),
-                                    icon: state.status == CreateCommentStatus.submitting
-                                        ? const SizedBox(
-                                            height: 20,
-                                            width: 20,
-                                            child: CircularProgressIndicator(),
-                                          )
-                                        : Icon(
-                                            widget.comment != null ? Icons.edit_rounded : Icons.send_rounded,
-                                            color: theme.colorScheme.onSecondary,
-                                            semanticLabel: widget.comment != null ? l10n.editComment : l10n.createComment,
-                                          ),
-                                    style: ElevatedButton.styleFrom(
-                                      backgroundColor: theme.colorScheme.secondary,
-                                      disabledBackgroundColor: getBackgroundColor(context),
-                                    ),
-                                  ),
-                                ),
-                              ),
-                            ],
+                          Container(
+                            height: MediaQuery.of(context).padding.bottom,
+                            color: theme.cardColor,
                           ),
-                        ),
-                        Container(
-                          height: MediaQuery.of(context).padding.bottom,
-                          color: theme.cardColor,
-                        ),
-                      ],
+                        ],
+                      ),
                     ),
                   ),
                 ),

--- a/lib/src/features/post/presentation/pages/create_post_page.dart
+++ b/lib/src/features/post/presentation/pages/create_post_page.dart
@@ -4,8 +4,7 @@ import 'dart:io';
 import 'package:flutter/material.dart';
 
 import 'package:flutter_bloc/flutter_bloc.dart';
-import 'package:flutter_keyboard_visibility/flutter_keyboard_visibility.dart';
-import 'package:link_preview_generator/link_preview_generator.dart';
+import 'package:keyboard_detection/keyboard_detection.dart';
 
 import 'package:thunder/packages/ui/ui.dart' show showSnackbar;
 import 'package:thunder/src/features/account/account.dart';
@@ -25,6 +24,7 @@ import 'package:thunder/src/foundation/config/global_context.dart';
 import 'package:thunder/src/foundation/primitives/primitives.dart';
 import 'package:thunder/src/shared/media/media_utils.dart' show isImageUrl, selectImagesToUpload;
 import 'package:thunder/src/shared/media/media_view.dart';
+import 'package:thunder/src/shared/links/link_metadata_repository.dart';
 import 'package:thunder/src/shared/language_selector.dart';
 
 class CreatePostPage extends StatefulWidget {
@@ -107,7 +107,7 @@ class _CreatePostPageState extends State<CreatePostPage> with WidgetsBindingObse
   final TextEditingController _tagsTextController = TextEditingController();
 
   final FocusNode _bodyFocusNode = FocusNode();
-  final KeyboardVisibilityController _keyboardVisibilityController = KeyboardVisibilityController();
+  final KeyboardDetectionController _keyboardDetectionController = KeyboardDetectionController();
 
   bool _showPreview = false;
   bool _wasKeyboardVisible = false;
@@ -245,16 +245,19 @@ class _CreatePostPageState extends State<CreatePostPage> with WidgetsBindingObse
     });
   }
 
-  Future<String?> _getDataFromLink({String? link, bool updateTitleField = true}) async {
+  Future<String?> _getDataFromLink({required Account account, String? link, bool updateTitleField = true}) async {
     final resolvedLink = link ?? widget.url;
 
     if (resolvedLink?.isNotEmpty == true) {
       try {
-        final WebInfo info = await LinkPreview.scrapeFromURL(resolvedLink!);
-        if (updateTitleField) {
-          _titleTextController.text = info.title;
+        final metadata = await LinkMetadataRepositoryImpl(account: account).getLinkMetadata(url: resolvedLink!);
+        final title = metadata?.title;
+
+        if (updateTitleField && title != null && mounted) {
+          _titleTextController.text = title;
         }
-        return info.title;
+
+        return title;
       } catch (_) {
         return null;
       }
@@ -365,156 +368,160 @@ class _CreatePostPageState extends State<CreatePostPage> with WidgetsBindingObse
               builder: (context, state) {
                 return GestureDetector(
                   onTap: () => FocusManager.instance.primaryFocus?.unfocus(),
-                  child: Scaffold(
-                    resizeToAvoidBottomInset: false,
-                    appBar: AppBar(
-                      title: Text(widget.post != null ? l10n.editPost : l10n.createPost),
-                      centerTitle: false,
-                      actions: widget.showAdditionalSettingsButton
-                          ? [
-                              IconButton(
-                                key: const Key('create-post-additional-settings-button'),
-                                onPressed: () => _openAdditionalSettingsPage(context),
-                                icon: const Icon(Icons.tune_rounded),
-                                tooltip: l10n.advanced,
-                              ),
-                            ]
-                          : null,
-                    ),
-                    body: SafeArea(
-                      bottom: false,
-                      child: Column(
-                        crossAxisAlignment: CrossAxisAlignment.start,
-                        children: <Widget>[
-                          Expanded(
-                            child: SingleChildScrollView(
-                              child: Padding(
-                                padding: const EdgeInsets.only(left: 16.0, right: 16.0, top: 8.0),
-                                child: Column(
-                                  crossAxisAlignment: CrossAxisAlignment.start,
-                                  children: <Widget>[
-                                    CommunitySelector(
-                                      account: account,
-                                      community: state.community,
-                                      onCommunitySelected: (community) => context.read<CreatePostCubit>().updateCommunity(community),
-                                    ),
-                                    const SizedBox(height: 4.0),
-                                    UserSelector(
-                                      account: account,
-                                      communityActorId: state.community?.actorId,
-                                      onCommunityChanged: (community) => context.read<CreatePostCubit>().updateCommunity(community),
-                                      onUserChanged: (account) => context.read<FeatureAccountCubit>().setOverride(account),
-                                      enableAccountSwitching: widget.post == null,
-                                    ),
-                                    const SizedBox(height: 12.0),
-                                    CreatePostTitleField(
-                                      controller: _titleTextController,
-                                      onSuggestFromLink: () => _getDataFromLink(
-                                        link: _urlTextController.text,
-                                        updateTitleField: false,
+                  child: KeyboardDetection(
+                    controller: _keyboardDetectionController,
+                    child: Scaffold(
+                      resizeToAvoidBottomInset: false,
+                      appBar: AppBar(
+                        title: Text(widget.post != null ? l10n.editPost : l10n.createPost),
+                        centerTitle: false,
+                        actions: widget.showAdditionalSettingsButton
+                            ? [
+                                IconButton(
+                                  key: const Key('create-post-additional-settings-button'),
+                                  onPressed: () => _openAdditionalSettingsPage(context),
+                                  icon: const Icon(Icons.tune_rounded),
+                                  tooltip: l10n.advanced,
+                                ),
+                              ]
+                            : null,
+                      ),
+                      body: SafeArea(
+                        bottom: false,
+                        child: Column(
+                          crossAxisAlignment: CrossAxisAlignment.start,
+                          children: <Widget>[
+                            Expanded(
+                              child: SingleChildScrollView(
+                                child: Padding(
+                                  padding: const EdgeInsets.only(left: 16.0, right: 16.0, top: 8.0),
+                                  child: Column(
+                                    crossAxisAlignment: CrossAxisAlignment.start,
+                                    children: <Widget>[
+                                      CommunitySelector(
+                                        account: account,
+                                        community: state.community,
+                                        onCommunitySelected: (community) => context.read<CreatePostCubit>().updateCommunity(community),
                                       ),
-                                    ),
-                                    const SizedBox(height: 10),
-                                    CreatePostUrlField(
-                                      controller: _urlTextController,
-                                      state: state,
-                                      onUploadPostImageRequested: () async {
-                                        if (state.status == CreatePostStatus.postImageUploadInProgress) {
-                                          return;
-                                        }
-
-                                        final imagesPath = await selectImagesToUpload();
-                                        if (mounted) {
-                                          context.read<CreatePostCubit>().uploadImages(imagesPath, isPostImage: true);
-                                        }
-                                      },
-                                    ),
-                                    if (isImageUrl(state.url)) ...[
-                                      const SizedBox(height: 10),
-                                      TextFormField(
-                                        key: const Key('create-post-alt-text-field'),
-                                        controller: _altTextTextController,
-                                        decoration: InputDecoration(
-                                          labelText: l10n.altText,
-                                          isDense: true,
-                                          border: const OutlineInputBorder(),
-                                          contentPadding: const EdgeInsets.all(13),
+                                      const SizedBox(height: 4.0),
+                                      UserSelector(
+                                        account: account,
+                                        communityActorId: state.community?.actorId,
+                                        onCommunityChanged: (community) => context.read<CreatePostCubit>().updateCommunity(community),
+                                        onUserChanged: (account) => context.read<FeatureAccountCubit>().setOverride(account),
+                                        enableAccountSwitching: widget.post == null,
+                                      ),
+                                      const SizedBox(height: 12.0),
+                                      CreatePostTitleField(
+                                        controller: _titleTextController,
+                                        onSuggestFromLink: () => _getDataFromLink(
+                                          account: account,
+                                          link: _urlTextController.text,
+                                          updateTitleField: false,
                                         ),
+                                      ),
+                                      const SizedBox(height: 10),
+                                      CreatePostUrlField(
+                                        controller: _urlTextController,
+                                        state: state,
+                                        onUploadPostImageRequested: () async {
+                                          if (state.status == CreatePostStatus.postImageUploadInProgress) {
+                                            return;
+                                          }
+
+                                          final imagesPath = await selectImagesToUpload();
+                                          if (mounted) {
+                                            context.read<CreatePostCubit>().uploadImages(imagesPath, isPostImage: true);
+                                          }
+                                        },
+                                      ),
+                                      if (isImageUrl(state.url)) ...[
+                                        const SizedBox(height: 10),
+                                        TextFormField(
+                                          key: const Key('create-post-alt-text-field'),
+                                          controller: _altTextTextController,
+                                          decoration: InputDecoration(
+                                            labelText: l10n.altText,
+                                            isDense: true,
+                                            border: const OutlineInputBorder(),
+                                            contentPadding: const EdgeInsets.all(13),
+                                          ),
+                                        ),
+                                      ],
+                                      SizedBox(height: state.url.isNotEmpty ? 10 : 5),
+                                      if (state.url.isNotEmpty && widget.showMediaPreview)
+                                        MediaView(
+                                          showFullHeightImages: false,
+                                          edgeToEdgeImages: false,
+                                          viewMode: ViewMode.comfortable,
+                                          markPostReadOnMediaView: false,
+                                          isUserLoggedIn: true,
+                                          media: Media(
+                                            originalUrl: state.url,
+                                            mediaUrl: isImageUrl(state.url)
+                                                ? state.url
+                                                : state.customThumbnail.isNotEmpty && isImageUrl(state.customThumbnail)
+                                                    ? state.customThumbnail
+                                                    : null,
+                                            nsfw: state.isNsfw,
+                                            mediaType: MediaType.link,
+                                          ),
+                                        ),
+                                      if (state.crossPosts.isNotEmpty && widget.post == null) const SizedBox(height: 6),
+                                      if (state.url.isNotEmpty && state.crossPosts.isNotEmpty && widget.post == null)
+                                        CrossPosts(
+                                          crossPosts: state.crossPosts,
+                                          isNewPost: true,
+                                        ),
+                                      const SizedBox(height: 10),
+                                      CreatePostMetadataRow(
+                                        languageSelector: LanguageSelector(
+                                          account: account,
+                                          languageId: state.languageId,
+                                          onLanguageSelected: (language) => context.read<CreatePostCubit>().updateLanguage(language?.id),
+                                        ),
+                                        nsfw: state.isNsfw,
+                                        onNsfwChanged: (value) => context.read<CreatePostCubit>().updateNsfw(value),
+                                      ),
+                                      const SizedBox(height: 10),
+                                      CreatePostEditorSection(
+                                        body: state.body,
+                                        controller: _bodyTextController,
+                                        focusNode: _bodyFocusNode,
+                                        showPreview: _showPreview,
+                                        nsfw: state.isNsfw,
                                       ),
                                     ],
-                                    SizedBox(height: state.url.isNotEmpty ? 10 : 5),
-                                    if (state.url.isNotEmpty && widget.showMediaPreview)
-                                      MediaView(
-                                        showFullHeightImages: false,
-                                        edgeToEdgeImages: false,
-                                        viewMode: ViewMode.comfortable,
-                                        markPostReadOnMediaView: false,
-                                        isUserLoggedIn: true,
-                                        media: Media(
-                                          originalUrl: state.url,
-                                          mediaUrl: isImageUrl(state.url)
-                                              ? state.url
-                                              : state.customThumbnail.isNotEmpty && isImageUrl(state.customThumbnail)
-                                                  ? state.customThumbnail
-                                                  : null,
-                                          nsfw: state.isNsfw,
-                                          mediaType: MediaType.link,
-                                        ),
-                                      ),
-                                    if (state.crossPosts.isNotEmpty && widget.post == null) const SizedBox(height: 6),
-                                    if (state.url.isNotEmpty && state.crossPosts.isNotEmpty && widget.post == null)
-                                      CrossPosts(
-                                        crossPosts: state.crossPosts,
-                                        isNewPost: true,
-                                      ),
-                                    const SizedBox(height: 10),
-                                    CreatePostMetadataRow(
-                                      languageSelector: LanguageSelector(
-                                        account: account,
-                                        languageId: state.languageId,
-                                        onLanguageSelected: (language) => context.read<CreatePostCubit>().updateLanguage(language?.id),
-                                      ),
-                                      nsfw: state.isNsfw,
-                                      onNsfwChanged: (value) => context.read<CreatePostCubit>().updateNsfw(value),
-                                    ),
-                                    const SizedBox(height: 10),
-                                    CreatePostEditorSection(
-                                      body: state.body,
-                                      controller: _bodyTextController,
-                                      focusNode: _bodyFocusNode,
-                                      showPreview: _showPreview,
-                                      nsfw: state.isNsfw,
-                                    ),
-                                  ],
+                                  ),
                                 ),
                               ),
                             ),
-                          ),
-                          const Divider(height: 1),
-                          CreatePostBottomBar(
-                            account: account,
-                            state: state,
-                            bodyController: _bodyTextController,
-                            bodyFocusNode: _bodyFocusNode,
-                            post: widget.post,
-                            showPreview: _showPreview,
-                            onTogglePreview: _togglePreview,
-                            onUploadBodyImages: () async {
-                              if (state.status == CreatePostStatus.imageUploadInProgress) {
-                                return;
-                              }
+                            const Divider(height: 1),
+                            CreatePostBottomBar(
+                              account: account,
+                              state: state,
+                              bodyController: _bodyTextController,
+                              bodyFocusNode: _bodyFocusNode,
+                              post: widget.post,
+                              showPreview: _showPreview,
+                              onTogglePreview: _togglePreview,
+                              onUploadBodyImages: () async {
+                                if (state.status == CreatePostStatus.imageUploadInProgress) {
+                                  return;
+                                }
 
-                              final imagesPath = await selectImagesToUpload(allowMultiple: true);
-                              if (mounted) {
-                                context.read<CreatePostCubit>().uploadImages(imagesPath, isPostImage: false);
-                              }
-                            },
-                          ),
-                          Container(
-                            height: MediaQuery.of(context).padding.bottom,
-                            color: theme.cardColor,
-                          ),
-                        ],
+                                final imagesPath = await selectImagesToUpload(allowMultiple: true);
+                                if (mounted) {
+                                  context.read<CreatePostCubit>().uploadImages(imagesPath, isPostImage: false);
+                                }
+                              },
+                            ),
+                            Container(
+                              height: MediaQuery.of(context).padding.bottom,
+                              color: theme.cardColor,
+                            ),
+                          ],
+                        ),
                       ),
                     ),
                   ),
@@ -529,7 +536,7 @@ class _CreatePostPageState extends State<CreatePostPage> with WidgetsBindingObse
 
   void _togglePreview() {
     if (!_showPreview) {
-      setState(() => _wasKeyboardVisible = _keyboardVisibilityController.isVisible);
+      setState(() => _wasKeyboardVisible = _keyboardDetectionController.stateAsBool(true) ?? false);
       FocusManager.instance.primaryFocus?.unfocus();
     }
 

--- a/lib/src/features/post/presentation/widgets/post_page_app_bar.dart
+++ b/lib/src/features/post/presentation/widgets/post_page_app_bar.dart
@@ -264,6 +264,7 @@ class PostAppBarActions extends StatelessWidget {
                       state.post!.media.first.originalUrl!,
                       state.post!.media.first.originalUrl!,
                       initialPage: LinkBottomSheetPage.alternateLinks,
+                      preferredImageUrl: state.post!.thumbnailUrl ?? state.post!.media.first.thumbnailUrl,
                     );
                   },
                   icon: Icons.link_rounded,

--- a/lib/src/foundation/networking/lemmy/base_lemmy_api_client.dart
+++ b/lib/src/foundation/networking/lemmy/base_lemmy_api_client.dart
@@ -5,6 +5,7 @@ import 'package:thunder/src/foundation/primitives/enums/post_sort_type.dart';
 import 'package:thunder/src/foundation/primitives/enums/search_sort_type.dart';
 import 'package:thunder/src/foundation/primitives/models/thunder_comment_report.dart';
 import 'package:thunder/src/foundation/primitives/models/modlog_event_item.dart';
+import 'package:thunder/src/foundation/primitives/models/thunder_link_metadata.dart';
 import 'package:thunder/src/foundation/primitives/models/thunder_post_report.dart';
 import 'package:thunder/src/foundation/primitives/models/thunder_private_message.dart';
 import 'package:thunder/src/foundation/primitives/models/thunder_site_response.dart';
@@ -96,6 +97,11 @@ abstract class BaseLemmyApiClient extends BaseApiClient implements ThunderApiCli
     bool? showSaved,
   }) async {
     throw UnimplementedError('Lemmy endpoints are implemented in version-specific clients.');
+  }
+
+  @override
+  Future<ThunderLinkMetadata?> getLinkMetadata({required String url}) async {
+    return null;
   }
 
   @override

--- a/lib/src/foundation/networking/lemmy/lemmy_v3_api_client.dart
+++ b/lib/src/foundation/networking/lemmy/lemmy_v3_api_client.dart
@@ -9,6 +9,7 @@ import 'package:thunder/src/foundation/primitives/enums/post_sort_type.dart';
 import 'package:thunder/src/foundation/primitives/enums/search_sort_type.dart';
 import 'package:thunder/src/foundation/primitives/models/thunder_comment_report.dart';
 import 'package:thunder/src/foundation/primitives/models/modlog_event_item.dart';
+import 'package:thunder/src/foundation/primitives/models/thunder_link_metadata.dart';
 import 'package:thunder/src/foundation/primitives/models/thunder_post_report.dart';
 import 'package:thunder/src/foundation/primitives/models/thunder_private_message.dart';
 import 'package:thunder/src/foundation/primitives/models/thunder_site.dart';
@@ -1265,10 +1266,16 @@ class LemmyV3ApiClient extends BaseLemmyApiClient {
     });
   }
 
-  Future<Map<String, dynamic>> getSiteMetadata({required String url}) async {
-    return await request(HttpMethod.get, '$basePath/post/site_metadata', {
+  @override
+  Future<ThunderLinkMetadata?> getLinkMetadata({required String url}) async {
+    final response = await request(HttpMethod.get, '$basePath/post/site_metadata', {
       'url': url,
     });
+
+    final metadata = response['metadata'];
+    if (metadata is! Map<String, dynamic>) return null;
+
+    return ThunderLinkMetadata.fromLemmySiteMetadata(metadata, url: url);
   }
 
   // Private messages

--- a/lib/src/foundation/networking/lemmy/lemmy_v4_api_client.dart
+++ b/lib/src/foundation/networking/lemmy/lemmy_v4_api_client.dart
@@ -1,7 +1,9 @@
 import 'package:thunder/src/foundation/primitives/models/thunder_site_response.dart';
+import 'package:thunder/src/foundation/networking/base_api_client.dart';
 import 'package:thunder/src/foundation/networking/lemmy/base_lemmy_api_client.dart';
 import 'package:thunder/src/foundation/primitives/models/thunder_comment.dart';
 import 'package:thunder/src/foundation/primitives/models/thunder_community.dart';
+import 'package:thunder/src/foundation/primitives/models/thunder_link_metadata.dart';
 import 'package:thunder/src/foundation/primitives/models/thunder_post.dart';
 import 'package:thunder/src/foundation/primitives/models/thunder_user.dart';
 
@@ -75,6 +77,18 @@ class LemmyV4ApiClient extends BaseLemmyApiClient {
   ThunderSiteResponse parseSiteResponse(Map<String, dynamic> json) {
     // TODO: Replace with ThunderSiteResponse.fromLemmyV4SiteResponse when v4 schema differs
     return ThunderSiteResponse.fromLemmySiteResponse(json);
+  }
+
+  @override
+  Future<ThunderLinkMetadata?> getLinkMetadata({required String url}) async {
+    final response = await request(HttpMethod.get, '$basePath/post/site_metadata', {
+      'url': url,
+    });
+
+    final metadata = response['metadata'];
+    if (metadata is! Map<String, dynamic>) return null;
+
+    return ThunderLinkMetadata.fromLemmySiteMetadata(metadata, url: url);
   }
 
   // =============================================================

--- a/lib/src/foundation/networking/piefed/piefed_api_client.dart
+++ b/lib/src/foundation/networking/piefed/piefed_api_client.dart
@@ -10,6 +10,7 @@ import 'package:thunder/src/foundation/primitives/enums/search_sort_type.dart';
 import 'package:thunder/src/foundation/primitives/models/thunder_comment_report.dart';
 import 'package:thunder/src/foundation/primitives/models/modlog_event_item.dart';
 import 'package:thunder/src/foundation/primitives/models/piefed_post_metadata.dart';
+import 'package:thunder/src/foundation/primitives/models/thunder_link_metadata.dart';
 import 'package:thunder/src/foundation/primitives/models/thunder_post_report.dart';
 import 'package:thunder/src/foundation/primitives/models/thunder_private_message.dart';
 import 'package:thunder/src/foundation/primitives/models/thunder_site.dart';
@@ -448,10 +449,16 @@ class PiefedApiClient extends BaseApiClient implements ThunderApiClient {
   }
 
   /// Get site metadata for a URL.
-  Future<Map<String, dynamic>> getSiteMetadata({String? url}) async {
-    return await request(HttpMethod.get, '$basePath/post/site_metadata', {
+  @override
+  Future<ThunderLinkMetadata?> getLinkMetadata({required String url}) async {
+    final response = await request(HttpMethod.get, '$basePath/post/site_metadata', {
       'url': url,
     });
+
+    final metadata = response['metadata'];
+    if (metadata is! Map<String, dynamic>) return null;
+
+    return ThunderLinkMetadata.fromPiefedSiteMetadata(metadata, url: url);
   }
 
   @override

--- a/lib/src/foundation/networking/thunder_api_client.dart
+++ b/lib/src/foundation/networking/thunder_api_client.dart
@@ -5,6 +5,7 @@ import 'package:thunder/src/foundation/primitives/enums/post_sort_type.dart';
 import 'package:thunder/src/foundation/primitives/enums/search_sort_type.dart';
 import 'package:thunder/src/foundation/primitives/models/thunder_comment_report.dart';
 import 'package:thunder/src/foundation/primitives/models/modlog_event_item.dart';
+import 'package:thunder/src/foundation/primitives/models/thunder_link_metadata.dart';
 import 'package:thunder/src/foundation/primitives/models/thunder_post_report.dart';
 import 'package:thunder/src/foundation/primitives/models/thunder_private_message.dart';
 import 'package:thunder/src/foundation/primitives/models/thunder_site.dart';
@@ -125,6 +126,9 @@ abstract class ThunderApiClient {
     bool? showHidden,
     bool? showSaved,
   });
+
+  /// Fetch server-side metadata for an external URL.
+  Future<ThunderLinkMetadata?> getLinkMetadata({required String url});
 
   /// Create a new post.
   Future<ThunderPost> createPost({

--- a/lib/src/foundation/primitives/models/models.dart
+++ b/lib/src/foundation/primitives/models/models.dart
@@ -8,6 +8,7 @@ export 'thunder_community.dart';
 export 'thunder_flair.dart';
 export 'thunder_instance_info.dart';
 export 'thunder_language.dart';
+export 'thunder_link_metadata.dart';
 export 'thunder_local_user.dart';
 export 'thunder_my_user.dart';
 export 'thunder_post.dart';

--- a/lib/src/foundation/primitives/models/thunder_link_metadata.dart
+++ b/lib/src/foundation/primitives/models/thunder_link_metadata.dart
@@ -1,0 +1,51 @@
+import 'package:equatable/equatable.dart';
+
+/// A class that holds metadata about a link.
+class ThunderLinkMetadata extends Equatable {
+  /// The URL of the link.
+  final String url;
+
+  /// The title of the link.
+  final String? title;
+
+  /// The description of the link.
+  final String? description;
+
+  /// The image URL of the link.
+  final String? imageUrl;
+
+  const ThunderLinkMetadata({required this.url, this.title, this.description, this.imageUrl});
+
+  /// Whether the link has content.
+  bool get hasContent => title != null || description != null || imageUrl != null;
+
+  /// Creates a new ThunderLinkMetadata from a Lemmy site metadata.
+  factory ThunderLinkMetadata.fromLemmySiteMetadata(Map<String, dynamic> metadata, {required String url}) {
+    return ThunderLinkMetadata(
+      url: url,
+      title: _stringOrNull(metadata['title']),
+      description: _stringOrNull(metadata['description']),
+      imageUrl: _stringOrNull(metadata['image']),
+    );
+  }
+
+  /// Creates a new ThunderLinkMetadata from a PieFed site metadata.
+  factory ThunderLinkMetadata.fromPiefedSiteMetadata(Map<String, dynamic> metadata, {required String url}) {
+    return ThunderLinkMetadata(
+      url: url,
+      title: _stringOrNull(metadata['title']),
+      description: _stringOrNull(metadata['description']),
+      imageUrl: _stringOrNull(metadata['image']),
+    );
+  }
+
+  static String? _stringOrNull(dynamic value) {
+    if (value is! String) return null;
+
+    final trimmed = value.trim();
+    return trimmed.isEmpty ? null : trimmed;
+  }
+
+  @override
+  List<Object?> get props => [url, title, description, imageUrl];
+}

--- a/lib/src/shared/links/link_bottom_sheet.dart
+++ b/lib/src/shared/links/link_bottom_sheet.dart
@@ -1,11 +1,15 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 
-import 'package:link_preview_generator/link_preview_generator.dart';
 import 'package:share_plus/share_plus.dart';
+import 'package:cached_network_image/cached_network_image.dart';
 
 import 'package:thunder/l10n/generated/app_localizations.dart';
 import 'package:thunder/src/app/shell/navigation/link_navigation_utils.dart';
+import 'package:thunder/src/features/account/account.dart';
+import 'package:thunder/src/features/session/presentation/utils/effective_account_context.dart';
+import 'package:thunder/src/foundation/primitives/models/thunder_link_metadata.dart';
+import 'package:thunder/src/shared/links/link_metadata_repository.dart';
 import 'package:thunder/packages/ui/ui.dart';
 
 /// Handles the long press on a link by showing a bottom sheet with the link details.
@@ -14,6 +18,7 @@ void handleLinkLongPress(
   String text,
   String? url, {
   LinkBottomSheetPage initialPage = LinkBottomSheetPage.general,
+  String? preferredImageUrl,
   void Function(String)? customNavigation,
 }) {
   HapticFeedback.mediumImpact();
@@ -26,6 +31,7 @@ void handleLinkLongPress(
       text: text,
       url: url,
       initialPage: initialPage,
+      preferredImageUrl: preferredImageUrl,
       customNavigation: customNavigation,
     ),
   );
@@ -51,11 +57,15 @@ class LinkBottomSheet extends StatefulWidget {
   /// The function to call when the user wants to navigate to a custom URL
   final void Function(String)? customNavigation;
 
+  /// The preferred image URL to display before falling back to fetched metadata.
+  final String? preferredImageUrl;
+
   const LinkBottomSheet({
     super.key,
     required this.text,
     required this.url,
     this.initialPage = LinkBottomSheetPage.general,
+    this.preferredImageUrl,
     this.customNavigation,
   });
 
@@ -65,13 +75,180 @@ class LinkBottomSheet extends StatefulWidget {
 
 class _LinkBottomSheetState extends State<LinkBottomSheet> {
   LinkBottomSheetPage? page;
+  Future<ThunderLinkMetadata?>? _linkMetadataFuture;
+  String? _linkMetadataUrl;
+  String? _linkMetadataAccountKey;
+
+  Account? _resolveMetadataAccount(BuildContext context) {
+    try {
+      return resolveEffectiveAccount(context);
+    } catch (_) {
+      return null;
+    }
+  }
+
+  void _ensureLinkMetadataFuture(Account? account) {
+    final url = widget.url?.trim();
+
+    if (account == null || url == null || !url.toLowerCase().startsWith('http')) {
+      _linkMetadataFuture = null;
+      _linkMetadataUrl = url;
+      _linkMetadataAccountKey = null;
+      return;
+    }
+
+    final accountKey = '${account.id}:${account.instance}:${account.platform}';
+
+    if (_linkMetadataFuture != null && _linkMetadataUrl == url && _linkMetadataAccountKey == accountKey) {
+      return;
+    }
+
+    _linkMetadataUrl = url;
+    _linkMetadataAccountKey = accountKey;
+    _linkMetadataFuture = LinkMetadataRepositoryImpl(account: account).getLinkMetadata(url: url);
+  }
+
+  Widget _buildLinkMetadataPreviewSection(ThemeData theme) {
+    final metadataFuture = _linkMetadataFuture;
+    final preferredImageUrl = widget.preferredImageUrl;
+
+    if (metadataFuture == null && preferredImageUrl == null) {
+      return const SizedBox.shrink();
+    }
+
+    if (metadataFuture == null) {
+      return Column(
+        children: [
+          Padding(
+            padding: const EdgeInsets.only(left: 24, right: 24),
+            child: Container(
+              decoration: BoxDecoration(
+                color: theme.dividerColor.withValues(alpha: 0.25),
+                borderRadius: BorderRadius.circular(10),
+              ),
+              clipBehavior: Clip.antiAlias,
+              child: CachedNetworkImage(
+                imageUrl: preferredImageUrl!,
+                width: double.infinity,
+                height: 160,
+                fit: BoxFit.cover,
+                placeholder: (context, url) => const SizedBox(
+                  height: 160,
+                  child: Center(child: CircularProgressIndicator()),
+                ),
+                errorWidget: (context, url, error) => const SizedBox.shrink(),
+              ),
+            ),
+          ),
+          const SizedBox(height: 10),
+        ],
+      );
+    }
+
+    return FutureBuilder<ThunderLinkMetadata?>(
+      future: metadataFuture,
+      builder: (context, snapshot) {
+        if (snapshot.connectionState == ConnectionState.waiting) {
+          return Column(
+            children: [
+              Padding(
+                padding: const EdgeInsets.only(left: 24, right: 24),
+                child: Container(
+                  height: 96,
+                  decoration: BoxDecoration(
+                    color: theme.dividerColor.withValues(alpha: 0.25),
+                    borderRadius: BorderRadius.circular(10),
+                  ),
+                  alignment: Alignment.center,
+                  child: const CircularProgressIndicator(),
+                ),
+              ),
+              const SizedBox(height: 10),
+            ],
+          );
+        }
+
+        final metadata = snapshot.data;
+        final hasMetadataContent = metadata?.hasContent ?? false;
+        if (!hasMetadataContent && preferredImageUrl == null) {
+          return const SizedBox.shrink();
+        }
+
+        final title = metadata?.title;
+        final description = metadata?.description;
+        final imageUrl = preferredImageUrl ?? metadata?.imageUrl;
+
+        return Column(
+          children: [
+            Padding(
+              padding: const EdgeInsets.only(left: 24, right: 24),
+              child: Container(
+                decoration: BoxDecoration(
+                  color: theme.dividerColor.withValues(alpha: 0.25),
+                  borderRadius: BorderRadius.circular(10),
+                ),
+                clipBehavior: Clip.antiAlias,
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    if (imageUrl != null)
+                      CachedNetworkImage(
+                        imageUrl: imageUrl,
+                        width: double.infinity,
+                        height: 160,
+                        fit: BoxFit.cover,
+                        placeholder: (context, url) => const SizedBox(
+                          height: 160,
+                          child: Center(child: CircularProgressIndicator()),
+                        ),
+                        errorWidget: (context, url, error) => const SizedBox.shrink(),
+                      ),
+                    if (title != null || description != null)
+                      Padding(
+                        padding: const EdgeInsets.all(12),
+                        child: Column(
+                          crossAxisAlignment: CrossAxisAlignment.start,
+                          children: [
+                            if (title != null)
+                              Text(
+                                title,
+                                maxLines: 2,
+                                overflow: TextOverflow.ellipsis,
+                                style: theme.textTheme.titleMedium,
+                              ),
+                            if (title != null && description != null) const SizedBox(height: 6),
+                            if (description != null)
+                              Text(
+                                description,
+                                maxLines: 4,
+                                overflow: TextOverflow.ellipsis,
+                                style: theme.textTheme.bodyMedium,
+                              ),
+                          ],
+                        ),
+                      ),
+                  ],
+                ),
+              ),
+            ),
+            const SizedBox(height: 10),
+          ],
+        );
+      },
+    );
+  }
 
   @override
   Widget build(BuildContext context) {
     final ThemeData theme = Theme.of(context);
     final AppLocalizations l10n = AppLocalizations.of(context)!;
 
-    bool isValidUrl = widget.url?.startsWith('http') ?? false;
+    final normalizedUrl = widget.url?.trim();
+    final isValidUrl = normalizedUrl?.toLowerCase().startsWith('http') ?? false;
+    final resolvedUrl = normalizedUrl?.isNotEmpty == true ? normalizedUrl! : widget.text;
+    final metadataAccount = isValidUrl ? _resolveMetadataAccount(context) : null;
+
+    _ensureLinkMetadataFuture(metadataAccount);
 
     return SingleChildScrollView(
       child: AnimatedSize(
@@ -81,6 +258,7 @@ class _LinkBottomSheetState extends State<LinkBottomSheet> {
           child: Column(
             mainAxisAlignment: MainAxisAlignment.start,
             mainAxisSize: MainAxisSize.max,
+            crossAxisAlignment: CrossAxisAlignment.stretch,
             children: [
               Padding(
                 padding: const EdgeInsets.only(left: 10, right: 10),
@@ -116,23 +294,7 @@ class _LinkBottomSheetState extends State<LinkBottomSheet> {
               ),
               const SizedBox(height: 10),
               if (isValidUrl && (page ?? widget.initialPage) == LinkBottomSheetPage.general) ...[
-                Padding(
-                  padding: const EdgeInsets.only(left: 24, right: 24),
-                  child: LinkPreviewGenerator(
-                    link: widget.url!,
-                    placeholderWidget: const CircularProgressIndicator(),
-                    linkPreviewStyle: LinkPreviewStyle.large,
-                    cacheDuration: Duration.zero,
-                    onTap: null,
-                    bodyTextOverflow: TextOverflow.fade,
-                    graphicFit: BoxFit.scaleDown,
-                    removeElevation: true,
-                    backgroundColor: theme.dividerColor.withValues(alpha: 0.25),
-                    borderRadius: 10,
-                    useDefaultOnTap: false,
-                  ),
-                ),
-                const SizedBox(height: 10),
+                _buildLinkMetadataPreviewSection(theme),
               ],
               Padding(
                 padding: const EdgeInsets.only(left: 24, right: 24),
@@ -143,7 +305,11 @@ class _LinkBottomSheetState extends State<LinkBottomSheet> {
                   ),
                   child: Padding(
                     padding: const EdgeInsets.all(5),
-                    child: Text(widget.url!),
+                    child: Text(
+                      resolvedUrl.characters.join('\u200B'), // Add a zero-width space to allow the text to wrap at any character
+                      maxLines: 3,
+                      overflow: TextOverflow.ellipsis,
+                    ),
                   ),
                 ),
               ),

--- a/lib/src/shared/links/link_metadata_repository.dart
+++ b/lib/src/shared/links/link_metadata_repository.dart
@@ -1,0 +1,33 @@
+import 'package:flutter/foundation.dart';
+
+import 'package:thunder/src/foundation/contracts/account.dart';
+import 'package:thunder/src/foundation/networking/networking.dart';
+import 'package:thunder/src/foundation/primitives/primitives.dart';
+
+abstract class LinkMetadataRepository {
+  Future<ThunderLinkMetadata?> getLinkMetadata({required String url});
+}
+
+class LinkMetadataRepositoryImpl implements LinkMetadataRepository {
+  LinkMetadataRepositoryImpl({required this.account, ThunderApiClient? api}) : _api = api ?? ApiClientFactory.create(account, debug: kDebugMode);
+
+  /// The account to use for the link metadata
+  final Account account;
+
+  /// The API client to use for the link metadata
+  final ThunderApiClient _api;
+
+  @override
+  Future<ThunderLinkMetadata?> getLinkMetadata({required String url}) async {
+    final trimmedUrl = url.trim();
+
+    if (trimmedUrl.isEmpty || account.anonymous) return null;
+
+    try {
+      return await _api.getLinkMetadata(url: trimmedUrl);
+    } catch (error) {
+      if (kDebugMode) debugPrint('Failed to fetch link metadata for $trimmedUrl: $error');
+      return null;
+    }
+  }
+}

--- a/lib/src/shared/media/media_view.dart
+++ b/lib/src/shared/media/media_view.dart
@@ -137,7 +137,7 @@ class _MediaViewState extends State<MediaView> with TickerProviderStateMixin {
 
   void _openLinkLongPress(String text, String? url) {
     if (url != null) {
-      handleLinkLongPress(context, text, url);
+      handleLinkLongPress(context, text, url, preferredImageUrl: widget.media.thumbnailUrl);
     }
   }
 

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -758,54 +758,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.6.0"
-  flutter_keyboard_visibility:
-    dependency: "direct main"
-    description:
-      name: flutter_keyboard_visibility
-      sha256: "98664be7be0e3ffca00de50f7f6a287ab62c763fc8c762e0a21584584a3ff4f8"
-      url: "https://pub.dev"
-    source: hosted
-    version: "6.0.0"
-  flutter_keyboard_visibility_linux:
-    dependency: transitive
-    description:
-      name: flutter_keyboard_visibility_linux
-      sha256: "6fba7cd9bb033b6ddd8c2beb4c99ad02d728f1e6e6d9b9446667398b2ac39f08"
-      url: "https://pub.dev"
-    source: hosted
-    version: "1.0.0"
-  flutter_keyboard_visibility_macos:
-    dependency: transitive
-    description:
-      name: flutter_keyboard_visibility_macos
-      sha256: c5c49b16fff453dfdafdc16f26bdd8fb8d55812a1d50b0ce25fc8d9f2e53d086
-      url: "https://pub.dev"
-    source: hosted
-    version: "1.0.0"
-  flutter_keyboard_visibility_platform_interface:
-    dependency: transitive
-    description:
-      name: flutter_keyboard_visibility_platform_interface
-      sha256: e43a89845873f7be10cb3884345ceb9aebf00a659f479d1c8f4293fcb37022a4
-      url: "https://pub.dev"
-    source: hosted
-    version: "2.0.0"
-  flutter_keyboard_visibility_web:
-    dependency: transitive
-    description:
-      name: flutter_keyboard_visibility_web
-      sha256: d3771a2e752880c79203f8d80658401d0c998e4183edca05a149f5098ce6e3d1
-      url: "https://pub.dev"
-    source: hosted
-    version: "2.0.0"
-  flutter_keyboard_visibility_windows:
-    dependency: transitive
-    description:
-      name: flutter_keyboard_visibility_windows
-      sha256: fc4b0f0b6be9b93ae527f3d527fb56ee2d918cd88bbca438c478af7bcfd0ef73
-      url: "https://pub.dev"
-    source: hosted
-    version: "1.0.0"
   flutter_launcher_icons:
     dependency: "direct dev"
     description:
@@ -908,10 +860,10 @@ packages:
     dependency: "direct main"
     description:
       name: flutter_typeahead
-      sha256: d64712c65db240b1057559b952398ebb6e498077baeebf9b0731dade62438a6d
+      sha256: "7b3f84e0bff51c544f4d1382c00413c36c1714328a6a89600865e497437d29d2"
       url: "https://pub.dev"
     source: hosted
-    version: "5.2.0"
+    version: "6.0.0"
   flutter_web_plugins:
     dependency: transitive
     description: flutter
@@ -1174,6 +1126,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "4.11.0"
+  keyboard_detection:
+    dependency: "direct main"
+    description:
+      name: keyboard_detection
+      sha256: e25924923c9f94dbdb705eac5f3149ac4ec7503ec99a7476a13c86baa4174bdb
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.8.1"
   l10n_esperanto:
     dependency: "direct main"
     description:
@@ -1206,15 +1166,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.0.2"
-  link_preview_generator:
-    dependency: "direct main"
-    description:
-      path: "."
-      ref: "77a00003216591c32194c2af3c4fc1cf64797e53"
-      resolved-ref: "77a00003216591c32194c2af3c4fc1cf64797e53"
-      url: "https://github.com/thunder-app/link_preview_generator.git"
-    source: git
-    version: "1.2.0"
   lints:
     dependency: transitive
     description:
@@ -1480,38 +1431,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.8"
-  pointer_interceptor:
-    dependency: transitive
-    description:
-      name: pointer_interceptor
-      sha256: "57210410680379aea8b1b7ed6ae0c3ad349bfd56fe845b8ea934a53344b9d523"
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.10.1+2"
-  pointer_interceptor_ios:
-    dependency: transitive
-    description:
-      name: pointer_interceptor_ios
-      sha256: "03c5fa5896080963ab4917eeffda8d28c90f22863a496fb5ba13bc10943e40e4"
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.10.1+1"
-  pointer_interceptor_platform_interface:
-    dependency: transitive
-    description:
-      name: pointer_interceptor_platform_interface
-      sha256: "0597b0560e14354baeb23f8375cd612e8bd4841bf8306ecb71fcd0bb78552506"
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.10.0+1"
-  pointer_interceptor_web:
-    dependency: transitive
-    description:
-      name: pointer_interceptor_web
-      sha256: "460b600e71de6fcea2b3d5f662c92293c049c4319e27f0829310e5a953b3ee2a"
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.10.3"
   pool:
     dependency: transitive
     description:
@@ -1957,14 +1876,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.1.0"
-  universal_html:
-    dependency: transitive
-    description:
-      name: universal_html
-      sha256: c0bcae5c733c60f26c7dfc88b10b0fd27cbcc45cb7492311cdaa6067e21c9cd4
-      url: "https://pub.dev"
-    source: hosted
-    version: "2.3.0"
   universal_io:
     dependency: transitive
     description:
@@ -2185,10 +2096,10 @@ packages:
     dependency: "direct main"
     description:
       name: webview_flutter_wkwebview
-      sha256: e15d8828e014291324a4d0cf6e272090167f4fa5673ffcf8fe446f4a4cd35861
+      sha256: a68868ac4828a5f012bf81e8bd25d879f3cec5bd5301575466caafbf9a320a65
       url: "https://pub.dev"
     source: hosted
-    version: "3.24.3"
+    version: "3.24.5"
   win32:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -10,10 +10,6 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  link_preview_generator:
-    git:
-      url: https://github.com/thunder-app/link_preview_generator.git
-      ref: 77a00003216591c32194c2af3c4fc1cf64797e53
   markdown_editor:
     git:
       url: https://github.com/thunder-app/markdown-editor.git
@@ -48,13 +44,13 @@ dependencies:
   flutter_custom_tabs: ^2.0.0-beta.1
   flutter_displaymode: ^0.7.0
   flutter_file_dialog: ^3.0.2
-  flutter_keyboard_visibility: ^6.0.0
+  keyboard_detection: ^0.8.1
   flutter_local_notifications: ^21.0.0
   flutter_markdown: ^0.7.3+1
   flutter_native_splash: ^2.4.7
   flutter_sharing_intent: ^2.0.4
   flutter_staggered_grid_view: ^0.7.0
-  flutter_typeahead: ^5.2.0
+  flutter_typeahead: ^6.0.0
   gal: ^2.2.0
   html: ^0.15.4
   html_unescape: ^2.0.0

--- a/scripts/build-and-serve-web.sh
+++ b/scripts/build-and-serve-web.sh
@@ -10,5 +10,5 @@ cd "${SCRIPT_DIR}/.."
 
 flutter pub get
 flutter gen-l10n
-flutter build web
+flutter build web --wasm
 python3 "${SCRIPT_DIR}/serve-web.py" --port "${PORT}"

--- a/web/index.html
+++ b/web/index.html
@@ -113,6 +113,11 @@
       media="(prefers-color-scheme: dark)">
     <img class="center" aria-hidden="true" src="splash/img/light-1x.png" alt="">
   </picture>
+  <script>
+    window.addEventListener('contextmenu', function (e) {
+      e.preventDefault();
+    });
+  </script>
   <script src="flutter_bootstrap.js" async=""></script>
 </body>
 


### PR DESCRIPTION
## Pull Request Description

This PR improves the logic for the link bottom sheet previews. The following changes were made:
- Removed `link_preview_generator` package in favour of a local widget. This just helps reduce the amount of dependencies Thunder needs to have and also fixes a few issues related to theming.
- Replaced the previous link scraping logic with Lemmy/PieFed equivalent APIs. It turns out there are API endpoints to fetch a site's metadata (`/post/site_metadata`) which doesn't rely on us having to perform scraping ourselves.

Additionally, a few other changes were made (mainly to allow for WASM compilation for web builds)
- Replaced flutter_keyboard_visibility with keyboard_detection as flutter_keyboard_visibility is not being actively maintained. This was preventing WASM builds from being built.
- Upgraded flutter_typeahead version which removes a transitive dependency on flutter_keyboard_visibility.

<!--- Please describe what was changed -->

## Issue Being Fixed

<!-- Please describe the problem that is being fixed and, if applicable, reference a GitHub issue -->

Issue Number: #1371

## Screenshots / Recordings

<!-- This section is optional but highly recommended to show off your changes! -->

## Checklist

- [ ] If a new package was added, did you ensure it uses an appropriate license and is actively maintained?
- [ ] Did you use localized strings (and added appropriate descriptions) where applicable?
- [ ] Did you add `semanticLabel`s where applicable for accessibility?
