### PR TITLE
Add ability to send direct messages on Lemmy/PieFed

### DIFF
--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -934,6 +934,10 @@
   "@dimReadPosts": {
     "description": "Description of the effect on read posts."
   },
+  "directMessage": "Direct message",
+  "@directMessage": {
+    "description": "Title for the private message compose page"
+  },
   "disable": "Disable",
   "@disable": {
     "description": "Action for disabling something"
@@ -2613,11 +2617,19 @@
   "@selectLanguage": {
     "description": "The prompt to select a language in the post creation page"
   },
+  "selectRecipient": "Select recipient",
+  "@selectRecipient": {
+    "description": "Prompt to choose a private message recipient"
+  },
   "selectSearchType": "Select Search Type",
   "@selectSearchType": {},
   "selectText": "Select Text",
   "@selectText": {
     "description": "Post and comment action for selecting text"
+  },
+  "send": "Send",
+  "@send": {
+    "description": "Action to send content"
   },
   "sendBackgroundTestLocalNotification": "Send background test local notification",
   "@sendBackgroundTestLocalNotification": {

--- a/lib/l10n/generated/app_localizations.dart
+++ b/lib/l10n/generated/app_localizations.dart
@@ -1512,6 +1512,12 @@ abstract class AppLocalizations {
   /// **'Dim Read Posts'**
   String get dimReadPosts;
 
+  /// Title for the private message compose page
+  ///
+  /// In en, this message translates to:
+  /// **'Direct message'**
+  String get directMessage;
+
   /// Action for disabling something
   ///
   /// In en, this message translates to:
@@ -4110,6 +4116,12 @@ abstract class AppLocalizations {
   /// **'Select Language'**
   String get selectLanguage;
 
+  /// Prompt to choose a private message recipient
+  ///
+  /// In en, this message translates to:
+  /// **'Select recipient'**
+  String get selectRecipient;
+
   /// No description provided for @selectSearchType.
   ///
   /// In en, this message translates to:
@@ -4121,6 +4133,12 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'Select Text'**
   String get selectText;
+
+  /// Action to send content
+  ///
+  /// In en, this message translates to:
+  /// **'Send'**
+  String get send;
 
   /// The option to send a background notification for testing
   ///

--- a/lib/l10n/generated/app_localizations_ar.dart
+++ b/lib/l10n/generated/app_localizations_ar.dart
@@ -783,6 +783,9 @@ class AppLocalizationsAr extends AppLocalizations {
   String get dimReadPosts => 'Dim Read Posts';
 
   @override
+  String get directMessage => 'Direct message';
+
+  @override
   String get disable => 'Disable';
 
   @override
@@ -2260,10 +2263,16 @@ class AppLocalizationsAr extends AppLocalizations {
   String get selectLanguage => 'Select Language';
 
   @override
+  String get selectRecipient => 'Select recipient';
+
+  @override
   String get selectSearchType => 'Select Search Type';
 
   @override
   String get selectText => 'Select Text';
+
+  @override
+  String get send => 'Send';
 
   @override
   String get sendBackgroundTestLocalNotification =>

--- a/lib/l10n/generated/app_localizations_be.dart
+++ b/lib/l10n/generated/app_localizations_be.dart
@@ -791,6 +791,9 @@ class AppLocalizationsBe extends AppLocalizations {
   String get dimReadPosts => 'Dim Read Posts';
 
   @override
+  String get directMessage => 'Direct message';
+
+  @override
   String get disable => 'Disable';
 
   @override
@@ -2268,10 +2271,16 @@ class AppLocalizationsBe extends AppLocalizations {
   String get selectLanguage => 'Select Language';
 
   @override
+  String get selectRecipient => 'Select recipient';
+
+  @override
   String get selectSearchType => 'Select Search Type';
 
   @override
   String get selectText => 'Select Text';
+
+  @override
+  String get send => 'Send';
 
   @override
   String get sendBackgroundTestLocalNotification =>

--- a/lib/l10n/generated/app_localizations_cs.dart
+++ b/lib/l10n/generated/app_localizations_cs.dart
@@ -796,6 +796,9 @@ class AppLocalizationsCs extends AppLocalizations {
   String get dimReadPosts => 'Ztmavit Přečtené Příspěvky';
 
   @override
+  String get directMessage => 'Direct message';
+
+  @override
   String get disable => 'Zrušit';
 
   @override
@@ -2266,10 +2269,16 @@ class AppLocalizationsCs extends AppLocalizations {
   String get selectLanguage => 'Vybrat Jazyk';
 
   @override
+  String get selectRecipient => 'Select recipient';
+
+  @override
   String get selectSearchType => 'Vybrat Typ Vyhledávání';
 
   @override
   String get selectText => 'Select Text';
+
+  @override
+  String get send => 'Send';
 
   @override
   String get sendBackgroundTestLocalNotification =>

--- a/lib/l10n/generated/app_localizations_de.dart
+++ b/lib/l10n/generated/app_localizations_de.dart
@@ -801,6 +801,9 @@ class AppLocalizationsDe extends AppLocalizations {
   String get dimReadPosts => 'Gelesene Posts ausgrauen';
 
   @override
+  String get directMessage => 'Direct message';
+
+  @override
   String get disable => 'Deaktivieren';
 
   @override
@@ -2304,10 +2307,16 @@ class AppLocalizationsDe extends AppLocalizations {
   String get selectLanguage => 'Sprache auswählen';
 
   @override
+  String get selectRecipient => 'Select recipient';
+
+  @override
   String get selectSearchType => 'Suchart auswählen';
 
   @override
   String get selectText => 'Text auswählen';
+
+  @override
+  String get send => 'Send';
 
   @override
   String get sendBackgroundTestLocalNotification =>

--- a/lib/l10n/generated/app_localizations_en.dart
+++ b/lib/l10n/generated/app_localizations_en.dart
@@ -791,6 +791,9 @@ class AppLocalizationsEn extends AppLocalizations {
   String get dimReadPosts => 'Dim Read Posts';
 
   @override
+  String get directMessage => 'Direct message';
+
+  @override
   String get disable => 'Disable';
 
   @override
@@ -2268,10 +2271,16 @@ class AppLocalizationsEn extends AppLocalizations {
   String get selectLanguage => 'Select Language';
 
   @override
+  String get selectRecipient => 'Select recipient';
+
+  @override
   String get selectSearchType => 'Select Search Type';
 
   @override
   String get selectText => 'Select Text';
+
+  @override
+  String get send => 'Send';
 
   @override
   String get sendBackgroundTestLocalNotification =>

--- a/lib/l10n/generated/app_localizations_eo.dart
+++ b/lib/l10n/generated/app_localizations_eo.dart
@@ -787,6 +787,9 @@ class AppLocalizationsEo extends AppLocalizations {
   String get dimReadPosts => 'Legitaj afiŝoj estos grizitaj';
 
   @override
+  String get directMessage => 'Direct message';
+
+  @override
   String get disable => 'Malebligi';
 
   @override
@@ -2250,10 +2253,16 @@ class AppLocalizationsEo extends AppLocalizations {
   String get selectLanguage => 'Elekti lingvon';
 
   @override
+  String get selectRecipient => 'Select recipient';
+
+  @override
   String get selectSearchType => 'Elekti Serĉan Tipon';
 
   @override
   String get selectText => 'Select Text';
+
+  @override
+  String get send => 'Send';
 
   @override
   String get sendBackgroundTestLocalNotification =>

--- a/lib/l10n/generated/app_localizations_es.dart
+++ b/lib/l10n/generated/app_localizations_es.dart
@@ -807,6 +807,9 @@ class AppLocalizationsEs extends AppLocalizations {
   String get dimReadPosts => 'Publicaciones de lectura oscura';
 
   @override
+  String get directMessage => 'Direct message';
+
+  @override
   String get disable => 'Desactivar';
 
   @override
@@ -2314,10 +2317,16 @@ class AppLocalizationsEs extends AppLocalizations {
   String get selectLanguage => 'Selecciona el idioma';
 
   @override
+  String get selectRecipient => 'Select recipient';
+
+  @override
   String get selectSearchType => 'Seleccione el tipo de la búsqueda';
 
   @override
   String get selectText => 'Seleccionar el texto';
+
+  @override
+  String get send => 'Send';
 
   @override
   String get sendBackgroundTestLocalNotification =>

--- a/lib/l10n/generated/app_localizations_fi.dart
+++ b/lib/l10n/generated/app_localizations_fi.dart
@@ -788,6 +788,9 @@ class AppLocalizationsFi extends AppLocalizations {
   String get dimReadPosts => 'Luetut postaukset näkyvät tummennettuina';
 
   @override
+  String get directMessage => 'Direct message';
+
+  @override
   String get disable => 'Disable';
 
   @override
@@ -2254,10 +2257,16 @@ class AppLocalizationsFi extends AppLocalizations {
   String get selectLanguage => 'Valitse kieli';
 
   @override
+  String get selectRecipient => 'Select recipient';
+
+  @override
   String get selectSearchType => 'Valitse Hakulaji';
 
   @override
   String get selectText => 'Select Text';
+
+  @override
+  String get send => 'Send';
 
   @override
   String get sendBackgroundTestLocalNotification =>

--- a/lib/l10n/generated/app_localizations_fr.dart
+++ b/lib/l10n/generated/app_localizations_fr.dart
@@ -811,6 +811,9 @@ class AppLocalizationsFr extends AppLocalizations {
   String get dimReadPosts => 'Griser les publications lues.';
 
   @override
+  String get directMessage => 'Direct message';
+
+  @override
   String get disable => 'Désactiver';
 
   @override
@@ -2295,10 +2298,16 @@ class AppLocalizationsFr extends AppLocalizations {
   String get selectLanguage => 'Sélectionner la langue';
 
   @override
+  String get selectRecipient => 'Select recipient';
+
+  @override
   String get selectSearchType => 'Sélectionner le type de recherche';
 
   @override
   String get selectText => 'Select Text';
+
+  @override
+  String get send => 'Send';
 
   @override
   String get sendBackgroundTestLocalNotification =>

--- a/lib/l10n/generated/app_localizations_hu.dart
+++ b/lib/l10n/generated/app_localizations_hu.dart
@@ -791,6 +791,9 @@ class AppLocalizationsHu extends AppLocalizations {
   String get dimReadPosts => 'Dim Read Posts';
 
   @override
+  String get directMessage => 'Direct message';
+
+  @override
   String get disable => 'Disable';
 
   @override
@@ -2268,10 +2271,16 @@ class AppLocalizationsHu extends AppLocalizations {
   String get selectLanguage => 'Select Language';
 
   @override
+  String get selectRecipient => 'Select recipient';
+
+  @override
   String get selectSearchType => 'Select Search Type';
 
   @override
   String get selectText => 'Select Text';
+
+  @override
+  String get send => 'Send';
 
   @override
   String get sendBackgroundTestLocalNotification =>

--- a/lib/l10n/generated/app_localizations_it.dart
+++ b/lib/l10n/generated/app_localizations_it.dart
@@ -794,6 +794,9 @@ class AppLocalizationsIt extends AppLocalizations {
   String get dimReadPosts => 'Sbiadisci Post Letti';
 
   @override
+  String get directMessage => 'Direct message';
+
+  @override
   String get disable => 'Disabilita';
 
   @override
@@ -2266,10 +2269,16 @@ class AppLocalizationsIt extends AppLocalizations {
   String get selectLanguage => 'Seleziona lingua';
 
   @override
+  String get selectRecipient => 'Select recipient';
+
+  @override
   String get selectSearchType => 'Seleziona Tipo di Ricerca';
 
   @override
   String get selectText => 'Seleziona Testo';
+
+  @override
+  String get send => 'Send';
 
   @override
   String get sendBackgroundTestLocalNotification =>

--- a/lib/l10n/generated/app_localizations_nb.dart
+++ b/lib/l10n/generated/app_localizations_nb.dart
@@ -786,6 +786,9 @@ class AppLocalizationsNb extends AppLocalizations {
   String get dimReadPosts => 'Dim Read Posts';
 
   @override
+  String get directMessage => 'Direct message';
+
+  @override
   String get disable => 'Disable';
 
   @override
@@ -2251,10 +2254,16 @@ class AppLocalizationsNb extends AppLocalizations {
   String get selectLanguage => 'Select Language';
 
   @override
+  String get selectRecipient => 'Select recipient';
+
+  @override
   String get selectSearchType => 'Select Search Type';
 
   @override
   String get selectText => 'Select Text';
+
+  @override
+  String get send => 'Send';
 
   @override
   String get sendBackgroundTestLocalNotification =>

--- a/lib/l10n/generated/app_localizations_nl.dart
+++ b/lib/l10n/generated/app_localizations_nl.dart
@@ -797,6 +797,9 @@ class AppLocalizationsNl extends AppLocalizations {
   String get dimReadPosts => 'Gelezen berichten dimmen';
 
   @override
+  String get directMessage => 'Direct message';
+
+  @override
   String get disable => 'Uitschakelen';
 
   @override
@@ -2291,10 +2294,16 @@ class AppLocalizationsNl extends AppLocalizations {
   String get selectLanguage => 'Taal selecteren';
 
   @override
+  String get selectRecipient => 'Select recipient';
+
+  @override
   String get selectSearchType => 'Selecteer zoektype';
 
   @override
   String get selectText => 'Tekst selecteren';
+
+  @override
+  String get send => 'Send';
 
   @override
   String get sendBackgroundTestLocalNotification =>

--- a/lib/l10n/generated/app_localizations_pl.dart
+++ b/lib/l10n/generated/app_localizations_pl.dart
@@ -799,6 +799,9 @@ class AppLocalizationsPl extends AppLocalizations {
   String get dimReadPosts => 'Przyciemnij Przeczytane Wpisy';
 
   @override
+  String get directMessage => 'Direct message';
+
+  @override
   String get disable => 'Wyłącz';
 
   @override
@@ -2269,10 +2272,16 @@ class AppLocalizationsPl extends AppLocalizations {
   String get selectLanguage => 'Wybierz język';
 
   @override
+  String get selectRecipient => 'Select recipient';
+
+  @override
   String get selectSearchType => 'Wybierz Typ Wyszukiwania';
 
   @override
   String get selectText => 'Select Text';
+
+  @override
+  String get send => 'Send';
 
   @override
   String get sendBackgroundTestLocalNotification =>

--- a/lib/l10n/generated/app_localizations_ps.dart
+++ b/lib/l10n/generated/app_localizations_ps.dart
@@ -792,6 +792,9 @@ class AppLocalizationsPs extends AppLocalizations {
   String get dimReadPosts => 'Dim Read Posts';
 
   @override
+  String get directMessage => 'Direct message';
+
+  @override
   String get disable => 'Disable';
 
   @override
@@ -2269,10 +2272,16 @@ class AppLocalizationsPs extends AppLocalizations {
   String get selectLanguage => 'Select Language';
 
   @override
+  String get selectRecipient => 'Select recipient';
+
+  @override
   String get selectSearchType => 'Select Search Type';
 
   @override
   String get selectText => 'Select Text';
+
+  @override
+  String get send => 'Send';
 
   @override
   String get sendBackgroundTestLocalNotification =>

--- a/lib/l10n/generated/app_localizations_pt.dart
+++ b/lib/l10n/generated/app_localizations_pt.dart
@@ -800,6 +800,9 @@ class AppLocalizationsPt extends AppLocalizations {
   String get dimReadPosts => 'Dim Read Posts';
 
   @override
+  String get directMessage => 'Direct message';
+
+  @override
   String get disable => 'Disable';
 
   @override
@@ -2277,10 +2280,16 @@ class AppLocalizationsPt extends AppLocalizations {
   String get selectLanguage => 'Select Language';
 
   @override
+  String get selectRecipient => 'Select recipient';
+
+  @override
   String get selectSearchType => 'Select Search Type';
 
   @override
   String get selectText => 'Select Text';
+
+  @override
+  String get send => 'Send';
 
   @override
   String get sendBackgroundTestLocalNotification =>

--- a/lib/l10n/generated/app_localizations_ru.dart
+++ b/lib/l10n/generated/app_localizations_ru.dart
@@ -801,6 +801,9 @@ class AppLocalizationsRu extends AppLocalizations {
       'Прочитанные сообщения будут выделены серым цветом';
 
   @override
+  String get directMessage => 'Direct message';
+
+  @override
   String get disable => 'Отключить';
 
   @override
@@ -2268,10 +2271,16 @@ class AppLocalizationsRu extends AppLocalizations {
   String get selectLanguage => 'Выберите язык';
 
   @override
+  String get selectRecipient => 'Select recipient';
+
+  @override
   String get selectSearchType => 'Выберите тип поиска';
 
   @override
   String get selectText => 'Select Text';
+
+  @override
+  String get send => 'Send';
 
   @override
   String get sendBackgroundTestLocalNotification =>

--- a/lib/l10n/generated/app_localizations_sk.dart
+++ b/lib/l10n/generated/app_localizations_sk.dart
@@ -796,6 +796,9 @@ class AppLocalizationsSk extends AppLocalizations {
   String get dimReadPosts => 'Stmaviť prečítané príspevky';
 
   @override
+  String get directMessage => 'Direct message';
+
+  @override
   String get disable => 'Zakázať';
 
   @override
@@ -2269,10 +2272,16 @@ class AppLocalizationsSk extends AppLocalizations {
   String get selectLanguage => 'Vybrať jazyk';
 
   @override
+  String get selectRecipient => 'Select recipient';
+
+  @override
   String get selectSearchType => 'Vybrať typ vyhľadávania';
 
   @override
   String get selectText => 'Select Text';
+
+  @override
+  String get send => 'Send';
 
   @override
   String get sendBackgroundTestLocalNotification =>

--- a/lib/l10n/generated/app_localizations_sv.dart
+++ b/lib/l10n/generated/app_localizations_sv.dart
@@ -792,6 +792,9 @@ class AppLocalizationsSv extends AppLocalizations {
   String get dimReadPosts => 'Dim Read Posts';
 
   @override
+  String get directMessage => 'Direct message';
+
+  @override
   String get disable => 'Disable';
 
   @override
@@ -2262,10 +2265,16 @@ class AppLocalizationsSv extends AppLocalizations {
   String get selectLanguage => 'Select Language';
 
   @override
+  String get selectRecipient => 'Select recipient';
+
+  @override
   String get selectSearchType => 'Välj Söktyp';
 
   @override
   String get selectText => 'Select Text';
+
+  @override
+  String get send => 'Send';
 
   @override
   String get sendBackgroundTestLocalNotification =>

--- a/lib/l10n/generated/app_localizations_ta.dart
+++ b/lib/l10n/generated/app_localizations_ta.dart
@@ -803,6 +803,9 @@ class AppLocalizationsTa extends AppLocalizations {
   String get dimReadPosts => 'மங்கலான இடுகைகள்';
 
   @override
+  String get directMessage => 'Direct message';
+
+  @override
   String get disable => 'முடக்கு';
 
   @override
@@ -2308,10 +2311,16 @@ class AppLocalizationsTa extends AppLocalizations {
   String get selectLanguage => 'மொழியைத் தேர்ந்தெடுக்கவும்';
 
   @override
+  String get selectRecipient => 'Select recipient';
+
+  @override
   String get selectSearchType => 'தேடல் வகையைத் தேர்ந்தெடுக்கவும்';
 
   @override
   String get selectText => 'உரையைத் தேர்ந்தெடுக்கவும்';
+
+  @override
+  String get send => 'Send';
 
   @override
   String get sendBackgroundTestLocalNotification =>

--- a/lib/l10n/generated/app_localizations_tr.dart
+++ b/lib/l10n/generated/app_localizations_tr.dart
@@ -795,6 +795,9 @@ class AppLocalizationsTr extends AppLocalizations {
   String get dimReadPosts => 'Okunmuş Gönderileri Soluklaştır';
 
   @override
+  String get directMessage => 'Direct message';
+
+  @override
   String get disable => 'Devre Dışı Bırak';
 
   @override
@@ -2277,10 +2280,16 @@ class AppLocalizationsTr extends AppLocalizations {
   String get selectLanguage => 'Dil Seç';
 
   @override
+  String get selectRecipient => 'Select recipient';
+
+  @override
   String get selectSearchType => 'Arama Türünü Seç';
 
   @override
   String get selectText => 'Metni Seç';
+
+  @override
+  String get send => 'Send';
 
   @override
   String get sendBackgroundTestLocalNotification =>

--- a/lib/l10n/generated/app_localizations_uk.dart
+++ b/lib/l10n/generated/app_localizations_uk.dart
@@ -793,6 +793,9 @@ class AppLocalizationsUk extends AppLocalizations {
   String get dimReadPosts => 'Dim Read Posts';
 
   @override
+  String get directMessage => 'Direct message';
+
+  @override
   String get disable => 'Disable';
 
   @override
@@ -2264,10 +2267,16 @@ class AppLocalizationsUk extends AppLocalizations {
   String get selectLanguage => 'Select Language';
 
   @override
+  String get selectRecipient => 'Select recipient';
+
+  @override
   String get selectSearchType => 'Виберіть тип пошуку';
 
   @override
   String get selectText => 'Select Text';
+
+  @override
+  String get send => 'Send';
 
   @override
   String get sendBackgroundTestLocalNotification =>

--- a/lib/l10n/generated/app_localizations_zh.dart
+++ b/lib/l10n/generated/app_localizations_zh.dart
@@ -791,6 +791,9 @@ class AppLocalizationsZh extends AppLocalizations {
   String get dimReadPosts => 'Dim Read Posts';
 
   @override
+  String get directMessage => 'Direct message';
+
+  @override
   String get disable => 'Disable';
 
   @override
@@ -2268,10 +2271,16 @@ class AppLocalizationsZh extends AppLocalizations {
   String get selectLanguage => 'Select Language';
 
   @override
+  String get selectRecipient => 'Select recipient';
+
+  @override
   String get selectSearchType => 'Select Search Type';
 
   @override
   String get selectText => 'Select Text';
+
+  @override
+  String get send => 'Send';
 
   @override
   String get sendBackgroundTestLocalNotification =>

--- a/lib/src/app/shell/navigation/navigation_private_message.dart
+++ b/lib/src/app/shell/navigation/navigation_private_message.dart
@@ -1,0 +1,115 @@
+import 'dart:io';
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+
+import 'package:flutter_bloc/flutter_bloc.dart';
+
+import 'package:thunder/packages/ui/ui.dart';
+import 'package:thunder/src/app/shell/navigation/loading_page.dart';
+import 'package:thunder/src/app/shell/navigation/navigation_utils.dart';
+import 'package:thunder/src/app/shell/navigation/swipeable_page_route.dart';
+import 'package:thunder/src/app/wiring/state_factories.dart';
+import 'package:thunder/src/features/private_message/presentation/pages/create_private_message_page.dart';
+import 'package:thunder/src/features/private_message/presentation/pages/private_message_thread_page.dart';
+import 'package:thunder/src/features/private_message/presentation/state/create_private_message_cubit.dart';
+import 'package:thunder/src/features/private_message/presentation/state/private_message_thread_cubit.dart';
+import 'package:thunder/src/features/settings/api.dart';
+import 'package:thunder/src/foundation/contracts/contracts.dart';
+import 'package:thunder/src/foundation/primitives/primitives.dart';
+
+/// Opens the full direct-message editor and returns the sent message, if any.
+Future<ThunderPrivateMessage?> navigateToCreatePrivateMessagePage(
+  BuildContext context, {
+  Account? account,
+  ThunderUser? recipient,
+  String? initialContent,
+  void Function(ThunderPrivateMessage message)? onMessageSent,
+}) async {
+  try {
+    final routeScope = resolveAccountAwareRouteScope(context, account: account, includeThunderCubit: true);
+    final effectiveAccount = routeScope.account;
+    final createPrivateMessageCubit = createCreatePrivateMessageCubit(effectiveAccount);
+    final themeCubit = context.read<ThemePreferencesCubit>();
+    final gestureCubit = context.read<GesturePreferencesCubit>();
+    final reduceAnimations = themeCubit.state.reduceAnimations;
+    final enableFullScreenSwipeNavigationGesture = gestureCubit.state.enableFullScreenSwipeNavigationGesture;
+
+    final route = SwipeablePageRoute(
+      transitionDuration: isLoadingPageShown
+          ? Duration.zero
+          : reduceAnimations
+              ? const Duration(milliseconds: 100)
+              : null,
+      reverseTransitionDuration: reduceAnimations ? const Duration(milliseconds: 100) : const Duration(milliseconds: 500),
+      canSwipe: !kIsWeb && Platform.isIOS || enableFullScreenSwipeNavigationGesture,
+      canOnlySwipeFromEdge: true,
+      builder: (context) => MultiBlocProvider(
+        providers: routeScope.providers(
+          provideThunderCubit: true,
+          extraProviders: [
+            BlocProvider<CreatePrivateMessageCubit>.value(value: createPrivateMessageCubit),
+          ],
+        ),
+        child: CreatePrivateMessagePage(
+          account: effectiveAccount,
+          recipient: recipient,
+          initialContent: initialContent,
+          onMessageSent: onMessageSent,
+        ),
+      ),
+    );
+
+    final result = await pushOnTopOfLoadingPage(context, route);
+    if (result is ThunderPrivateMessage) return result;
+  } catch (e) {
+    showSnackbar(e.toString());
+  }
+
+  return null;
+}
+
+/// Opens a direct-message thread with [participant].
+Future<void> navigateToPrivateMessageThreadPage(
+  BuildContext context, {
+  Account? account,
+  required ThunderUser participant,
+  List<ThunderPrivateMessage> initialMessages = const <ThunderPrivateMessage>[],
+  int? conversationId,
+  ValueChanged<List<ThunderPrivateMessage>>? onThreadUpdated,
+}) async {
+  final routeScope = resolveAccountAwareRouteScope(context, account: account, includeThunderCubit: true);
+  final effectiveAccount = routeScope.account;
+  final threadCubit = createPrivateMessageThreadCubit(
+    effectiveAccount,
+    participant: participant,
+    initialMessages: initialMessages,
+    conversationId: conversationId,
+  );
+  final themeCubit = context.read<ThemePreferencesCubit>();
+  final gestureCubit = context.read<GesturePreferencesCubit>();
+  final reduceAnimations = themeCubit.state.reduceAnimations;
+  final enableFullScreenSwipeNavigationGesture = gestureCubit.state.enableFullScreenSwipeNavigationGesture;
+
+  await Navigator.of(context).push(
+    SwipeablePageRoute(
+      transitionDuration: reduceAnimations ? const Duration(milliseconds: 100) : null,
+      canSwipe: !kIsWeb && Platform.isIOS || enableFullScreenSwipeNavigationGesture,
+      canOnlySwipeFromEdge: true,
+      backGestureDetectionWidth: 45,
+      builder: (context) => MultiBlocProvider(
+        providers: routeScope.providers(
+          provideThunderCubit: true,
+          extraProviders: [
+            BlocProvider<PrivateMessageThreadCubit>.value(value: threadCubit),
+          ],
+        ),
+        child: PrivateMessageThreadPage(
+          account: effectiveAccount,
+          participant: participant,
+          onThreadUpdated: onThreadUpdated,
+        ),
+      ),
+    ),
+  );
+}

--- a/lib/src/app/wiring/state_factories.dart
+++ b/lib/src/app/wiring/state_factories.dart
@@ -16,6 +16,7 @@ import 'package:thunder/src/features/instance/api.dart';
 import 'package:thunder/src/features/moderator/api.dart';
 import 'package:thunder/src/features/notification/api.dart';
 import 'package:thunder/src/features/post/api.dart';
+import 'package:thunder/src/features/private_message/api.dart';
 import 'package:thunder/src/features/search/api.dart';
 import 'package:thunder/src/features/session/api.dart';
 import 'package:thunder/src/features/user/api.dart';
@@ -162,6 +163,30 @@ CreateCommentCubit createCreateCommentCubit(Account account) {
     commentRepositoryFactory: (account) => CommentRepositoryImpl(account: account),
     accountRepositoryFactory: (account) => AccountRepositoryImpl(account: account),
     localizationService: const GlobalContextLocalizationService(),
+  );
+}
+
+CreatePrivateMessageCubit createCreatePrivateMessageCubit(Account account) {
+  return CreatePrivateMessageCubit(
+    account: account,
+    privateMessageRepository: (account) => PrivateMessageRepositoryImpl(account: account),
+    searchRepository: (account) => SearchRepositoryImpl(account: account),
+    localizationService: const GlobalContextLocalizationService(),
+  );
+}
+
+PrivateMessageThreadCubit createPrivateMessageThreadCubit(
+  Account account, {
+  required ThunderUser participant,
+  List<ThunderPrivateMessage> initialMessages = const <ThunderPrivateMessage>[],
+  int? conversationId,
+}) {
+  return PrivateMessageThreadCubit(
+    account: account,
+    participant: participant,
+    repository: PrivateMessageRepositoryImpl(account: account),
+    initialMessages: initialMessages,
+    conversationId: conversationId,
   );
 }
 

--- a/lib/src/features/inbox/presentation/pages/inbox_page.dart
+++ b/lib/src/features/inbox/presentation/pages/inbox_page.dart
@@ -3,6 +3,7 @@ import 'package:flutter/services.dart';
 
 import 'package:flutter_bloc/flutter_bloc.dart';
 
+import 'package:thunder/src/app/shell/navigation/navigation_private_message.dart';
 import 'package:thunder/src/features/account/account.dart';
 import 'package:thunder/src/foundation/primitives/primitives.dart';
 import 'package:thunder/src/features/inbox/inbox.dart';
@@ -86,11 +87,28 @@ class _InboxPageState extends State<InboxPage> with SingleTickerProviderStateMix
     );
   }
 
+  Future<void> _openPrivateMessageComposer() async {
+    final account = context.read<InboxBloc>().account;
+    final message = await navigateToCreatePrivateMessagePage(context, account: account);
+    if (!mounted || message == null) return;
+
+    final inboxBloc = context.read<InboxBloc>();
+    if (inboxBloc.account.id != account.id) return;
+
+    inboxBloc.add(InboxPrivateMessageSentEvent(message));
+  }
+
   @override
   Widget build(BuildContext context) {
     final l10n = GlobalContext.l10n;
 
     return Scaffold(
+      floatingActionButton: inboxType == InboxType.messages
+          ? FloatingActionButton(
+              onPressed: _openPrivateMessageComposer,
+              child: Icon(Icons.mail_rounded, semanticLabel: l10n.directMessage),
+            )
+          : null,
       body: BlocConsumer<InboxBloc, InboxState>(
         listener: (context, state) {
           if (state.status == InboxStatus.initial || state.status == InboxStatus.loading || state.status == InboxStatus.empty) {
@@ -171,6 +189,7 @@ class _InboxPageState extends State<InboxPage> with SingleTickerProviderStateMix
                     bottom: TabBar(
                       controller: tabController,
                       onTap: (index) {
+                        setState(() {});
                         context.read<InboxBloc>().add(GetInboxEvent(inboxType: inboxType, reset: true, showAll: showAll));
                       },
                       tabs: [

--- a/lib/src/features/inbox/presentation/state/inbox_bloc.dart
+++ b/lib/src/features/inbox/presentation/state/inbox_bloc.dart
@@ -9,6 +9,7 @@ import 'package:thunder/src/foundation/errors/errors.dart';
 import 'package:thunder/src/features/comment/comment.dart';
 import 'package:thunder/src/features/inbox/inbox.dart';
 import 'package:thunder/src/features/notification/notification.dart';
+import 'package:thunder/src/features/private_message/domain/utils/private_message_thread_utils.dart';
 
 part 'inbox_event.dart';
 part 'inbox_state.dart';
@@ -54,7 +55,43 @@ class InboxBloc extends Bloc<InboxEvent, InboxState> {
   void _init() {
     on<GetInboxEvent>(_getInboxEvent, transformer: restartable());
     on<InboxItemActionEvent>(_inboxItemActionEvent);
+    on<InboxPrivateMessageSentEvent>(_privateMessageSent);
+    on<InboxPrivateMessageThreadUpdatedEvent>(_privateMessageThreadUpdated);
     on<MarkAllAsReadEvent>(_markAllAsRead);
+  }
+
+  void _privateMessageSent(InboxPrivateMessageSentEvent event, Emitter<InboxState> emit) {
+    _upsertPrivateMessages([event.privateMessage], emit);
+  }
+
+  void _privateMessageThreadUpdated(InboxPrivateMessageThreadUpdatedEvent event, Emitter<InboxState> emit) {
+    _upsertPrivateMessages(event.privateMessages, emit);
+  }
+
+  void _upsertPrivateMessages(List<ThunderPrivateMessage> privateMessages, Emitter<InboxState> emit) {
+    if (privateMessages.isEmpty) return;
+
+    final updatedIds = privateMessages.map((privateMessage) => privateMessage.id).toSet();
+    final previousThreadUnreadCount = _privateMessageUnreadCount(state.privateMessages.where((privateMessage) => updatedIds.contains(privateMessage.id)));
+    final nextThreadUnreadCount = _privateMessageUnreadCount(privateMessages);
+    final unreadDelta = nextThreadUnreadCount - previousThreadUnreadCount;
+    final updatedPrivateMessages = [
+      ...privateMessages,
+      ...state.privateMessages.where((privateMessage) => !updatedIds.contains(privateMessage.id)),
+    ]..sort((a, b) => b.published.compareTo(a.published));
+
+    emit(state.copyWith(
+      status: InboxStatus.success,
+      privateMessages: cleanDeletedMessages(updatedPrivateMessages),
+      totalUnreadCount: (state.totalUnreadCount + unreadDelta).clamp(0, 1 << 31),
+      messagesUnreadCount: (state.messagesUnreadCount + unreadDelta).clamp(0, 1 << 31),
+      errorMessage: null,
+      errorReason: null,
+    ));
+  }
+
+  int _privateMessageUnreadCount(Iterable<ThunderPrivateMessage> privateMessages) {
+    return privateMessages.where((privateMessage) => !privateMessage.read && isIncomingPrivateMessage(privateMessage, account)).length;
   }
 
   Future<void> _getInboxEvent(GetInboxEvent event, emit) async {
@@ -108,7 +145,7 @@ class InboxBloc extends Bloc<InboxEvent, InboxState> {
             break;
           case InboxType.messages:
             privateMessagesResponse = await notificationRepository.messages(
-              unread: !event.showAll,
+              unread: false,
               limit: limit,
               page: 1,
             );
@@ -129,7 +166,7 @@ class InboxBloc extends Bloc<InboxEvent, InboxState> {
             );
 
             privateMessagesResponse = await notificationRepository.messages(
-              unread: !event.showAll,
+              unread: false,
               limit: limit,
               page: 1,
             );
@@ -194,7 +231,7 @@ class InboxBloc extends Bloc<InboxEvent, InboxState> {
         case InboxType.messages:
           if (state.hasReachedInboxPrivateMessageEnd) return;
           privateMessagesResponse = await notificationRepository.messages(
-            unread: state.showUnreadOnly,
+            unread: false,
             limit: limit,
             page: state.inboxPrivateMessagePage,
           );
@@ -341,11 +378,7 @@ class InboxBloc extends Bloc<InboxEvent, InboxState> {
               updatedMentions.removeAt(existingMentionIndex);
             }
           } else if (existingPrivateMessageView != null && existingPrivateMessageIndex != -1) {
-            if (!state.showUnreadOnly) {
-              updatedPrivateMessages[existingPrivateMessageIndex] = existingPrivateMessageView.copyWith(read: value);
-            } else if (value) {
-              updatedPrivateMessages.removeAt(existingPrivateMessageIndex);
-            }
+            updatedPrivateMessages[existingPrivateMessageIndex] = existingPrivateMessageView.copyWith(read: value);
           }
 
           if (existingCommentReplyView != null) {
@@ -571,7 +604,7 @@ class InboxBloc extends Bloc<InboxEvent, InboxState> {
         status: InboxStatus.success,
         replies: state.showUnreadOnly ? [] : updatedReplies,
         mentions: state.showUnreadOnly ? [] : updatedMentions,
-        privateMessages: state.showUnreadOnly ? [] : updatedPrivateMessages,
+        privateMessages: updatedPrivateMessages,
         totalUnreadCount: 0,
         repliesUnreadCount: 0,
         mentionsUnreadCount: 0,

--- a/lib/src/features/inbox/presentation/state/inbox_event.dart
+++ b/lib/src/features/inbox/presentation/state/inbox_event.dart
@@ -97,4 +97,26 @@ class InboxItemActionEvent extends InboxEvent {
   List<Object?> get props => [action, commentReplyId, personMentionId, privateMessageId, actionInput];
 }
 
+/// Adds or updates a sent private message in the current inbox state.
+class InboxPrivateMessageSentEvent extends InboxEvent {
+  const InboxPrivateMessageSentEvent(this.privateMessage);
+
+  /// The private message returned by the compose flow.
+  final ThunderPrivateMessage privateMessage;
+
+  @override
+  List<Object?> get props => [privateMessage];
+}
+
+/// Reconciles the inbox with the latest local state for an opened thread.
+class InboxPrivateMessageThreadUpdatedEvent extends InboxEvent {
+  const InboxPrivateMessageThreadUpdatedEvent(this.privateMessages);
+
+  /// Messages returned by the direct-message thread route.
+  final List<ThunderPrivateMessage> privateMessages;
+
+  @override
+  List<Object?> get props => [privateMessages];
+}
+
 class MarkAllAsReadEvent extends InboxEvent {}

--- a/lib/src/features/inbox/presentation/widgets/inbox_private_message_thread_tile.dart
+++ b/lib/src/features/inbox/presentation/widgets/inbox_private_message_thread_tile.dart
@@ -1,0 +1,83 @@
+import 'package:flutter/material.dart';
+
+import 'package:flutter_bloc/flutter_bloc.dart';
+
+import 'package:thunder/src/app/shell/navigation/navigation_private_message.dart';
+import 'package:thunder/src/features/inbox/presentation/state/inbox_bloc.dart';
+import 'package:thunder/src/features/private_message/domain/models/private_message_thread.dart';
+import 'package:thunder/src/foundation/contracts/contracts.dart';
+import 'package:thunder/src/foundation/utils/utils.dart';
+import 'package:thunder/src/features/instance/domain/utils/instance_link_utils.dart';
+import 'package:thunder/src/shared/avatars/user_avatar.dart';
+import 'package:thunder/src/shared/name/full_name_widgets.dart';
+
+/// List row for a grouped direct-message thread in the inbox.
+class InboxPrivateMessageThreadTile extends StatelessWidget {
+  /// Creates a direct-message thread row.
+  const InboxPrivateMessageThreadTile({
+    super.key,
+    required this.account,
+    required this.thread,
+  });
+
+  /// Account that owns the inbox.
+  final Account account;
+
+  /// Grouped thread summary to display.
+  final PrivateMessageThread thread;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final participant = thread.participant;
+
+    return ListTile(
+      key: ValueKey<String>(participant.actorId),
+      leading: UserAvatar(user: participant, radius: 24.0),
+      title: Row(
+        mainAxisAlignment: MainAxisAlignment.spaceBetween,
+        children: [
+          Expanded(
+            child: UserFullNameWidget(
+              name: participant.name,
+              displayName: participant.displayName,
+              instance: fetchInstanceNameFromUrl(participant.actorId),
+              includeInstance: true,
+            ),
+          ),
+          Text(
+            formatTimeToString(dateTime: thread.latestMessage.published.toIso8601String()),
+            style: theme.textTheme.labelSmall,
+          ),
+        ],
+      ),
+      subtitle: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          const SizedBox(height: 2.0),
+          Text(
+            thread.latestMessage.content.replaceAll('\n', ' '),
+            maxLines: 2,
+            overflow: TextOverflow.ellipsis,
+            style: thread.unreadCount > 0
+                ? theme.textTheme.bodyMedium?.copyWith(fontWeight: FontWeight.w500)
+                : theme.textTheme.bodyMedium?.copyWith(color: theme.colorScheme.onSurface.withValues(alpha: 0.5)),
+          ),
+        ],
+      ),
+      onTap: () {
+        navigateToPrivateMessageThreadPage(
+          context,
+          account: account,
+          participant: participant,
+          initialMessages: thread.messages,
+          conversationId: thread.conversationId,
+          onThreadUpdated: (messages) {
+            if (!context.mounted) return;
+            context.read<InboxBloc>().add(InboxPrivateMessageThreadUpdatedEvent(messages));
+          },
+        );
+      },
+    );
+  }
+}

--- a/lib/src/features/inbox/presentation/widgets/inbox_private_messages_view.dart
+++ b/lib/src/features/inbox/presentation/widgets/inbox_private_messages_view.dart
@@ -2,33 +2,26 @@ import 'package:flutter/material.dart';
 
 import 'package:flutter_bloc/flutter_bloc.dart';
 
-import 'package:thunder/l10n/generated/app_localizations.dart';
-import 'package:thunder/src/foundation/primitives/primitives.dart';
-import 'package:thunder/src/features/comment/comment.dart';
-import 'package:thunder/src/features/feed/feed.dart';
 import 'package:thunder/src/features/inbox/inbox.dart';
-import 'package:thunder/src/shared/markdown/common_markdown_body.dart';
-import 'package:thunder/src/shared/name/full_name_widgets.dart';
-import 'package:thunder/src/foundation/utils/utils.dart';
-import 'package:thunder/src/features/instance/domain/utils/instance_link_utils.dart';
-import 'package:thunder/packages/ui/ui.dart' show ThunderDivider;
+import 'package:thunder/src/features/inbox/presentation/widgets/inbox_private_message_thread_tile.dart';
+import 'package:thunder/src/features/private_message/domain/utils/private_message_thread_utils.dart';
+import 'package:thunder/src/foundation/config/global_context.dart';
 
-class InboxPrivateMessagesView extends StatefulWidget {
-  final List<ThunderPrivateMessage> privateMessages;
-
+/// Displays direct messages grouped into participant threads.
+class InboxPrivateMessagesView extends StatelessWidget {
+  /// Creates a direct-message inbox view.
   const InboxPrivateMessagesView({super.key, this.privateMessages = const []});
 
-  @override
-  State<InboxPrivateMessagesView> createState() => _InboxPrivateMessagesViewState();
-}
+  /// Private messages loaded for the inbox.
+  final List<ThunderPrivateMessage> privateMessages;
 
-class _InboxPrivateMessagesViewState extends State<InboxPrivateMessagesView> {
   @override
   Widget build(BuildContext context) {
-    final l10n = AppLocalizations.of(context)!;
-    final theme = Theme.of(context);
-    final state = context.read<InboxBloc>().state;
-    final textStyle = theme.textTheme.bodyMedium;
+    final l10n = GlobalContext.l10n;
+
+    final inboxBloc = context.read<InboxBloc>();
+    final state = inboxBloc.state;
+    final threads = groupPrivateMessagesByParticipant(privateMessages, inboxBloc.account);
 
     return Builder(builder: (context) {
       return CustomScrollView(
@@ -40,82 +33,22 @@ class _InboxPrivateMessagesViewState extends State<InboxPrivateMessagesView> {
               hasScrollBody: false,
               child: Center(child: CircularProgressIndicator()),
             ),
-          if (state.status != InboxStatus.loading && widget.privateMessages.isEmpty)
+          if (state.status != InboxStatus.loading && threads.isEmpty)
             SliverFillRemaining(
               hasScrollBody: false,
               child: Center(child: Text(l10n.noMessages)),
             ),
           SliverList.builder(
-            itemCount: widget.privateMessages.length,
+            itemCount: threads.length,
             itemBuilder: (context, index) {
-              return Card(
-                key: ValueKey<int>(widget.privateMessages[index].id),
-                child: Padding(
-                  padding: const EdgeInsets.symmetric(horizontal: 12.0, vertical: 12.0),
-                  child: Column(
-                    crossAxisAlignment: CrossAxisAlignment.start,
-                    children: [
-                      Row(
-                        crossAxisAlignment: CrossAxisAlignment.start,
-                        children: [
-                          Expanded(
-                            child: Wrap(
-                              crossAxisAlignment: WrapCrossAlignment.center,
-                              children: [
-                                UserFullNameWidget(
-                                    name: widget.privateMessages[index].creator?.name,
-                                    displayName: widget.privateMessages[index].creator?.displayName,
-                                    instance: fetchInstanceNameFromUrl(widget.privateMessages[index].creator?.actorId),
-                                    includeInstance: true),
-                                const Padding(
-                                  padding: EdgeInsets.symmetric(horizontal: 8.0),
-                                  child: Icon(Icons.arrow_forward_rounded, size: 14),
-                                ),
-                                UserFullNameWidget(
-                                    name: widget.privateMessages[index].recipient?.name,
-                                    displayName: widget.privateMessages[index].recipient?.displayName,
-                                    instance: fetchInstanceNameFromUrl(widget.privateMessages[index].recipient?.actorId),
-                                    includeInstance: true),
-                              ],
-                            ),
-                          ),
-                          Text(
-                            formatTimeToString(dateTime: widget.privateMessages[index].published.toIso8601String()),
-                            style: textStyle!.copyWith(fontSize: MediaQuery.textScalerOf(context).scale((textStyle.fontSize!) * (FontScale.base.textScaleFactor))),
-                          )
-                        ],
-                      ),
-                      Padding(
-                        padding: const EdgeInsets.symmetric(vertical: 10.0),
-                        child: CommonMarkdownBody(body: widget.privateMessages[index].content),
-                      ),
-                      ThunderDivider(sliver: false, padding: false),
-                      Align(
-                        alignment: Alignment.centerRight,
-                        child: IconButton(
-                          visualDensity: VisualDensity.compact,
-                          onPressed: () => context.read<InboxBloc>().add(
-                                InboxItemActionEvent(
-                                  action: CommentAction.read,
-                                  privateMessageId: widget.privateMessages[index].id,
-                                  actionInput: ReadInboxActionInput(!widget.privateMessages[index].read),
-                                ),
-                              ),
-                          icon: Icon(
-                            Icons.check,
-                            semanticLabel: l10n.markAsRead,
-                            color: widget.privateMessages[index].read ? Colors.green : null,
-                          ),
-                        ),
-                      ),
-                    ],
-                  ),
-                ),
+              final thread = threads[index];
+              return InboxPrivateMessageThreadTile(
+                account: inboxBloc.account,
+                thread: thread,
               );
             },
           ),
-          if (state.hasReachedInboxMentionEnd && widget.privateMessages.isNotEmpty) const SliverToBoxAdapter(child: FeedReachedEnd()),
-          if (widget.privateMessages.isNotEmpty)
+          if (threads.isNotEmpty)
             SliverToBoxAdapter(
               child: SizedBox(height: kBottomNavigationBarHeight),
             )

--- a/lib/src/features/private_message/api.dart
+++ b/lib/src/features/private_message/api.dart
@@ -1,0 +1,1 @@
+export 'private_message.dart';

--- a/lib/src/features/private_message/data/repositories/private_message_repository.dart
+++ b/lib/src/features/private_message/data/repositories/private_message_repository.dart
@@ -1,0 +1,101 @@
+import 'package:flutter/foundation.dart';
+
+import 'package:thunder/src/foundation/contracts/contracts.dart';
+import 'package:thunder/src/foundation/networking/networking.dart';
+import 'package:thunder/src/foundation/primitives/primitives.dart';
+
+/// Repository contract for direct-message reads, writes, and read state.
+abstract class PrivateMessageRepository {
+  /// Fetches private messages for the inbox.
+  Future<List<ThunderPrivateMessage>> messages({
+    bool unread,
+    int limit,
+    int page,
+  });
+
+  /// Fetches messages exchanged with a single person.
+  Future<List<ThunderPrivateMessage>> conversation({
+    required int personId,
+    int? conversationId,
+    int page,
+    int limit,
+  });
+
+  /// Sends a direct message to a recipient.
+  Future<ThunderPrivateMessage> create({
+    required int recipientId,
+    required String content,
+  });
+
+  /// Updates the read state for a private message.
+  Future<void> markAsRead({
+    required int messageId,
+    bool read,
+  });
+}
+
+/// API-backed implementation of [PrivateMessageRepository].
+class PrivateMessageRepositoryImpl implements PrivateMessageRepository {
+  /// Creates a repository for [account].
+  PrivateMessageRepositoryImpl({
+    required this.account,
+    ThunderApiClient? api,
+    LocalizationService localizationService = const GlobalContextLocalizationService(),
+  })  : _api = api ?? ApiClientFactory.create(account, debug: kDebugMode),
+        _localizationService = localizationService;
+
+  /// Account used to authenticate private-message requests.
+  final Account account;
+  final ThunderApiClient _api;
+  final LocalizationService _localizationService;
+
+  void _ensureLoggedIn() {
+    if (account.anonymous) {
+      throw Exception(_localizationService.l10n.userNotLoggedIn);
+    }
+  }
+
+  @override
+  Future<List<ThunderPrivateMessage>> messages({
+    bool unread = false,
+    int limit = 50,
+    int page = 1,
+  }) async {
+    _ensureLoggedIn();
+    return _api.getPrivateMessages(page: page, limit: limit, unread: unread);
+  }
+
+  @override
+  Future<List<ThunderPrivateMessage>> conversation({
+    required int personId,
+    int? conversationId,
+    int page = 1,
+    int limit = 50,
+  }) async {
+    _ensureLoggedIn();
+    return _api.getPrivateMessageConversation(
+      personId: personId,
+      conversationId: conversationId,
+      page: page,
+      limit: limit,
+    );
+  }
+
+  @override
+  Future<ThunderPrivateMessage> create({
+    required int recipientId,
+    required String content,
+  }) async {
+    _ensureLoggedIn();
+    return _api.createPrivateMessage(recipientId: recipientId, content: content);
+  }
+
+  @override
+  Future<void> markAsRead({
+    required int messageId,
+    bool read = true,
+  }) async {
+    _ensureLoggedIn();
+    await _api.markPrivateMessageAsRead(messageId: messageId, read: read);
+  }
+}

--- a/lib/src/features/private_message/domain/models/private_message_thread.dart
+++ b/lib/src/features/private_message/domain/models/private_message_thread.dart
@@ -1,0 +1,50 @@
+import 'package:equatable/equatable.dart';
+
+import 'package:thunder/src/foundation/primitives/primitives.dart';
+
+/// Summary of direct messages grouped by the other participant.
+class PrivateMessageThread extends Equatable {
+  /// Creates a grouped direct-message thread.
+  const PrivateMessageThread({
+    required this.participant,
+    required this.messages,
+    required this.latestMessage,
+    required this.unreadCount,
+    this.conversationId,
+  });
+
+  /// User on the other side of the thread.
+  final ThunderUser participant;
+
+  /// Messages in the thread, sorted from oldest to newest.
+  final List<ThunderPrivateMessage> messages;
+
+  /// Most recent message used for inbox previews and sorting.
+  final ThunderPrivateMessage latestMessage;
+
+  /// Count of unread incoming messages in this thread.
+  final int unreadCount;
+
+  /// Server-provided conversation ID, when available.
+  final int? conversationId;
+
+  /// Creates a copy with updated fields.
+  PrivateMessageThread copyWith({
+    ThunderUser? participant,
+    List<ThunderPrivateMessage>? messages,
+    ThunderPrivateMessage? latestMessage,
+    int? unreadCount,
+    int? conversationId,
+  }) {
+    return PrivateMessageThread(
+      participant: participant ?? this.participant,
+      messages: messages ?? this.messages,
+      latestMessage: latestMessage ?? this.latestMessage,
+      unreadCount: unreadCount ?? this.unreadCount,
+      conversationId: conversationId ?? this.conversationId,
+    );
+  }
+
+  @override
+  List<Object?> get props => [participant, messages, latestMessage, unreadCount, conversationId];
+}

--- a/lib/src/features/private_message/domain/utils/private_message_thread_utils.dart
+++ b/lib/src/features/private_message/domain/utils/private_message_thread_utils.dart
@@ -1,0 +1,86 @@
+import 'package:collection/collection.dart';
+
+import 'package:thunder/src/features/private_message/domain/models/private_message_thread.dart';
+import 'package:thunder/src/foundation/contracts/contracts.dart';
+import 'package:thunder/src/foundation/primitives/primitives.dart';
+
+/// Returns the user on the other side of a private message.
+ThunderUser? otherPrivateMessageParticipant(ThunderPrivateMessage message, Account account) {
+  final currentUserId = account.userId;
+
+  if (currentUserId != null) {
+    if (message.creatorId == currentUserId) return message.recipient;
+    if (message.recipientId == currentUserId) return message.creator;
+  }
+
+  if (message.creator?.actorId == account.actorId) return message.recipient;
+  return message.creator ?? message.recipient;
+}
+
+/// Returns true when [message] was received by [account].
+bool isIncomingPrivateMessage(ThunderPrivateMessage message, Account account) {
+  final currentUserId = account.userId;
+  if (currentUserId != null) return message.recipientId == currentUserId;
+  return message.recipient?.actorId == account.actorId;
+}
+
+/// Marks incoming messages as read locally for the account viewing a thread.
+List<ThunderPrivateMessage> markIncomingPrivateMessagesRead(
+  List<ThunderPrivateMessage> messages,
+  Account account,
+) {
+  return messages.map((message) {
+    if (message.read || !isIncomingPrivateMessage(message, account)) return message;
+    return message.copyWith(read: true);
+  }).toList();
+}
+
+/// Groups private messages into participant threads for the inbox.
+List<PrivateMessageThread> groupPrivateMessagesByParticipant(
+  List<ThunderPrivateMessage> messages,
+  Account account,
+) {
+  final grouped = <String, List<ThunderPrivateMessage>>{};
+  final participants = <String, ThunderUser>{};
+
+  for (final message in messages) {
+    final participant = otherPrivateMessageParticipant(message, account);
+    if (participant == null) continue;
+
+    final key = participant.actorId.isNotEmpty ? participant.actorId : participant.id.toString();
+    participants[key] = participant;
+    grouped.putIfAbsent(key, () => <ThunderPrivateMessage>[]).add(message);
+  }
+
+  final threads = grouped.entries.map((entry) {
+    final threadMessages = [...entry.value]..sort((a, b) => a.published.compareTo(b.published));
+    final latest = threadMessages.last;
+    final unreadCount = threadMessages.where((message) => !message.read && isIncomingPrivateMessage(message, account)).length;
+    final conversationId = threadMessages.firstWhereOrNull((message) => message.conversationId != null)?.conversationId;
+
+    return PrivateMessageThread(
+      participant: participants[entry.key]!,
+      messages: threadMessages,
+      latestMessage: latest,
+      unreadCount: unreadCount,
+      conversationId: conversationId,
+    );
+  }).toList();
+
+  threads.sort((a, b) => b.latestMessage.published.compareTo(a.latestMessage.published));
+  return threads;
+}
+
+/// Merges private messages by ID and sorts them from oldest to newest.
+List<ThunderPrivateMessage> mergePrivateMessages(
+  List<ThunderPrivateMessage> current,
+  List<ThunderPrivateMessage> incoming,
+) {
+  final byId = <int, ThunderPrivateMessage>{for (final message in current) message.id: message};
+
+  for (final message in incoming) {
+    byId[message.id] = message;
+  }
+
+  return byId.values.toList()..sort((a, b) => a.published.compareTo(b.published));
+}

--- a/lib/src/features/private_message/presentation/pages/create_private_message_page.dart
+++ b/lib/src/features/private_message/presentation/pages/create_private_message_page.dart
@@ -1,0 +1,189 @@
+import 'package:flutter/material.dart';
+
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:keyboard_detection/keyboard_detection.dart';
+
+import 'package:thunder/packages/ui/ui.dart';
+import 'package:thunder/src/features/account/account.dart';
+import 'package:thunder/src/features/private_message/presentation/widgets/create_private_message/create_private_message_bottom_bar.dart';
+import 'package:thunder/src/features/private_message/presentation/widgets/create_private_message/create_private_message_editor_section.dart';
+import 'package:thunder/src/features/private_message/presentation/widgets/create_private_message/create_private_message_recipient_tile.dart';
+import 'package:thunder/src/features/private_message/presentation/state/create_private_message_cubit.dart';
+import 'package:thunder/src/features/user/user.dart';
+import 'package:thunder/src/foundation/contracts/contracts.dart';
+import 'package:thunder/src/foundation/primitives/primitives.dart';
+import 'package:thunder/src/shared/input_dialogs.dart';
+import 'package:thunder/src/foundation/config/global_context.dart';
+
+/// Page for composing and sending a direct message.
+class CreatePrivateMessagePage extends StatefulWidget {
+  /// Creates a direct-message composer for [account].
+  const CreatePrivateMessagePage({
+    super.key,
+    required this.account,
+    this.recipient,
+    this.initialContent,
+    this.onMessageSent,
+  });
+
+  /// Account used to send the message.
+  final Account account;
+
+  /// Optional recipient used when the composer is opened from a user action.
+  final ThunderUser? recipient;
+
+  /// Optional markdown content used when expanding a quick reply into the full composer.
+  final String? initialContent;
+
+  /// Callback invoked after a message is successfully sent.
+  final void Function(ThunderPrivateMessage message)? onMessageSent;
+
+  @override
+  State<CreatePrivateMessagePage> createState() => _CreatePrivateMessagePageState();
+}
+
+class _CreatePrivateMessagePageState extends State<CreatePrivateMessagePage> {
+  final TextEditingController _bodyController = TextEditingController();
+  final FocusNode _bodyFocusNode = FocusNode();
+  final KeyboardDetectionController _keyboardDetectionController = KeyboardDetectionController();
+
+  bool _showPreview = false;
+  bool _wasKeyboardVisible = false;
+
+  @override
+  void initState() {
+    super.initState();
+    _bodyController.text = widget.initialContent ?? '';
+    _bodyController.addListener(() => context.read<CreatePrivateMessageCubit>().updateContent(_bodyController.text));
+
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      context.read<CreatePrivateMessageCubit>().initialize(
+            recipient: widget.recipient,
+            content: widget.initialContent,
+          );
+      _bodyFocusNode.requestFocus();
+    });
+  }
+
+  @override
+  void dispose() {
+    _bodyController.dispose();
+    _bodyFocusNode.dispose();
+    super.dispose();
+  }
+
+  void _selectRecipient(Account account) {
+    final l10n = GlobalContext.l10n;
+
+    showUserInputDialog(
+      context,
+      title: l10n.selectRecipient,
+      account: account,
+      onUserSelected: (user) => context.read<CreatePrivateMessageCubit>().setRecipient(user),
+    );
+  }
+
+  Future<void> _submit() async {
+    final message = await context.read<CreatePrivateMessageCubit>().submit();
+    if (!mounted || message == null) return;
+
+    widget.onMessageSent?.call(message);
+    Navigator.of(context).pop(message);
+  }
+
+  void _togglePreview() {
+    if (!_showPreview) {
+      _wasKeyboardVisible = _keyboardDetectionController.stateAsBool(true) ?? false;
+      FocusManager.instance.primaryFocus?.unfocus();
+    }
+
+    setState(() => _showPreview = !_showPreview);
+    if (!_showPreview && _wasKeyboardVisible) {
+      _bodyFocusNode.requestFocus();
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final l10n = GlobalContext.l10n;
+    final theme = Theme.of(context);
+
+    return BlocConsumer<CreatePrivateMessageCubit, CreatePrivateMessageState>(
+      listener: (context, state) {
+        if (state.message?.isNotEmpty == true) {
+          showSnackbar(state.message!);
+        }
+      },
+      builder: (context, state) {
+        final account = widget.account;
+
+        return GestureDetector(
+          onTap: () => FocusManager.instance.primaryFocus?.unfocus(),
+          child: KeyboardDetection(
+            controller: _keyboardDetectionController,
+            child: Scaffold(
+              resizeToAvoidBottomInset: false,
+              appBar: AppBar(
+                title: Text(l10n.directMessage),
+                centerTitle: false,
+              ),
+              body: SafeArea(
+                bottom: false,
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Expanded(
+                      child: SingleChildScrollView(
+                        child: Column(
+                          crossAxisAlignment: CrossAxisAlignment.start,
+                          children: [
+                            Padding(
+                              padding: const EdgeInsets.only(left: 16.0, top: 8.0),
+                              child: UserSelector(
+                                account: account,
+                                enableAccountSwitching: false,
+                              ),
+                            ),
+                            const SizedBox(height: 10),
+                            Padding(
+                              padding: const EdgeInsets.symmetric(horizontal: 16.0),
+                              child: CreatePrivateMessageRecipientTile(
+                                recipient: state.recipient,
+                                onTap: () => _selectRecipient(account),
+                              ),
+                            ),
+                            const SizedBox(height: 10),
+                            CreatePrivateMessageEditorSection(
+                              controller: _bodyController,
+                              focusNode: _bodyFocusNode,
+                              showPreview: _showPreview,
+                            ),
+                          ],
+                        ),
+                      ),
+                    ),
+                    const Divider(height: 1),
+                    CreatePrivateMessageBottomBar(
+                      account: account,
+                      controller: _bodyController,
+                      focusNode: _bodyFocusNode,
+                      showPreview: _showPreview,
+                      canSubmit: state.canSubmit,
+                      status: state.status,
+                      onTogglePreview: _togglePreview,
+                      onSubmit: _submit,
+                    ),
+                    Container(
+                      height: MediaQuery.of(context).padding.bottom,
+                      color: theme.cardColor,
+                    ),
+                  ],
+                ),
+              ),
+            ),
+          ),
+        );
+      },
+    );
+  }
+}

--- a/lib/src/features/private_message/presentation/pages/private_message_thread_page.dart
+++ b/lib/src/features/private_message/presentation/pages/private_message_thread_page.dart
@@ -1,0 +1,192 @@
+import 'package:flutter/material.dart';
+
+import 'package:flutter_bloc/flutter_bloc.dart';
+
+import 'package:thunder/packages/ui/ui.dart';
+import 'package:thunder/src/app/shell/navigation/navigation_private_message.dart';
+import 'package:thunder/src/features/instance/domain/utils/instance_link_utils.dart';
+import 'package:thunder/src/features/private_message/domain/utils/private_message_thread_utils.dart';
+import 'package:thunder/src/features/private_message/presentation/state/private_message_thread_cubit.dart';
+import 'package:thunder/src/features/private_message/presentation/widgets/thread/private_message_bubble.dart';
+import 'package:thunder/src/features/private_message/presentation/widgets/thread/quick_reply_bar.dart';
+import 'package:thunder/src/foundation/contracts/contracts.dart';
+import 'package:thunder/src/foundation/primitives/primitives.dart';
+import 'package:thunder/src/shared/avatars/user_avatar.dart';
+import 'package:thunder/src/shared/name/full_name_widgets.dart';
+
+/// Page showing a direct-message conversation with one participant.
+class PrivateMessageThreadPage extends StatefulWidget {
+  /// Creates a direct-message thread page.
+  const PrivateMessageThreadPage({
+    super.key,
+    required this.account,
+    required this.participant,
+    this.onThreadUpdated,
+  });
+
+  /// Account viewing the thread.
+  final Account account;
+
+  /// User on the other side of the thread.
+  final ThunderUser participant;
+
+  /// Callback invoked with the latest local messages when the thread closes.
+  final ValueChanged<List<ThunderPrivateMessage>>? onThreadUpdated;
+
+  @override
+  State<PrivateMessageThreadPage> createState() => _PrivateMessageThreadPageState();
+}
+
+class _PrivateMessageThreadPageState extends State<PrivateMessageThreadPage> {
+  final TextEditingController _quickReplyController = TextEditingController();
+  final ScrollController _scrollController = ScrollController();
+  late final PrivateMessageThreadCubit _cubit;
+  int _previousMessageCount = 0;
+  PrivateMessageThreadStatus _previousStatus = PrivateMessageThreadStatus.initial;
+
+  @override
+  void initState() {
+    super.initState();
+    _cubit = context.read<PrivateMessageThreadCubit>();
+    _previousMessageCount = _cubit.state.messages.length;
+    _previousStatus = _cubit.state.status;
+    _quickReplyController.addListener(() => _cubit.updateQuickReply(_quickReplyController.text));
+    if (_cubit.state.messages.isNotEmpty) {
+      _scrollToLatest();
+    }
+    WidgetsBinding.instance.addPostFrameCallback((_) => _cubit.load());
+  }
+
+  @override
+  void dispose() {
+    widget.onThreadUpdated?.call(_cubit.state.messages);
+    _quickReplyController.dispose();
+    _scrollController.dispose();
+    super.dispose();
+  }
+
+  /// Scrolls to the newest message at the bottom of the list.
+  void _scrollToLatest() {
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!_scrollController.hasClients) return;
+      _scrollController.jumpTo(_scrollController.position.maxScrollExtent);
+    });
+  }
+
+  Future<void> _openComposer() async {
+    final cubit = context.read<PrivateMessageThreadCubit>();
+    final result = await navigateToCreatePrivateMessagePage(
+      context,
+      account: widget.account,
+      recipient: widget.participant,
+      initialContent: cubit.state.quickReply,
+    );
+
+    if (!mounted || result == null) return;
+    if (!_belongsToCurrentThread(result)) return;
+
+    cubit.appendMessage(result);
+    _quickReplyController.clear();
+  }
+
+  bool _belongsToCurrentThread(ThunderPrivateMessage message) {
+    final participant = otherPrivateMessageParticipant(message, widget.account);
+    if (participant == null) return false;
+
+    if (participant.actorId.isNotEmpty && widget.participant.actorId.isNotEmpty) {
+      return participant.actorId == widget.participant.actorId;
+    }
+
+    return participant.id == widget.participant.id;
+  }
+
+  Future<void> _sendQuickReply() async {
+    final message = await _cubit.sendQuickReply();
+    if (message != null) {
+      _quickReplyController.clear();
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return BlocConsumer<PrivateMessageThreadCubit, PrivateMessageThreadState>(
+      listenWhen: (previous, current) => previous.messages.length != current.messages.length || previous.status != current.status || previous.message != current.message,
+      listener: (context, state) {
+        if (state.message?.isNotEmpty == true) {
+          showSnackbar(state.message!);
+        }
+
+        final messagesGrew = state.messages.length > _previousMessageCount;
+        final finishedInitialLoad =
+            _previousStatus == PrivateMessageThreadStatus.loading && _previousMessageCount == 0 && state.status == PrivateMessageThreadStatus.success && state.messages.isNotEmpty;
+
+        if (messagesGrew || finishedInitialLoad) {
+          _scrollToLatest();
+        }
+
+        _previousMessageCount = state.messages.length;
+        _previousStatus = state.status;
+      },
+      builder: (context, state) {
+        return Scaffold(
+          appBar: AppBar(
+            titleSpacing: 0,
+            title: Row(
+              children: [
+                UserAvatar(user: widget.participant, radius: 18),
+                const SizedBox(width: 10),
+                Expanded(
+                  child: UserFullNameWidget(
+                    name: widget.participant.name,
+                    displayName: widget.participant.displayName,
+                    instance: fetchInstanceNameFromUrl(widget.participant.actorId),
+                    includeInstance: true,
+                  ),
+                ),
+              ],
+            ),
+          ),
+          body: SafeArea(
+            child: Column(
+              children: [
+                Expanded(
+                  child: state.status == PrivateMessageThreadStatus.loading && state.messages.isEmpty
+                      ? const Center(child: CircularProgressIndicator())
+                      : CustomScrollView(
+                          controller: _scrollController,
+                          slivers: [
+                            SliverPadding(
+                              padding: const EdgeInsets.fromLTRB(12, 12, 12, 16),
+                              sliver: SliverList.builder(
+                                itemCount: state.messages.length,
+                                itemBuilder: (context, index) {
+                                  final message = state.messages[index];
+                                  return PrivateMessageBubble(
+                                    account: widget.account,
+                                    message: message,
+                                  );
+                                },
+                              ),
+                            ),
+                            const SliverFillRemaining(
+                              hasScrollBody: false,
+                              child: SizedBox.shrink(),
+                            ),
+                          ],
+                        ),
+                ),
+                QuickReplyBar(
+                  controller: _quickReplyController,
+                  canSend: state.canSendQuickReply,
+                  sending: state.status == PrivateMessageThreadStatus.sending,
+                  onOpenComposer: _openComposer,
+                  onSend: _sendQuickReply,
+                ),
+              ],
+            ),
+          ),
+        );
+      },
+    );
+  }
+}

--- a/lib/src/features/private_message/presentation/state/create_private_message_cubit.dart
+++ b/lib/src/features/private_message/presentation/state/create_private_message_cubit.dart
@@ -1,0 +1,129 @@
+import 'package:bloc/bloc.dart';
+import 'package:equatable/equatable.dart';
+
+import 'package:thunder/src/features/private_message/data/repositories/private_message_repository.dart';
+import 'package:thunder/src/features/search/search.dart';
+import 'package:thunder/src/foundation/contracts/contracts.dart';
+import 'package:thunder/src/foundation/errors/errors.dart';
+import 'package:thunder/src/foundation/networking/networking.dart';
+import 'package:thunder/src/foundation/primitives/primitives.dart';
+
+part 'create_private_message_state.dart';
+
+/// Coordinates recipient selection, body edits, and submission for direct messages.
+class CreatePrivateMessageCubit extends Cubit<CreatePrivateMessageState> {
+  /// Creates a cubit for composing direct messages from [account].
+  CreatePrivateMessageCubit({
+    required this.account,
+    required PrivateMessageRepository Function(Account account) privateMessageRepository,
+    required SearchRepository Function(Account account) searchRepository,
+    required LocalizationService localizationService,
+  })  : _privateMessageRepository = privateMessageRepository(account),
+        _searchRepository = searchRepository(account),
+        _localizationService = localizationService,
+        super(const CreatePrivateMessageState());
+
+  /// Account currently used to send direct messages.
+  final Account account;
+  final LocalizationService _localizationService;
+
+  final PrivateMessageRepository _privateMessageRepository;
+  final SearchRepository _searchRepository;
+
+  /// Initializes the composer with optional pre-filled recipient and content.
+  void initialize({ThunderUser? recipient, String? content}) {
+    emit(state.copyWith(
+      status: CreatePrivateMessageStatus.initial,
+      recipient: recipient,
+      content: content ?? '',
+      message: null,
+      errorReason: null,
+      privateMessage: null,
+    ));
+  }
+
+  /// Sets the selected recipient.
+  void setRecipient(ThunderUser? recipient) {
+    emit(state.copyWith(
+      status: CreatePrivateMessageStatus.initial,
+      recipient: recipient,
+      suggestions: const <ThunderUser>[],
+      message: null,
+      errorReason: null,
+    ));
+  }
+
+  /// Updates the message body.
+  void updateContent(String content) {
+    if (content == state.content) return;
+    emit(state.copyWith(content: content, message: null, errorReason: null));
+  }
+
+  /// Searches for users that can be selected as recipients.
+  Future<void> searchRecipients(String query) async {
+    final trimmed = query.trim();
+    if (trimmed.isEmpty) {
+      emit(state.copyWith(status: CreatePrivateMessageStatus.initial, suggestions: const <ThunderUser>[]));
+      return;
+    }
+
+    try {
+      emit(state.copyWith(status: CreatePrivateMessageStatus.searching, message: null, errorReason: null));
+      final results = await _searchRepository.search(query: trimmed, type: MetaSearchType.users, limit: 20);
+      emit(state.copyWith(status: CreatePrivateMessageStatus.initial, suggestions: results.users));
+    } catch (e) {
+      final message = getExceptionErrorMessage(e);
+      emit(state.copyWith(
+        status: CreatePrivateMessageStatus.error,
+        message: message,
+        errorReason: AppErrorReason.unexpected(message: message, details: e.toString()),
+      ));
+    }
+  }
+
+  /// Sends the direct message when the current state is valid.
+  Future<ThunderPrivateMessage?> submit() async {
+    final l10n = _localizationService.l10n;
+    final recipient = state.recipient;
+    final content = state.content.trim();
+
+    if (account.anonymous) {
+      emit(state.copyWith(
+        status: CreatePrivateMessageStatus.error,
+        message: l10n.userNotLoggedIn,
+        errorReason: AppErrorReason.notLoggedIn(message: l10n.userNotLoggedIn),
+      ));
+      return null;
+    }
+
+    if (recipient == null || content.isEmpty) {
+      emit(state.copyWith(
+        status: CreatePrivateMessageStatus.error,
+        message: l10n.missingErrorMessage,
+        errorReason: AppErrorReason.validation(message: l10n.missingErrorMessage),
+      ));
+      return null;
+    }
+
+    try {
+      emit(state.copyWith(status: CreatePrivateMessageStatus.submitting, message: null, errorReason: null));
+      final privateMessage = await _privateMessageRepository.create(recipientId: recipient.id, content: content);
+      emit(state.copyWith(
+        status: CreatePrivateMessageStatus.success,
+        privateMessage: privateMessage,
+        content: '',
+        message: null,
+        errorReason: null,
+      ));
+      return privateMessage;
+    } catch (e) {
+      final message = getExceptionErrorMessage(e);
+      emit(state.copyWith(
+        status: CreatePrivateMessageStatus.error,
+        message: message,
+        errorReason: AppErrorReason.actionFailed(message: message, details: e.toString()),
+      ));
+      return null;
+    }
+  }
+}

--- a/lib/src/features/private_message/presentation/state/create_private_message_state.dart
+++ b/lib/src/features/private_message/presentation/state/create_private_message_state.dart
@@ -1,0 +1,74 @@
+part of 'create_private_message_cubit.dart';
+
+const _createPrivateMessageStateUnset = Object();
+
+/// Lifecycle status for the direct-message composer.
+enum CreatePrivateMessageStatus {
+  initial,
+  searching,
+  submitting,
+  success,
+  error,
+}
+
+/// State for composing and sending a direct message.
+class CreatePrivateMessageState extends Equatable {
+  /// Creates direct-message compose state.
+  const CreatePrivateMessageState({
+    this.status = CreatePrivateMessageStatus.initial,
+    this.recipient,
+    this.suggestions = const <ThunderUser>[],
+    this.content = '',
+    this.privateMessage,
+    this.message,
+    this.errorReason,
+  });
+
+  /// Current lifecycle status.
+  final CreatePrivateMessageStatus status;
+
+  /// Selected recipient.
+  final ThunderUser? recipient;
+
+  /// Recipient search suggestions.
+  final List<ThunderUser> suggestions;
+
+  /// Markdown body content.
+  final String content;
+
+  /// Message returned after a successful submit.
+  final ThunderPrivateMessage? privateMessage;
+
+  /// User-visible status or error message.
+  final String? message;
+
+  /// Structured error reason for recoverable failures.
+  final AppErrorReason? errorReason;
+
+  /// Whether the current state can be submitted.
+  bool get canSubmit => recipient != null && content.trim().isNotEmpty && status != CreatePrivateMessageStatus.submitting;
+
+  /// Creates a copy with updated fields.
+  CreatePrivateMessageState copyWith({
+    CreatePrivateMessageStatus? status,
+    Object? recipient = _createPrivateMessageStateUnset,
+    List<ThunderUser>? suggestions,
+    String? content,
+    Object? privateMessage = _createPrivateMessageStateUnset,
+    Object? message = _createPrivateMessageStateUnset,
+    Object? errorReason = _createPrivateMessageStateUnset,
+  }) {
+    return CreatePrivateMessageState(
+      status: status ?? this.status,
+      recipient: identical(recipient, _createPrivateMessageStateUnset) ? this.recipient : recipient as ThunderUser?,
+      suggestions: suggestions ?? this.suggestions,
+      content: content ?? this.content,
+      privateMessage: identical(privateMessage, _createPrivateMessageStateUnset) ? this.privateMessage : privateMessage as ThunderPrivateMessage?,
+      message: identical(message, _createPrivateMessageStateUnset) ? this.message : message as String?,
+      errorReason: identical(errorReason, _createPrivateMessageStateUnset) ? this.errorReason : errorReason as AppErrorReason?,
+    );
+  }
+
+  @override
+  List<Object?> get props => [status, recipient, suggestions, content, privateMessage, message, errorReason];
+}

--- a/lib/src/features/private_message/presentation/state/private_message_thread_cubit.dart
+++ b/lib/src/features/private_message/presentation/state/private_message_thread_cubit.dart
@@ -1,0 +1,138 @@
+import 'dart:async';
+
+import 'package:bloc/bloc.dart';
+import 'package:equatable/equatable.dart';
+
+import 'package:thunder/src/features/private_message/data/repositories/private_message_repository.dart';
+import 'package:thunder/src/features/private_message/domain/utils/private_message_thread_utils.dart';
+import 'package:thunder/src/foundation/contracts/contracts.dart';
+import 'package:thunder/src/foundation/errors/errors.dart';
+import 'package:thunder/src/foundation/networking/networking.dart';
+import 'package:thunder/src/foundation/primitives/primitives.dart';
+
+part 'private_message_thread_state.dart';
+
+/// Coordinates loading and replying within a direct-message thread.
+class PrivateMessageThreadCubit extends Cubit<PrivateMessageThreadState> {
+  /// Creates a thread cubit for messages with [participant].
+  PrivateMessageThreadCubit({
+    required this.account,
+    required this.participant,
+    required PrivateMessageRepository repository,
+    List<ThunderPrivateMessage> initialMessages = const <ThunderPrivateMessage>[],
+    this.conversationId,
+  })  : _repository = repository,
+        super(PrivateMessageThreadState(messages: markIncomingPrivateMessagesRead(initialMessages, account))) {
+    if (initialMessages.isNotEmpty) {
+      unawaited(_markIncomingMessagesRead(initialMessages));
+    }
+  }
+
+  /// Account viewing the thread.
+  final Account account;
+
+  /// User on the other side of the thread.
+  final ThunderUser participant;
+  final PrivateMessageRepository _repository;
+
+  /// Optional server-provided conversation ID.
+  final int? conversationId;
+
+  /// Loads the thread, optionally resetting pagination.
+  Future<void> load({bool reset = true}) async {
+    try {
+      emit(state.copyWith(status: reset ? PrivateMessageThreadStatus.loading : PrivateMessageThreadStatus.refreshing, message: null, errorReason: null));
+
+      final response = await _repository.conversation(
+        personId: participant.id,
+        conversationId: conversationId,
+        page: reset ? 1 : state.page,
+        limit: 50,
+      );
+
+      final messages = markIncomingPrivateMessagesRead(
+        mergePrivateMessages(state.messages, response.isEmpty ? state.messages : response),
+        account,
+      );
+      unawaited(_markIncomingMessagesRead(response));
+
+      emit(state.copyWith(
+        status: PrivateMessageThreadStatus.success,
+        messages: messages,
+        page: reset ? 2 : state.page + 1,
+        hasReachedEnd: response.length < 50,
+        message: null,
+        errorReason: null,
+      ));
+    } catch (e) {
+      final message = getExceptionErrorMessage(e);
+      emit(state.copyWith(
+        status: PrivateMessageThreadStatus.error,
+        message: message,
+        errorReason: AppErrorReason.unexpected(message: message, details: e.toString()),
+      ));
+    }
+  }
+
+  /// Updates the inline quick-reply text.
+  void updateQuickReply(String value) {
+    if (value == state.quickReply) return;
+    emit(state.copyWith(quickReply: value, message: null, errorReason: null));
+  }
+
+  /// Clears the inline quick-reply text.
+  void clearQuickReply() {
+    emit(state.copyWith(quickReply: ''));
+  }
+
+  /// Adds a newly sent message to the thread.
+  void appendMessage(ThunderPrivateMessage message) {
+    emit(state.copyWith(
+      status: PrivateMessageThreadStatus.success,
+      messages: mergePrivateMessages(state.messages, [message]),
+      quickReply: '',
+      message: null,
+      errorReason: null,
+    ));
+  }
+
+  /// Sends the current quick reply.
+  Future<ThunderPrivateMessage?> sendQuickReply() async {
+    final content = state.quickReply.trim();
+    if (content.isEmpty || state.status == PrivateMessageThreadStatus.sending) return null;
+
+    try {
+      emit(state.copyWith(status: PrivateMessageThreadStatus.sending, message: null, errorReason: null));
+      final privateMessage = await _repository.create(recipientId: participant.id, content: content);
+
+      emit(state.copyWith(
+        status: PrivateMessageThreadStatus.success,
+        messages: mergePrivateMessages(state.messages, [privateMessage]),
+        quickReply: '',
+        message: null,
+        errorReason: null,
+      ));
+
+      return privateMessage;
+    } catch (e) {
+      final message = getExceptionErrorMessage(e);
+      emit(state.copyWith(
+        status: PrivateMessageThreadStatus.error,
+        message: message,
+        errorReason: AppErrorReason.actionFailed(message: message, details: e.toString()),
+      ));
+      return null;
+    }
+  }
+
+  Future<void> _markIncomingMessagesRead(List<ThunderPrivateMessage> messages) async {
+    for (final message in messages) {
+      if (message.read || !isIncomingPrivateMessage(message, account)) continue;
+      try {
+        await _repository.markAsRead(messageId: message.id);
+      } catch (_) {
+        // Keep the thread responsive; a later inbox refresh will reconcile failures.
+      }
+    }
+  }
+}

--- a/lib/src/features/private_message/presentation/state/private_message_thread_state.dart
+++ b/lib/src/features/private_message/presentation/state/private_message_thread_state.dart
@@ -1,0 +1,75 @@
+part of 'private_message_thread_cubit.dart';
+
+const _privateMessageThreadStateUnset = Object();
+
+/// Lifecycle status for a direct-message thread.
+enum PrivateMessageThreadStatus {
+  initial,
+  loading,
+  refreshing,
+  sending,
+  success,
+  error,
+}
+
+/// State for a direct-message thread.
+class PrivateMessageThreadState extends Equatable {
+  /// Creates direct-message thread state.
+  const PrivateMessageThreadState({
+    this.status = PrivateMessageThreadStatus.initial,
+    this.messages = const <ThunderPrivateMessage>[],
+    this.quickReply = '',
+    this.page = 1,
+    this.hasReachedEnd = false,
+    this.message,
+    this.errorReason,
+  });
+
+  /// Current lifecycle status.
+  final PrivateMessageThreadStatus status;
+
+  /// Messages in this thread, sorted from oldest to newest.
+  final List<ThunderPrivateMessage> messages;
+
+  /// Inline quick-reply content.
+  final String quickReply;
+
+  /// Next page to fetch.
+  final int page;
+
+  /// Whether pagination has reached the end of the thread.
+  final bool hasReachedEnd;
+
+  /// User-visible status or error message.
+  final String? message;
+
+  /// Structured error reason for recoverable failures.
+  final AppErrorReason? errorReason;
+
+  /// Whether the quick reply can be sent.
+  bool get canSendQuickReply => quickReply.trim().isNotEmpty && status != PrivateMessageThreadStatus.sending;
+
+  /// Creates a copy with updated fields.
+  PrivateMessageThreadState copyWith({
+    PrivateMessageThreadStatus? status,
+    List<ThunderPrivateMessage>? messages,
+    String? quickReply,
+    int? page,
+    bool? hasReachedEnd,
+    Object? message = _privateMessageThreadStateUnset,
+    Object? errorReason = _privateMessageThreadStateUnset,
+  }) {
+    return PrivateMessageThreadState(
+      status: status ?? this.status,
+      messages: messages ?? this.messages,
+      quickReply: quickReply ?? this.quickReply,
+      page: page ?? this.page,
+      hasReachedEnd: hasReachedEnd ?? this.hasReachedEnd,
+      message: identical(message, _privateMessageThreadStateUnset) ? this.message : message as String?,
+      errorReason: identical(errorReason, _privateMessageThreadStateUnset) ? this.errorReason : errorReason as AppErrorReason?,
+    );
+  }
+
+  @override
+  List<Object?> get props => [status, messages, quickReply, page, hasReachedEnd, message, errorReason];
+}

--- a/lib/src/features/private_message/presentation/widgets/create_private_message/create_private_message_bottom_bar.dart
+++ b/lib/src/features/private_message/presentation/widgets/create_private_message/create_private_message_bottom_bar.dart
@@ -1,0 +1,162 @@
+import 'package:flutter/material.dart';
+
+import 'package:markdown_editor/markdown_editor.dart';
+
+import 'package:thunder/src/features/account/account.dart';
+import 'package:thunder/src/features/instance/domain/utils/instance_link_utils.dart';
+import 'package:thunder/src/features/private_message/presentation/state/create_private_message_cubit.dart';
+import 'package:thunder/src/foundation/config/global_context.dart';
+import 'package:thunder/src/shared/input_dialogs.dart';
+import 'package:thunder/src/shared/theme/color_utils.dart';
+
+/// Bottom markdown toolbar and submit controls for the direct-message composer.
+class CreatePrivateMessageBottomBar extends StatelessWidget {
+  /// Creates a bottom bar that mirrors the post/comment compose controls.
+  const CreatePrivateMessageBottomBar({
+    super.key,
+    required this.account,
+    required this.controller,
+    required this.focusNode,
+    required this.showPreview,
+    required this.canSubmit,
+    required this.status,
+    required this.onTogglePreview,
+    required this.onSubmit,
+  });
+
+  /// Account used for username and community markdown lookups.
+  final Account account;
+
+  /// Controls the message body input.
+  final TextEditingController controller;
+
+  /// Focus node for the message body input.
+  final FocusNode focusNode;
+
+  /// Whether the editor is currently showing markdown preview.
+  final bool showPreview;
+
+  /// Whether the current compose state can be submitted.
+  final bool canSubmit;
+
+  /// Current submission status.
+  final CreatePrivateMessageStatus status;
+
+  /// Toggles between source and preview mode.
+  final VoidCallback onTogglePreview;
+
+  /// Sends the direct message.
+  final VoidCallback onSubmit;
+
+  @override
+  Widget build(BuildContext context) {
+    final l10n = GlobalContext.l10n;
+    final theme = Theme.of(context);
+
+    return Container(
+      color: theme.cardColor,
+      margin: EdgeInsets.only(bottom: MediaQuery.of(context).viewInsets.bottom),
+      child: Row(
+        children: [
+          Expanded(
+            child: IgnorePointer(
+              ignoring: showPreview,
+              child: MarkdownToolbar(
+                controller: controller,
+                focusNode: focusNode,
+                actions: const [
+                  MarkdownType.link,
+                  MarkdownType.bold,
+                  MarkdownType.italic,
+                  MarkdownType.blockquote,
+                  MarkdownType.strikethrough,
+                  MarkdownType.title,
+                  MarkdownType.list,
+                  MarkdownType.separator,
+                  MarkdownType.code,
+                  MarkdownType.spoiler,
+                  MarkdownType.username,
+                  MarkdownType.community,
+                ],
+                customTapActions: {
+                  MarkdownType.username: () => _insertUserMention(context),
+                  MarkdownType.community: () => _insertCommunityMention(context),
+                },
+              ),
+            ),
+          ),
+          Padding(
+            padding: const EdgeInsets.only(bottom: 2.0, top: 2.0, left: 4.0, right: 2.0),
+            child: IconButton(
+              onPressed: onTogglePreview,
+              icon: Icon(
+                showPreview ? Icons.visibility_off_rounded : Icons.visibility,
+                color: theme.colorScheme.onSecondary,
+                semanticLabel: l10n.postTogglePreview,
+              ),
+              style: ElevatedButton.styleFrom(backgroundColor: theme.colorScheme.secondaryContainer),
+            ),
+          ),
+          Padding(
+            padding: const EdgeInsets.only(bottom: 2.0, top: 2.0, left: 2.0, right: 8.0),
+            child: SizedBox(
+              width: 60,
+              child: IconButton(
+                onPressed: canSubmit ? onSubmit : null,
+                icon: status == CreatePrivateMessageStatus.submitting
+                    ? const SizedBox(
+                        height: 20,
+                        width: 20,
+                        child: CircularProgressIndicator(),
+                      )
+                    : Icon(
+                        Icons.send_rounded,
+                        color: theme.colorScheme.onSecondary,
+                        semanticLabel: l10n.send,
+                      ),
+                style: ElevatedButton.styleFrom(
+                  backgroundColor: theme.colorScheme.secondary,
+                  disabledBackgroundColor: getBackgroundColor(context),
+                ),
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  void _insertUserMention(BuildContext context) {
+    final l10n = GlobalContext.l10n;
+
+    showUserInputDialog(
+      context,
+      title: l10n.username,
+      account: account,
+      onUserSelected: (user) {
+        controller.text = controller.text.replaceRange(
+          controller.selection.end,
+          controller.selection.end,
+          '[@${user.name}@${fetchInstanceNameFromUrl(user.actorId)}](${user.actorId})',
+        );
+      },
+    );
+  }
+
+  void _insertCommunityMention(BuildContext context) {
+    final l10n = GlobalContext.l10n;
+
+    showCommunityInputDialog(
+      context,
+      title: l10n.community,
+      account: account,
+      onCommunitySelected: (community) {
+        controller.text = controller.text.replaceRange(
+          controller.selection.end,
+          controller.selection.end,
+          '!${community.name}@${fetchInstanceNameFromUrl(community.actorId)}',
+        );
+      },
+    );
+  }
+}

--- a/lib/src/features/private_message/presentation/widgets/create_private_message/create_private_message_editor_section.dart
+++ b/lib/src/features/private_message/presentation/widgets/create_private_message/create_private_message_editor_section.dart
@@ -1,0 +1,63 @@
+import 'package:flutter/material.dart';
+
+import 'package:markdown_editor/markdown_editor.dart';
+
+import 'package:thunder/src/foundation/config/global_context.dart';
+import 'package:thunder/src/shared/markdown/common_markdown_body.dart';
+import 'package:thunder/src/shared/theme/color_utils.dart';
+
+/// Displays the direct-message markdown editor or its rendered preview.
+class CreatePrivateMessageEditorSection extends StatelessWidget {
+  /// Creates an editor section with the same layout as post/comment compose pages.
+  const CreatePrivateMessageEditorSection({
+    super.key,
+    required this.controller,
+    required this.focusNode,
+    required this.showPreview,
+  });
+
+  /// Controls the message body input.
+  final TextEditingController controller;
+
+  /// Focus node used to restore keyboard focus after preview toggles.
+  final FocusNode focusNode;
+
+  /// Whether to show rendered markdown instead of the editor.
+  final bool showPreview;
+
+  @override
+  Widget build(BuildContext context) {
+    final l10n = GlobalContext.l10n;
+    final theme = Theme.of(context);
+
+    return AnimatedCrossFade(
+      firstChild: Padding(
+        padding: const EdgeInsets.all(8.0),
+        child: Container(
+          width: double.infinity,
+          padding: const EdgeInsets.all(8.0),
+          decoration: BoxDecoration(
+            color: getBackgroundColor(context),
+            borderRadius: const BorderRadius.all(Radius.circular(8.0)),
+          ),
+          child: CommonMarkdownBody(body: controller.text, isComment: true),
+        ),
+      ),
+      secondChild: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 16.0),
+        child: MarkdownTextInputField(
+          controller: controller,
+          focusNode: focusNode,
+          label: l10n.message(0),
+          minLines: 8,
+          maxLines: null,
+          textStyle: theme.textTheme.bodyLarge,
+          spellCheckConfiguration: const SpellCheckConfiguration.disabled(),
+        ),
+      ),
+      crossFadeState: showPreview ? CrossFadeState.showFirst : CrossFadeState.showSecond,
+      duration: const Duration(milliseconds: 120),
+      excludeBottomFocus: false,
+    );
+  }
+}

--- a/lib/src/features/private_message/presentation/widgets/create_private_message/create_private_message_recipient_tile.dart
+++ b/lib/src/features/private_message/presentation/widgets/create_private_message/create_private_message_recipient_tile.dart
@@ -1,0 +1,64 @@
+import 'package:flutter/material.dart';
+
+import 'package:thunder/src/features/user/user.dart';
+import 'package:thunder/src/foundation/config/global_context.dart';
+
+/// A compact selector row for choosing the recipient of a direct message.
+class CreatePrivateMessageRecipientTile extends StatelessWidget {
+  /// Creates a recipient selector matching the app's account selector style.
+  const CreatePrivateMessageRecipientTile({
+    super.key,
+    required this.recipient,
+    required this.onTap,
+  });
+
+  /// The selected recipient, or null when the user still needs to choose one.
+  final ThunderUser? recipient;
+
+  /// Opens recipient selection.
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    final l10n = GlobalContext.l10n;
+    final recipient = this.recipient;
+
+    return Transform.translate(
+      offset: const Offset(-8.0, 0),
+      child: InkWell(
+        borderRadius: const BorderRadius.all(Radius.circular(50.0)),
+        onTap: onTap,
+        child: Padding(
+          padding: const EdgeInsets.only(left: 8.0, top: 4.0, bottom: 4.0),
+          child: Row(
+            mainAxisAlignment: MainAxisAlignment.spaceBetween,
+            children: [
+              recipient == null ? _RecipientPlaceholder(label: l10n.selectRecipient) : UserIndicator(user: recipient),
+              const Icon(Icons.chevron_right_rounded),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _RecipientPlaceholder extends StatelessWidget {
+  const _RecipientPlaceholder({required this.label});
+
+  final String label;
+
+  @override
+  Widget build(BuildContext context) {
+    return SizedBox(
+      height: 40,
+      child: Row(
+        spacing: 12.0,
+        children: [
+          const Icon(Icons.person_search_rounded),
+          Text(label),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/src/features/private_message/presentation/widgets/thread/private_message_bubble.dart
+++ b/lib/src/features/private_message/presentation/widgets/thread/private_message_bubble.dart
@@ -1,0 +1,74 @@
+import 'package:flutter/material.dart';
+
+import 'package:thunder/src/foundation/contracts/contracts.dart';
+import 'package:thunder/src/foundation/primitives/primitives.dart';
+import 'package:thunder/src/shared/markdown/common_markdown_body.dart';
+import 'package:thunder/src/shared/theme/color_utils.dart';
+
+/// Chat bubble for one private message in a direct-message thread.
+class PrivateMessageBubble extends StatefulWidget {
+  /// Creates a bubble aligned based on whether the message was sent by [account].
+  const PrivateMessageBubble({
+    super.key,
+    required this.account,
+    required this.message,
+  });
+
+  /// Account viewing the thread.
+  final Account account;
+
+  /// Private message to render.
+  final ThunderPrivateMessage message;
+
+  @override
+  State<PrivateMessageBubble> createState() => _PrivateMessageBubbleState();
+}
+
+class _PrivateMessageBubbleState extends State<PrivateMessageBubble> {
+  bool showFullDate = false;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+
+    final outgoing = widget.message.creatorId == widget.account.userId || widget.message.creator?.actorId == widget.account.actorId;
+    final color = outgoing ? theme.colorScheme.primaryContainer : getBackgroundColor(context);
+    final alignment = outgoing ? Alignment.centerRight : Alignment.centerLeft;
+    final textColor = outgoing ? theme.colorScheme.onPrimaryContainer : theme.colorScheme.onSurface;
+
+    return Align(
+      alignment: alignment,
+      child: ConstrainedBox(
+        constraints: BoxConstraints(maxWidth: MediaQuery.sizeOf(context).width * 0.78),
+        child: Column(
+          crossAxisAlignment: outgoing ? CrossAxisAlignment.end : CrossAxisAlignment.start,
+          children: [
+            Card(
+              color: color,
+              margin: const EdgeInsets.symmetric(vertical: 4),
+              child: Padding(
+                padding: const EdgeInsets.fromLTRB(12, 8, 12, 6),
+                child: DefaultTextStyle.merge(
+                  style: TextStyle(color: textColor),
+                  child: CommonMarkdownBody(body: widget.message.content, isComment: true),
+                ),
+              ),
+            ),
+            GestureDetector(
+              behavior: HitTestBehavior.opaque,
+              onTap: () {
+                setState(() => showFullDate = !showFullDate);
+              },
+              child: Text(
+                showFullDate
+                    ? '${MaterialLocalizations.of(context).formatMediumDate(widget.message.published)} · ${MaterialLocalizations.of(context).formatTimeOfDay(TimeOfDay.fromDateTime(widget.message.published))}'
+                    : MaterialLocalizations.of(context).formatTimeOfDay(TimeOfDay.fromDateTime(widget.message.published)),
+                style: theme.textTheme.labelSmall?.copyWith(color: textColor.withValues(alpha: 0.7)),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/src/features/private_message/presentation/widgets/thread/quick_reply_bar.dart
+++ b/lib/src/features/private_message/presentation/widgets/thread/quick_reply_bar.dart
@@ -1,0 +1,78 @@
+import 'package:flutter/material.dart';
+
+import 'package:thunder/src/foundation/config/global_context.dart';
+
+/// Reply field for sending a short direct-messages.
+class QuickReplyBar extends StatelessWidget {
+  /// Creates a compact reply bar with a shortcut to the full editor.
+  const QuickReplyBar({
+    super.key,
+    required this.controller,
+    required this.canSend,
+    required this.sending,
+    required this.onOpenComposer,
+    required this.onSend,
+  });
+
+  /// Controls the quick reply text field.
+  final TextEditingController controller;
+
+  /// Whether the reply can be sent.
+  final bool canSend;
+
+  /// Whether a reply is currently being sent.
+  final bool sending;
+
+  /// Opens the full direct-message editor.
+  final VoidCallback onOpenComposer;
+
+  /// Sends the quick reply.
+  final VoidCallback onSend;
+
+  @override
+  Widget build(BuildContext context) {
+    final l10n = GlobalContext.l10n;
+    final theme = Theme.of(context);
+
+    return Container(
+      padding: EdgeInsets.fromLTRB(16, 4, 12, 8 + MediaQuery.paddingOf(context).bottom),
+      child: Row(
+        mainAxisSize: MainAxisSize.max,
+        children: [
+          Expanded(
+            child: Container(
+              decoration: BoxDecoration(
+                color: theme.colorScheme.surfaceContainerHighest,
+                borderRadius: BorderRadius.circular(32.0),
+              ),
+              padding: const EdgeInsets.only(left: 0, right: 12, top: 4, bottom: 4),
+              child: Row(
+                children: [
+                  IconButton(
+                    constraints: const BoxConstraints(minWidth: 20, minHeight: 20),
+                    onPressed: onOpenComposer,
+                    icon: Icon(Icons.add_circle_outline_rounded, semanticLabel: l10n.message(0)),
+                  ),
+                  Expanded(
+                    child: TextField(
+                      controller: controller,
+                      minLines: 1,
+                      maxLines: 4,
+                      decoration: InputDecoration.collapsed(hintText: l10n.message(0)),
+                      textInputAction: TextInputAction.newline,
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ),
+          const SizedBox(width: 4),
+          IconButton.filledTonal(
+            onPressed: canSend ? onSend : null,
+            icon: sending ? const SizedBox(width: 22, height: 22, child: CircularProgressIndicator(strokeWidth: 2)) : Icon(Icons.send_rounded, semanticLabel: l10n.send, size: 22),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/src/features/private_message/private_message.dart
+++ b/lib/src/features/private_message/private_message.dart
@@ -1,0 +1,7 @@
+export 'data/repositories/private_message_repository.dart';
+export 'domain/models/private_message_thread.dart';
+export 'domain/utils/private_message_thread_utils.dart';
+export 'presentation/pages/create_private_message_page.dart';
+export 'presentation/pages/private_message_thread_page.dart';
+export 'presentation/state/create_private_message_cubit.dart';
+export 'presentation/state/private_message_thread_cubit.dart';

--- a/lib/src/features/user/presentation/widgets/user_action_bottom_sheet.dart
+++ b/lib/src/features/user/presentation/widgets/user_action_bottom_sheet.dart
@@ -7,6 +7,7 @@ import 'package:thunder/src/features/feed/feed.dart';
 import 'package:thunder/src/features/user/user.dart';
 import 'package:thunder/src/features/post/post.dart';
 import 'package:thunder/src/features/instance/domain/utils/instance_link_utils.dart';
+import 'package:thunder/src/app/shell/navigation/navigation_private_message.dart';
 import 'package:thunder/src/shared/avatars/user_avatar.dart';
 import 'package:thunder/src/shared/chips/user_chip.dart';
 import 'package:thunder/src/foundation/config/global_context.dart';
@@ -22,6 +23,11 @@ enum UserBottomSheetAction {
   ),
   blockUser(
     icon: Icons.block_rounded,
+    permissionType: PermissionType.user,
+    requiresAuthentication: true,
+  ),
+  messageUser(
+    icon: Icons.mail_rounded,
     permissionType: PermissionType.user,
     requiresAuthentication: true,
   ),
@@ -59,6 +65,7 @@ enum UserBottomSheetAction {
   String get name => switch (this) {
         UserBottomSheetAction.viewProfile => GlobalContext.l10n.visitUserProfile,
         UserBottomSheetAction.blockUser => GlobalContext.l10n.blockUser,
+        UserBottomSheetAction.messageUser => GlobalContext.l10n.message(0),
         UserBottomSheetAction.unblockUser => GlobalContext.l10n.unblockUser,
         UserBottomSheetAction.addUserLabel => GlobalContext.l10n.addUserLabel,
         UserBottomSheetAction.banUserFromCommunity => GlobalContext.l10n.banFromCommunity,
@@ -146,6 +153,14 @@ class _UserActionBottomSheetState extends State<UserActionBottomSheet> {
         await userRepository.block(widget.user.id, true);
         showSnackbar(l10n.successfullyBlockedUser(widget.user.displayNameOrName));
         widget.onAction(UserAction.block, null);
+        break;
+      case UserBottomSheetAction.messageUser:
+        Navigator.of(context).pop();
+        Future.microtask(() {
+          if (widget.context.mounted) {
+            navigateToCreatePrivateMessagePage(widget.context, account: widget.account, recipient: widget.user);
+          }
+        });
         break;
       case UserBottomSheetAction.unblockUser:
         Navigator.of(context).pop();
@@ -266,7 +281,7 @@ class _UserActionBottomSheetState extends State<UserActionBottomSheet> {
       userActions = userActions.where((action) => action.requiresAuthentication == false).toList();
     } else {
       if (widget.account.username == widget.user.name && widget.account.instance == fetchInstanceNameFromUrl(widget.user.actorId)) {
-        userActions = userActions.where((action) => action != UserBottomSheetAction.blockUser && action != UserBottomSheetAction.unblockUser).toList();
+        userActions = userActions.where((action) => action != UserBottomSheetAction.blockUser && action != UserBottomSheetAction.unblockUser && action != UserBottomSheetAction.messageUser).toList();
         moderatorActions = moderatorActions.where((action) => action != UserBottomSheetAction.addUserAsCommunityModerator && action != UserBottomSheetAction.removeUserAsCommunityModerator).toList();
       }
 

--- a/lib/src/features/user/presentation/widgets/user_header/user_header_actions.dart
+++ b/lib/src/features/user/presentation/widgets/user_header/user_header_actions.dart
@@ -4,6 +4,7 @@ import 'package:flutter/services.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 
 import 'package:thunder/src/foundation/primitives/primitives.dart';
+import 'package:thunder/src/app/shell/navigation/navigation_private_message.dart';
 import 'package:thunder/src/features/account/account.dart';
 import 'package:thunder/src/features/feed/feed.dart';
 import 'package:thunder/src/features/post/post.dart';
@@ -117,6 +118,7 @@ class _ActionChipsList extends StatelessWidget {
         if (isOwnProfile) _SavedActionChip(),
         _SortActionChip(),
         if (!isOwnProfile) _LabelActionChip(user: user),
+        if (isLoggedIn && !isOwnProfile) _MessageActionChip(user: user),
         if (isLoggedIn && !isOwnProfile && user.isAdmin != true) _BlockActionChip(user: user),
         _ShareActionChip(user: user),
       ],
@@ -174,6 +176,28 @@ class _SavedActionChipState extends State<_SavedActionChip> {
                 showSaved: showSaved,
               ),
             );
+      },
+    );
+  }
+}
+
+class _MessageActionChip extends StatelessWidget {
+  const _MessageActionChip({required this.user});
+
+  /// User to display actions for
+  final ThunderUser user;
+
+  @override
+  Widget build(BuildContext context) {
+    final l10n = GlobalContext.l10n;
+    final account = context.read<ProfileBloc>().state.account;
+
+    return ThunderActionChip(
+      icon: Icons.mail_rounded,
+      label: l10n.message(0),
+      onPressed: () {
+        HapticFeedback.mediumImpact();
+        navigateToCreatePrivateMessagePage(context, account: account, recipient: user);
       },
     );
   }

--- a/lib/src/features/user/presentation/widgets/user_list_entry.dart
+++ b/lib/src/features/user/presentation/widgets/user_list_entry.dart
@@ -1,5 +1,8 @@
 import 'package:flutter/material.dart';
 
+import 'package:flutter_bloc/flutter_bloc.dart';
+
+import 'package:thunder/src/app/shell/navigation/navigation_private_message.dart';
 import 'package:thunder/src/features/account/account.dart';
 import 'package:thunder/src/foundation/primitives/primitives.dart';
 import 'package:thunder/src/features/settings/api.dart';
@@ -10,6 +13,7 @@ import 'package:thunder/src/shared/name/full_name_widgets.dart';
 import 'package:thunder/src/features/user/user.dart';
 import 'package:thunder/src/features/instance/domain/utils/instance_link_utils.dart';
 import 'package:thunder/src/app/shell/navigation/navigation_utils.dart';
+import 'package:thunder/src/foundation/config/global_context.dart';
 
 /// A widget that can display a single user entry for use within a list (e.g., search page, instance explorer)
 class UserListEntry extends StatelessWidget {
@@ -23,6 +27,13 @@ class UserListEntry extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final l10n = GlobalContext.l10n;
+
+    final isLoggedIn = context.select<ProfileBloc, bool>((bloc) => bloc.state.isLoggedIn);
+    final account = context.select<ProfileBloc, Account>((bloc) => bloc.state.account);
+
+    final canMessage = isLoggedIn && account.userId != user.id;
+
     return Tooltip(
       excludeFromSemantics: true,
       message: '${user.displayNameOrName}\n${generateUserFullName(
@@ -48,6 +59,12 @@ class UserListEntry extends StatelessWidget {
             ),
           ],
         ),
+        trailing: canMessage
+            ? IconButton(
+                icon: Icon(Icons.mail_rounded, semanticLabel: l10n.message(0), size: 20.0),
+                onPressed: () => navigateToCreatePrivateMessagePage(context, account: account, recipient: user),
+              )
+            : null,
         onTap: () async {
           int? userId = user.id;
 

--- a/lib/src/foundation/networking/lemmy/base_lemmy_api_client.dart
+++ b/lib/src/foundation/networking/lemmy/base_lemmy_api_client.dart
@@ -475,12 +475,50 @@ abstract class BaseLemmyApiClient extends BaseApiClient implements ThunderApiCli
     bool unread = false,
     int? creatorId,
   }) async {
-    throw UnimplementedError('Lemmy endpoints are implemented in version-specific clients.');
+    final json = await request(HttpMethod.get, '$basePath/private_message/list', {
+      'page': page,
+      'limit': limit,
+      'unread_only': unread,
+      'creator_id': creatorId,
+    });
+    return (json['private_messages'] as List).map<ThunderPrivateMessage>((pm) => ThunderPrivateMessage.fromLemmyPrivateMessageView(pm)).toList();
   }
 
   @override
   Future<void> markPrivateMessageAsRead({required int messageId, required bool read}) async {
-    throw UnimplementedError('Lemmy endpoints are implemented in version-specific clients.');
+    await request(HttpMethod.post, '$basePath/private_message/mark_as_read', {
+      'private_message_id': messageId,
+      'read': read,
+    });
+  }
+
+  @override
+  Future<ThunderPrivateMessage> createPrivateMessage({required int recipientId, required String content}) async {
+    final json = await request(HttpMethod.post, '$basePath/private_message', {
+      'recipient_id': recipientId,
+      'content': content,
+    });
+    return ThunderPrivateMessage.fromLemmyPrivateMessageView(json['private_message_view']);
+  }
+
+  @override
+  Future<List<ThunderPrivateMessage>> getPrivateMessageConversation({
+    required int personId,
+    int? conversationId,
+    int? page,
+    int? limit,
+  }) async {
+    final messages = await getPrivateMessages(page: page, limit: limit);
+    final currentUserId = account.userId;
+
+    return messages.where((message) {
+      final creatorMatches = message.creatorId == personId;
+      final recipientMatches = message.recipientId == personId;
+      final sentByCurrentUser = currentUserId != null && message.creatorId == currentUserId;
+      final receivedByCurrentUser = currentUserId != null && message.recipientId == currentUserId;
+
+      return (creatorMatches && receivedByCurrentUser) || (recipientMatches && sentByCurrentUser);
+    }).toList();
   }
 
   // =============================================================

--- a/lib/src/foundation/networking/lemmy/lemmy_v3_api_client.dart
+++ b/lib/src/foundation/networking/lemmy/lemmy_v3_api_client.dart
@@ -1279,6 +1279,7 @@ class LemmyV3ApiClient extends BaseLemmyApiClient {
   }
 
   // Private messages
+  @override
   Future<ThunderPrivateMessage> createPrivateMessage({required int recipientId, required String content}) async {
     final json = await request(HttpMethod.post, '$basePath/private_message', {
       'recipient_id': recipientId,

--- a/lib/src/foundation/networking/piefed/piefed_api_client.dart
+++ b/lib/src/foundation/networking/piefed/piefed_api_client.dart
@@ -1233,6 +1233,7 @@ class PiefedApiClient extends BaseApiClient implements ThunderApiClient {
   }
 
   /// Create a private message.
+  @override
   Future<ThunderPrivateMessage> createPrivateMessage({required int recipientId, required String content}) async {
     final json = await request(HttpMethod.post, '$basePath/private_message', {
       'recipient_id': recipientId,
@@ -1269,8 +1270,9 @@ class PiefedApiClient extends BaseApiClient implements ThunderApiClient {
   }
 
   /// Get private message conversation.
+  @override
   Future<List<ThunderPrivateMessage>> getPrivateMessageConversation({
-    int? personId,
+    required int personId,
     int? conversationId,
     int? page,
     int? limit,
@@ -1470,6 +1472,9 @@ class PiefedApiClient extends BaseApiClient implements ThunderApiClient {
 
     return ThunderPrivateMessage(
       id: privateMessage['id'],
+      creatorId: privateMessage['creator_id'],
+      recipientId: privateMessage['recipient_id'],
+      conversationId: privateMessageView['conversation_id'],
       content: privateMessage['content'],
       deleted: privateMessage['deleted'],
       read: privateMessage['read'],

--- a/lib/src/foundation/networking/thunder_api_client.dart
+++ b/lib/src/foundation/networking/thunder_api_client.dart
@@ -430,6 +430,20 @@ abstract class ThunderApiClient {
   /// Mark a private message as read.
   Future<void> markPrivateMessageAsRead({required int messageId, required bool read});
 
+  /// Create a private message.
+  Future<ThunderPrivateMessage> createPrivateMessage({
+    required int recipientId,
+    required String content,
+  });
+
+  /// Get private messages for a conversation with a user.
+  Future<List<ThunderPrivateMessage>> getPrivateMessageConversation({
+    required int personId,
+    int? conversationId,
+    int? page,
+    int? limit,
+  });
+
   // =============================================================
   // Account Settings
   // =============================================================

--- a/lib/src/foundation/primitives/models/thunder_private_message.dart
+++ b/lib/src/foundation/primitives/models/thunder_private_message.dart
@@ -1,8 +1,18 @@
 import 'package:thunder/src/foundation/primitives/models/thunder_user.dart';
 
+/// Cross-platform representation of a Lemmy or PieFed private message.
 class ThunderPrivateMessage {
   /// The private message's ID.
   final int id;
+
+  /// The message creator's user ID.
+  final int? creatorId;
+
+  /// The message recipient's user ID.
+  final int? recipientId;
+
+  /// The conversation ID for platforms that expose one.
+  final int? conversationId;
 
   /// The private message's content.
   final String content;
@@ -22,8 +32,12 @@ class ThunderPrivateMessage {
   /// The private message's creator.
   final ThunderUser? creator;
 
+  /// Creates a private-message model.
   ThunderPrivateMessage({
     required this.id,
+    this.creatorId,
+    this.recipientId,
+    this.conversationId,
     required this.content,
     required this.deleted,
     required this.read,
@@ -32,8 +46,12 @@ class ThunderPrivateMessage {
     this.creator,
   });
 
+  /// Creates a copy with updated fields.
   ThunderPrivateMessage copyWith({
     int? id,
+    int? creatorId,
+    int? recipientId,
+    int? conversationId,
     String? content,
     bool? deleted,
     bool? read,
@@ -43,6 +61,9 @@ class ThunderPrivateMessage {
   }) {
     return ThunderPrivateMessage(
       id: id ?? this.id,
+      creatorId: creatorId ?? this.creatorId,
+      recipientId: recipientId ?? this.recipientId,
+      conversationId: conversationId ?? this.conversationId,
       content: content ?? this.content,
       deleted: deleted ?? this.deleted,
       read: read ?? this.read,
@@ -52,9 +73,12 @@ class ThunderPrivateMessage {
     );
   }
 
+  /// Parses a Lemmy private-message payload without associated user data.
   factory ThunderPrivateMessage.fromLemmyPrivateMessage(Map<String, dynamic> privateMessage) {
     return ThunderPrivateMessage(
       id: privateMessage['id'],
+      creatorId: privateMessage['creator_id'],
+      recipientId: privateMessage['recipient_id'],
       content: privateMessage['content'],
       deleted: privateMessage['deleted'],
       read: privateMessage['read'],
@@ -62,6 +86,7 @@ class ThunderPrivateMessage {
     );
   }
 
+  /// Parses a Lemmy private-message view with creator and recipient data.
   factory ThunderPrivateMessage.fromLemmyPrivateMessageView(Map<String, dynamic> privateMessageView) {
     final privateMessage = privateMessageView['private_message'];
     final recipient = privateMessageView['recipient'];
@@ -69,6 +94,9 @@ class ThunderPrivateMessage {
 
     return ThunderPrivateMessage(
       id: privateMessage['id'],
+      creatorId: privateMessage['creator_id'],
+      recipientId: privateMessage['recipient_id'],
+      conversationId: privateMessageView['conversation_id'],
       content: privateMessage['content'],
       deleted: privateMessage['deleted'],
       read: privateMessage['read'],


### PR DESCRIPTION
## Pull Request Description

This PR adds the ability to send direct messages to other users on both Lemmy and PieFed. As part of this, I've also overhauled the existing private message feature to act more like a messaging app, with the ability to view messages from a given user in a message thread.

I've tested this with Lemmy-Lemmy, Lemmy-PieFed, and PieFed-Lemmy accounts to ensure that everything works accordingly. This was a pretty large addition so there may still be bugs that were not caught!

<!--- Please describe what was changed -->

## Issue Being Fixed

<!-- Please describe the problem that is being fixed and, if applicable, reference a GitHub issue -->

Issue Number: #2090, #1697

## Screenshots / Recordings

<!-- This section is optional but highly recommended to show off your changes! -->

## Checklist

- [ ] If a new package was added, did you ensure it uses an appropriate license and is actively maintained?
- [ ] Did you use localized strings (and added appropriate descriptions) where applicable?
- [ ] Did you add `semanticLabel`s where applicable for accessibility?
